### PR TITLE
Create script for generating types from openapi schema

### DIFF
--- a/@types/index.ts
+++ b/@types/index.ts
@@ -1,0 +1,40 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export { ConditionStatus } from './models/ConditionStatus';
+export type { ContainerStatus } from './models/ContainerStatus';
+export type { Device } from './models/Device';
+export type { DeviceCondition } from './models/DeviceCondition';
+export type { DeviceList } from './models/DeviceList';
+export type { DeviceOSSpec } from './models/DeviceOSSpec';
+export type { DeviceSpec } from './models/DeviceSpec';
+export type { DeviceStatus } from './models/DeviceStatus';
+export type { DeviceSystemdUnitStatus } from './models/DeviceSystemdUnitStatus';
+export type { DeviceSystemInfo } from './models/DeviceSystemInfo';
+export type { EnrollmentRequest } from './models/EnrollmentRequest';
+export type { EnrollmentRequestApproval } from './models/EnrollmentRequestApproval';
+export type { EnrollmentRequestCondition } from './models/EnrollmentRequestCondition';
+export type { EnrollmentRequestList } from './models/EnrollmentRequestList';
+export type { EnrollmentRequestSpec } from './models/EnrollmentRequestSpec';
+export type { EnrollmentRequestStatus } from './models/EnrollmentRequestStatus';
+export type { Fleet } from './models/Fleet';
+export type { FleetCondition } from './models/FleetCondition';
+export type { FleetList } from './models/FleetList';
+export type { FleetSpec } from './models/FleetSpec';
+export type { FleetStatus } from './models/FleetStatus';
+export type { GitConfigProviderSpec } from './models/GitConfigProviderSpec';
+export type { InlineConfigProviderSpec } from './models/InlineConfigProviderSpec';
+export type { KubernetesSecretProviderSpec } from './models/KubernetesSecretProviderSpec';
+export type { LabelSelector } from './models/LabelSelector';
+export type { ListMeta } from './models/ListMeta';
+export type { ObjectMeta } from './models/ObjectMeta';
+export type { Repository } from './models/Repository';
+export type { RepositoryCondition } from './models/RepositoryCondition';
+export { RepositoryConditionType } from './models/RepositoryConditionType';
+export type { RepositoryList } from './models/RepositoryList';
+export type { RepositorySpec } from './models/RepositorySpec';
+export type { RepositoryStatus } from './models/RepositoryStatus';
+export type { Status } from './models/Status';
+export type { UnprocessableEntityResponse } from './models/UnprocessableEntityResponse';

--- a/@types/models/ConditionStatus.ts
+++ b/@types/models/ConditionStatus.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export enum ConditionStatus {
+  TRUE = 'True',
+  FALSE = 'False',
+  UNKNOWN = 'Unknown',
+}

--- a/@types/models/ContainerStatus.ts
+++ b/@types/models/ContainerStatus.ts
@@ -1,0 +1,23 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ContainerStatus = {
+  /**
+   * Name of the container.
+   */
+  name: string;
+  /**
+   * ID of the container.
+   */
+  id: string;
+  /**
+   * Status of the container (e.g., running, stopped, etc.).
+   */
+  status: string;
+  /**
+   * Image of the container.
+   */
+  image: string;
+};
+

--- a/@types/models/Device.ts
+++ b/@types/models/Device.ts
@@ -1,0 +1,24 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { DeviceSpec } from './DeviceSpec';
+import type { DeviceStatus } from './DeviceStatus';
+import type { ObjectMeta } from './ObjectMeta';
+/**
+ * Device represents a physical device.
+ */
+export type Device = {
+  /**
+   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+   */
+  apiVersion: string;
+  /**
+   * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+   */
+  kind: string;
+  metadata: ObjectMeta;
+  spec: DeviceSpec;
+  status?: DeviceStatus;
+};
+

--- a/@types/models/DeviceCondition.ts
+++ b/@types/models/DeviceCondition.ts
@@ -1,0 +1,29 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ConditionStatus } from './ConditionStatus';
+/**
+ * DeviceCondition contains condition information for a device.
+ */
+export type DeviceCondition = {
+  lastHeartbeatTime?: string;
+  lastTransitionTime?: string;
+  /**
+   * Human readable message indicating details about last transition.
+   */
+  message?: string;
+  /**
+   * (brief) reason for the condition's last transition.
+   */
+  reason?: string;
+  /**
+   * Status of the condition, one of True, False, Unknown.
+   */
+  status: ConditionStatus;
+  /**
+   * Type of device condition.
+   */
+  type: string;
+};
+

--- a/@types/models/DeviceList.ts
+++ b/@types/models/DeviceList.ts
@@ -1,0 +1,25 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { Device } from './Device';
+import type { ListMeta } from './ListMeta';
+/**
+ * DeviceList is a list of Devices.
+ */
+export type DeviceList = {
+  /**
+   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+   */
+  apiVersion: string;
+  /**
+   * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+   */
+  kind: string;
+  metadata: ListMeta;
+  /**
+   * List of Devices.
+   */
+  items: Array<Device>;
+};
+

--- a/@types/models/DeviceOSSpec.ts
+++ b/@types/models/DeviceOSSpec.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type DeviceOSSpec = {
+  /**
+   * ostree image name or URL.
+   */
+  image: string;
+};
+

--- a/@types/models/DeviceSpec.ts
+++ b/@types/models/DeviceSpec.ts
@@ -1,0 +1,25 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { DeviceOSSpec } from './DeviceOSSpec';
+import type { GitConfigProviderSpec } from './GitConfigProviderSpec';
+import type { InlineConfigProviderSpec } from './InlineConfigProviderSpec';
+import type { KubernetesSecretProviderSpec } from './KubernetesSecretProviderSpec';
+/**
+ * DeviceSpec is a description of a device's target state.
+ */
+export type DeviceSpec = {
+  os?: DeviceOSSpec;
+  /**
+   * List of config resources.
+   */
+  config?: Array<(GitConfigProviderSpec | KubernetesSecretProviderSpec | InlineConfigProviderSpec)>;
+  containers?: {
+    matchPattern?: Array<string>;
+  };
+  systemd?: {
+    matchPatterns?: Array<string>;
+  };
+};
+

--- a/@types/models/DeviceStatus.ts
+++ b/@types/models/DeviceStatus.ts
@@ -1,0 +1,28 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ContainerStatus } from './ContainerStatus';
+import type { DeviceCondition } from './DeviceCondition';
+import type { DeviceSystemdUnitStatus } from './DeviceSystemdUnitStatus';
+import type { DeviceSystemInfo } from './DeviceSystemInfo';
+/**
+ * DeviceStatus represents information about the status of a device. Status may trail the actual state of a device, especially if the device has not contacted the management service in a while.
+ */
+export type DeviceStatus = {
+  updatedAt?: string;
+  /**
+   * Current state of the device.
+   */
+  conditions?: Array<DeviceCondition>;
+  systemInfo?: DeviceSystemInfo;
+  /**
+   * Statuses of containers in the device.
+   */
+  containers?: Array<ContainerStatus>;
+  /**
+   * Current state of systemd units on the device.
+   */
+  systemdUnits?: Array<DeviceSystemdUnitStatus>;
+};
+

--- a/@types/models/DeviceSystemInfo.ts
+++ b/@types/models/DeviceSystemInfo.ts
@@ -1,0 +1,30 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * DeviceSystemInfo is a set of ids/uuids to uniquely identify the device.
+ */
+export type DeviceSystemInfo = {
+  /**
+   * The Architecture reported by the device.
+   */
+  architecture: string;
+  /**
+   * Boot ID reported by the device.
+   */
+  bootID: string;
+  /**
+   * MachineID reported by the device.
+   */
+  machineID: string;
+  /**
+   * The Operating System reported by the device.
+   */
+  operatingSystem: string;
+  /**
+   * The integrity measurements of the system.
+   */
+  measurements: Record<string, string>;
+};
+

--- a/@types/models/DeviceSystemdUnitStatus.ts
+++ b/@types/models/DeviceSystemdUnitStatus.ts
@@ -1,0 +1,22 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * The status of the systemd unit.
+ */
+export type DeviceSystemdUnitStatus = {
+  /**
+   * The name of the systemd unit.
+   */
+  name: any;
+  /**
+   * The load state of the systemd unit.
+   */
+  loadState: string;
+  /**
+   * The active state of the systemd unit.
+   */
+  activeState: string;
+};
+

--- a/@types/models/EnrollmentRequest.ts
+++ b/@types/models/EnrollmentRequest.ts
@@ -1,0 +1,24 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { EnrollmentRequestSpec } from './EnrollmentRequestSpec';
+import type { EnrollmentRequestStatus } from './EnrollmentRequestStatus';
+import type { ObjectMeta } from './ObjectMeta';
+/**
+ * EnrollmentRequest represents a request for approval to enroll a device.
+ */
+export type EnrollmentRequest = {
+  /**
+   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+   */
+  apiVersion: string;
+  /**
+   * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+   */
+  kind: string;
+  metadata: ObjectMeta;
+  spec: EnrollmentRequestSpec;
+  status?: EnrollmentRequestStatus;
+};
+

--- a/@types/models/EnrollmentRequestApproval.ts
+++ b/@types/models/EnrollmentRequestApproval.ts
@@ -1,0 +1,27 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type EnrollmentRequestApproval = {
+  /**
+   * labels is a set of labels to apply to the device.
+   */
+  labels?: Record<string, string>;
+  /**
+   * region is the region in which the device should be enrolled.
+   */
+  region?: string;
+  /**
+   * approved indicates whether the request has been approved.
+   */
+  approved: boolean;
+  /**
+   * approvedBy is the name of the approver.
+   */
+  approvedBy?: string;
+  /**
+   * approvedAt is the time at which the request was approved.
+   */
+  approvedAt?: string;
+};
+

--- a/@types/models/EnrollmentRequestCondition.ts
+++ b/@types/models/EnrollmentRequestCondition.ts
@@ -1,0 +1,28 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ConditionStatus } from './ConditionStatus';
+/**
+ * EnrollmentRequestCondition contains condition information for a EnrollmentRequest.
+ */
+export type EnrollmentRequestCondition = {
+  lastTransitionTime?: string;
+  /**
+   * Human readable message indicating details about last transition.
+   */
+  message?: string;
+  /**
+   * (brief) reason for the condition's last transition.
+   */
+  reason?: string;
+  /**
+   * Status of the condition, one of True, False, Unknown.
+   */
+  status: ConditionStatus;
+  /**
+   * Type of fleet condition.
+   */
+  type: string;
+};
+

--- a/@types/models/EnrollmentRequestList.ts
+++ b/@types/models/EnrollmentRequestList.ts
@@ -1,0 +1,25 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { EnrollmentRequest } from './EnrollmentRequest';
+import type { ListMeta } from './ListMeta';
+/**
+ * EnrollmentRequestList is a list of EnrollmentRequest.
+ */
+export type EnrollmentRequestList = {
+  /**
+   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+   */
+  apiVersion: string;
+  /**
+   * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+   */
+  kind: string;
+  metadata: ListMeta;
+  /**
+   * List of EnrollmentRequest.
+   */
+  items: Array<EnrollmentRequest>;
+};
+

--- a/@types/models/EnrollmentRequestSpec.ts
+++ b/@types/models/EnrollmentRequestSpec.ts
@@ -1,0 +1,16 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { DeviceStatus } from './DeviceStatus';
+/**
+ * EnrollmentRequestSpec is a description of a EnrollmentRequest's target state.
+ */
+export type EnrollmentRequestSpec = {
+  /**
+   * csr is a PEM-encoded PKCS#10 certificate signing request.
+   */
+  csr: string;
+  deviceStatus?: DeviceStatus;
+};
+

--- a/@types/models/EnrollmentRequestStatus.ts
+++ b/@types/models/EnrollmentRequestStatus.ts
@@ -1,0 +1,21 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { EnrollmentRequestApproval } from './EnrollmentRequestApproval';
+import type { EnrollmentRequestCondition } from './EnrollmentRequestCondition';
+/**
+ * EnrollmentRequestStatus represents information about the status of a EnrollmentRequest.
+ */
+export type EnrollmentRequestStatus = {
+  /**
+   * certificate is a PEM-encoded signed certificate.
+   */
+  certificate?: string;
+  /**
+   * Current state of the EnrollmentRequest.
+   */
+  conditions?: Array<EnrollmentRequestCondition>;
+  approval?: EnrollmentRequestApproval;
+};
+

--- a/@types/models/Fleet.ts
+++ b/@types/models/Fleet.ts
@@ -1,0 +1,24 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { FleetSpec } from './FleetSpec';
+import type { FleetStatus } from './FleetStatus';
+import type { ObjectMeta } from './ObjectMeta';
+/**
+ * Fleet represents a set of devices.
+ */
+export type Fleet = {
+  /**
+   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+   */
+  apiVersion: string;
+  /**
+   * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+   */
+  kind: string;
+  metadata: ObjectMeta;
+  spec: FleetSpec;
+  status?: FleetStatus;
+};
+

--- a/@types/models/FleetCondition.ts
+++ b/@types/models/FleetCondition.ts
@@ -1,0 +1,28 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ConditionStatus } from './ConditionStatus';
+/**
+ * DeviceCondition contains condition information for a device.
+ */
+export type FleetCondition = {
+  lastTransitionTime?: string;
+  /**
+   * Human readable message indicating details about last transition.
+   */
+  message?: string;
+  /**
+   * (brief) reason for the condition's last transition.
+   */
+  reason?: string;
+  /**
+   * Status of the condition, one of True, False, Unknown.
+   */
+  status: ConditionStatus;
+  /**
+   * Type of fleet condition.
+   */
+  type: string;
+};
+

--- a/@types/models/FleetList.ts
+++ b/@types/models/FleetList.ts
@@ -1,0 +1,25 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { Fleet } from './Fleet';
+import type { ListMeta } from './ListMeta';
+/**
+ * FleetList is a list of Fleets.
+ */
+export type FleetList = {
+  /**
+   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+   */
+  apiVersion: string;
+  /**
+   * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+   */
+  kind: string;
+  metadata: ListMeta;
+  /**
+   * List of Fleets.
+   */
+  items: Array<Fleet>;
+};
+

--- a/@types/models/FleetSpec.ts
+++ b/@types/models/FleetSpec.ts
@@ -1,0 +1,18 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { DeviceSpec } from './DeviceSpec';
+import type { LabelSelector } from './LabelSelector';
+import type { ObjectMeta } from './ObjectMeta';
+/**
+ * FleetSpec is a description of a fleet's target state.
+ */
+export type FleetSpec = {
+  selector?: LabelSelector;
+  template: {
+    metadata?: ObjectMeta;
+    spec: DeviceSpec;
+  };
+};
+

--- a/@types/models/FleetStatus.ts
+++ b/@types/models/FleetStatus.ts
@@ -1,0 +1,15 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { FleetCondition } from './FleetCondition';
+/**
+ * FleetStatus represents information about the status of a fleet. Status may trail the actual state of a fleet, especially if devices of a fleet have not contacted the management service in a while.
+ */
+export type FleetStatus = {
+  /**
+   * Current state of the fleet.
+   */
+  conditions?: Array<FleetCondition>;
+};
+

--- a/@types/models/GitConfigProviderSpec.ts
+++ b/@types/models/GitConfigProviderSpec.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type GitConfigProviderSpec = {
+  name: string;
+  gitRef: {
+    repoURL: string;
+    targetRevision: string;
+    path: string;
+  };
+};
+

--- a/@types/models/InlineConfigProviderSpec.ts
+++ b/@types/models/InlineConfigProviderSpec.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type InlineConfigProviderSpec = {
+  name: string;
+  inline: Record<string, any>;
+};
+

--- a/@types/models/KubernetesSecretProviderSpec.ts
+++ b/@types/models/KubernetesSecretProviderSpec.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type KubernetesSecretProviderSpec = {
+  name: string;
+  secretRef: {
+    name: string;
+    namespace: string;
+    mountPath: string;
+  };
+};
+

--- a/@types/models/LabelSelector.ts
+++ b/@types/models/LabelSelector.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type LabelSelector = {
+  matchLabels: Record<string, string>;
+};
+

--- a/@types/models/ListMeta.ts
+++ b/@types/models/ListMeta.ts
@@ -1,0 +1,18 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.
+ */
+export type ListMeta = {
+  /**
+   * continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.
+   */
+  continue?: string;
+  /**
+   * remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.
+   */
+  remainingItemCount?: number;
+};
+

--- a/@types/models/ObjectMeta.ts
+++ b/@types/models/ObjectMeta.ts
@@ -1,0 +1,20 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.
+ */
+export type ObjectMeta = {
+  creationTimestamp?: string;
+  deletionTimestamp?: string;
+  /**
+   * name of the object
+   */
+  name?: string;
+  /**
+   * Map of string keys and values that can be used to organize and categorize (scope and select) objects.
+   */
+  labels?: Record<string, string>;
+};
+

--- a/@types/models/Repository.ts
+++ b/@types/models/Repository.ts
@@ -1,0 +1,24 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ObjectMeta } from './ObjectMeta';
+import type { RepositorySpec } from './RepositorySpec';
+import type { RepositoryStatus } from './RepositoryStatus';
+/**
+ * Repository represents a git repository
+ */
+export type Repository = {
+  /**
+   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+   */
+  apiVersion: string;
+  /**
+   * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+   */
+  kind: string;
+  metadata: ObjectMeta;
+  spec: RepositorySpec;
+  status?: RepositoryStatus;
+};
+

--- a/@types/models/RepositoryCondition.ts
+++ b/@types/models/RepositoryCondition.ts
@@ -1,0 +1,30 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ConditionStatus } from './ConditionStatus';
+import type { RepositoryConditionType } from './RepositoryConditionType';
+/**
+ * RepositoryCondition contains condition information for a repository.
+ */
+export type RepositoryCondition = {
+  lastHeartbeatTime?: string;
+  lastTransitionTime?: string;
+  /**
+   * Human readable message indicating details about last transition.
+   */
+  message?: string;
+  /**
+   * (brief) reason for the condition's last transition.
+   */
+  reason?: string;
+  /**
+   * Status of the condition, one of True, False, Unknown.
+   */
+  status: ConditionStatus;
+  /**
+   * Type of repository condition.
+   */
+  type: RepositoryConditionType;
+};
+

--- a/@types/models/RepositoryConditionType.ts
+++ b/@types/models/RepositoryConditionType.ts
@@ -1,0 +1,7 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export enum RepositoryConditionType {
+  ACCESSIBLE = 'Accessible',
+}

--- a/@types/models/RepositoryList.ts
+++ b/@types/models/RepositoryList.ts
@@ -1,0 +1,25 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ListMeta } from './ListMeta';
+import type { Repository } from './Repository';
+/**
+ * RepositoryList is a list of Repositories.
+ */
+export type RepositoryList = {
+  /**
+   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+   */
+  apiVersion: string;
+  /**
+   * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+   */
+  kind: string;
+  metadata: ListMeta;
+  /**
+   * List of repositories.
+   */
+  items: Array<Repository>;
+};
+

--- a/@types/models/RepositorySpec.ts
+++ b/@types/models/RepositorySpec.ts
@@ -1,0 +1,19 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type RepositorySpec = {
+  /**
+   * The (possibly remote) repository URL to clone from
+   */
+  repo?: string;
+  /**
+   * The username for auth with HTTP transport
+   */
+  username?: string;
+  /**
+   * The password for auth with HTTP transport
+   */
+  password?: string;
+};
+

--- a/@types/models/RepositoryStatus.ts
+++ b/@types/models/RepositoryStatus.ts
@@ -1,0 +1,15 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { RepositoryCondition } from './RepositoryCondition';
+/**
+ * RepositoryStatus represents information about the status of a repository. Status may trail the actual state of a repository.
+ */
+export type RepositoryStatus = {
+  /**
+   * Current state of the repository.
+   */
+  conditions?: Array<RepositoryCondition>;
+};
+

--- a/@types/models/Status.ts
+++ b/@types/models/Status.ts
@@ -1,0 +1,22 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Status is a return value for calls that don't return other objects.
+ */
+export type Status = {
+  /**
+   * A human-readable description of the status of this operation.
+   */
+  message?: string;
+  /**
+   * A machine-readable description of why this operation is in the "Failure" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.
+   */
+  reason?: string;
+  /**
+   * Status of the operation. One of: "Success" or "Failure". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+   */
+  status?: string;
+};
+

--- a/@types/models/UnprocessableEntityResponse.ts
+++ b/@types/models/UnprocessableEntityResponse.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * UnprocessableEntityResponse is returned when the request is not valid.
+ */
+export type UnprocessableEntityResponse = {
+  /**
+   * Error message.
+   */
+  error: string;
+};
+

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "bundle-profile:analyze": "npm run build:bundle-profile && webpack-bundle-analyzer ./stats.json",
     "clean": "rimraf dist",
     "storybook": "start-storybook -p 6006",
-    "build:storybook": "build-storybook"
+    "build:storybook": "build-storybook",
+    "gen-types": "node ./scripts/openapi-typescript.js"
   },
   "devDependencies": {
     "@patternfly/react-charts": "^7.1.1",
@@ -56,6 +57,7 @@
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^29.6.1",
     "mini-css-extract-plugin": "^2.7.6",
+    "openapi-typescript-codegen": "^0.27.0",
     "postcss": "^8.4.25",
     "prettier": "^3.0.0",
     "prop-types": "^15.8.1",
@@ -91,6 +93,7 @@
     "axios": "^1.4.0",
     "d3": "^7.8.5",
     "dotenv": "^16.3.1",
+    "js-yaml": "^4.1.0",
     "jsrsasign": "^10.9.0",
     "monaco-editor-webpack-plugin": "^7.1.0",
     "react": "^18",

--- a/scripts/openapi-typescript.js
+++ b/scripts/openapi-typescript.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+const path = require('path');
+const OpenAPI = require('openapi-typescript-codegen');
+const YAML = require('js-yaml');
+
+const processJsonAPI = (jsonString) => {
+  const json = YAML.load(jsonString);
+  if (json.components) {
+    Object.keys(json.components.schemas).forEach((key) => {
+      const schema = json.components.schemas[key];
+      if (schema && typeof schema.type === 'undefined') {
+        schema.type = 'object';
+      }
+    });
+  }
+  return json;
+};
+
+async function main() {
+  const swaggerUrl = 'https://raw.githubusercontent.com/flightctl/flightctl/main/api/v1alpha1/openapi.yaml';
+  const output = path.resolve(__dirname, '../@types');
+  const response = await fetch(swaggerUrl);
+  const data = await response.text();
+
+  OpenAPI.generate({
+    input: processJsonAPI(data),
+    output,
+    exportCore: false,
+    exportServices: false,
+    exportModels: true,
+    exportSchemas: false,
+    indent: '2',
+  });
+}
+
+void main();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,16 +19,12 @@
     "strict": true,
     "paths": {
       "@app/*": ["src/app/*"],
-      "@assets/*": ["node_modules/@patternfly/react-core/dist/styles/assets/*"]
+      "@types": ["@types"],
+      "@assets/*": ["node_modules/@patternfly/react-core/dist/styles/assets/*"],
     },
     "importHelpers": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
   },
-  "include": [
-    "**/*.ts",
-    "**/*.tsx",
-    "**/*.jsx",
-    "**/*.js"
-  ],
-  "exclude": ["node_modules"]
+  "include": ["**/*.ts", "**/*.tsx", "**/*.jsx", "**/*.js"],
+  "exclude": ["node_modules"],
 }


### PR DESCRIPTION
Everything under `@types` folder is generated by the script.
To update the types, run `npm run gen-types`