### PR TITLE
MGMT-17051 Show fleet devices

### DIFF
--- a/src/app/components/Device/DeviceList.tsx
+++ b/src/app/components/Device/DeviceList.tsx
@@ -7,10 +7,16 @@ import { InfoCircleIcon } from '@patternfly/react-icons';
 import { useFetch } from '@app/hooks/useFetch';
 import { useFetchPeriodically } from '@app/hooks/useFetchPeriodically';
 import { getDeviceFleet } from '@app/utils/devices';
-import { DeviceList } from '@types';
+import { Device, DeviceList } from '@types';
 
 import ListPage from '../ListPage/ListPage';
 import ListPageBody from '../ListPage/ListPageBody';
+
+interface DeviceTableProps {
+  devices: Device[];
+  showFleet: boolean;
+  refetch: VoidFunction;
+}
 
 const DeviceEmptyState = () => (
   <EmptyState>
@@ -18,35 +24,37 @@ const DeviceEmptyState = () => (
   </EmptyState>
 );
 
-const DeviceTable = () => {
-  const [devicesList, loading, error, refetch] = useFetchPeriodically<DeviceList>({
-    endpoint: 'devices',
-  });
+export const DeviceTable = ({ devices, showFleet, refetch }: DeviceTableProps) => {
   const { remove } = useFetch();
 
+  const onDelete = async (deviceName: string) => {
+    await remove(`devices/${deviceName}`);
+    refetch();
+  };
+
   return (
-    <ListPageBody data={devicesList?.items} error={error} loading={loading} emptyState={<DeviceEmptyState />}>
-      <Table aria-label="Devices table">
-        <Thead>
-          <Tr>
-            <Th modifier="wrap">Fingerprint</Th>
-            <Th modifier="wrap">Name</Th>
-            <Th modifier="wrap">Fleet</Th>
-            <Th modifier="wrap">Creation timestamp</Th>
-            <Th modifier="wrap">Operating system</Th>
-            <Td />
-          </Tr>
-        </Thead>
-        <Tbody>
-          {devicesList?.items.map((device) => {
-            const deviceName = device.metadata.name as string;
-            const fleetName = getDeviceFleet(device);
-            return (
-              <Tr key={deviceName}>
-                <Td dataLabel="Fingerprint">
-                  <Link to={`/devicemanagement/devices/${deviceName}`}>{deviceName}</Link>
-                </Td>
-                <Td dataLabel="Name">{device.metadata.labels?.displayName || '-'}</Td>
+    <Table aria-label="Devices table">
+      <Thead>
+        <Tr>
+          <Th modifier="wrap">Fingerprint</Th>
+          <Th modifier="wrap">Name</Th>
+          {showFleet && <Th>Fleet</Th>}
+          <Th modifier="wrap">Creation timestamp</Th>
+          <Th modifier="wrap">Operating system</Th>
+          <Td />
+        </Tr>
+      </Thead>
+      <Tbody>
+        {devices.map((device) => {
+          const deviceName = device.metadata.name as string;
+          const fleetName = getDeviceFleet(device);
+          return (
+            <Tr key={deviceName}>
+              <Td dataLabel="Fingerprint">
+                <Link to={`/devicemanagement/devices/${deviceName}`}>{deviceName}</Link>
+              </Td>
+              <Td dataLabel="Name">{device.metadata.labels?.displayName || '-'}</Td>
+              {showFleet && (
                 <Td dataLabel="Fleet">
                   {fleetName ? (
                     <Link to={`/devicemanagement/fleets/${fleetName}`}>{fleetName}</Link>
@@ -60,33 +68,42 @@ const DeviceTable = () => {
                     </>
                   )}
                 </Td>
-                <Td dataLabel="Creation timestamp">{device.metadata.creationTimestamp || '-'}</Td>
-                <Td dataLabel="Operating system">{device.status?.systemInfo?.operatingSystem || '-'}</Td>
-                <Td isActionCell>
-                  <ActionsColumn
-                    items={[
-                      {
-                        title: 'Delete',
-                        onClick: async () => {
-                          await remove(`devices/${deviceName}`);
-                          refetch();
-                        },
-                      },
-                    ]}
-                  />
-                </Td>
-              </Tr>
-            );
-          })}
-        </Tbody>
-      </Table>
+              )}
+              <Td dataLabel="Creation timestamp">{device.metadata.creationTimestamp || '-'}</Td>
+              <Td dataLabel="Operating system">{device.status?.systemInfo?.operatingSystem || '-'}</Td>
+              <Td isActionCell>
+                <ActionsColumn
+                  items={[
+                    {
+                      title: 'Delete',
+                      onClick: () => onDelete(deviceName),
+                    },
+                  ]}
+                />
+              </Td>
+            </Tr>
+          );
+        })}
+      </Tbody>
+    </Table>
+  );
+};
+
+const DeviceListTable = () => {
+  const [devicesList, loading, error, refetch] = useFetchPeriodically<DeviceList>({
+    endpoint: 'devices',
+  });
+
+  return (
+    <ListPageBody data={devicesList?.items} error={error} loading={loading} emptyState={<DeviceEmptyState />}>
+      <DeviceTable devices={devicesList?.items || []} refetch={refetch} showFleet />
     </ListPageBody>
   );
 };
 
 const DeviceList = () => (
   <ListPage title="Devices">
-    <DeviceTable />
+    <DeviceListTable />
   </ListPage>
 );
 

--- a/src/app/components/Fleet/FleetDetailsContent.tsx
+++ b/src/app/components/Fleet/FleetDetailsContent.tsx
@@ -10,6 +10,9 @@ import {
   Grid,
   GridItem,
   Label,
+  Tab,
+  TabTitleText,
+  Tabs,
 } from '@patternfly/react-core';
 import { CheckCircleIcon, InProgressIcon, QuestionCircleIcon } from '@patternfly/react-icons';
 
@@ -22,6 +25,7 @@ import { DevicesDonuts } from '@app/old/Overview/devicesDonuts';
 import EventList from '@app/components/common/EventList';
 import LabelsView from '@app/components/common/LabelsView';
 import FleetServiceStatus from '@app/components/Metrics/FleetServiceStatus';
+import FleetDevicesTab from './FleetDevicesTab';
 import { UserPreferencesContext } from '@app/components/UserPreferences/UserPreferencesProvider';
 
 import SourceUrlList from './SourceUrlList';
@@ -64,98 +68,116 @@ const FleetStatus = ({ status }: { status: FleetStatus }) => {
 const FleetDetailsContent = ({ fleet }: { fleet: Required<Fleet> }) => {
   const { experimentalFeatures } = React.useContext(UserPreferencesContext);
 
+  const [activeTabKey, setActiveTabKey] = React.useState<number>(0);
+  const [deviceCount, setDeviceCount] = React.useState<number>();
+
+  const handleTabClick = (_event: React.MouseEvent | React.KeyboardEvent | MouseEvent, tabIndex: string | number) => {
+    setActiveTabKey(Number(tabIndex));
+  };
+
   const sourceUrls = getSourceUrls(fleet);
   return (
-    <Grid hasGutter>
-      <GridItem md={experimentalFeatures ? 6 : 12}>
+    <Tabs activeKey={activeTabKey} onSelect={handleTabClick} aria-label="Fleet details tabs" role="region">
+      <Tab eventKey={0} title={<TabTitleText>Details</TabTitleText>} aria-label="Fleet details">
         <Card>
           <CardTitle>Details</CardTitle>
           <CardBody>
-            <DescriptionList columnModifier={{ lg: '3Col' }}>
-              <DescriptionListGroup>
-                <DescriptionListTerm>Created</DescriptionListTerm>
-                <DescriptionListDescription>
-                  {getDateDisplay(fleet.metadata.creationTimestamp || '')}
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-              <DescriptionListGroup>
-                <DescriptionListTerm>OS image</DescriptionListTerm>
-                <DescriptionListDescription>{fleet.spec.template.spec.os?.image}</DescriptionListDescription>
-              </DescriptionListGroup>
-              <DescriptionListGroup>
-                <DescriptionListTerm>Label selector</DescriptionListTerm>
-                <DescriptionListDescription>
-                  <LabelsView labels={fleet.spec.selector?.matchLabels} />
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-              {experimentalFeatures && (
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Created by</DescriptionListTerm>
-                  <DescriptionListDescription>user unknown</DescriptionListDescription>
-                </DescriptionListGroup>
-              )}
+            <Grid hasGutter>
+              <GridItem md={experimentalFeatures ? 6 : 12}>
+                <DescriptionList columnModifier={{ lg: '3Col' }}>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Created</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {getDateDisplay(fleet.metadata.creationTimestamp || '')}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>OS image</DescriptionListTerm>
+                    <DescriptionListDescription>{fleet.spec.template.spec.os?.image}</DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Label selector</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <LabelsView labels={fleet.spec.selector?.matchLabels} />
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  {experimentalFeatures && (
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Created by</DescriptionListTerm>
+                      <DescriptionListDescription>user unknown</DescriptionListDescription>
+                    </DescriptionListGroup>
+                  )}
 
-              <DescriptionListGroup>
-                <DescriptionListTerm>Status</DescriptionListTerm>
-                <DescriptionListDescription>
-                  <FleetStatus status={fleet.status} />
-                </DescriptionListDescription>
-              </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Status</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <FleetStatus status={fleet.status} />
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  {experimentalFeatures && (
+                    <>
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>Fail threshold</DescriptionListTerm>
+                        <DescriptionListDescription>20% of batch (m)</DescriptionListDescription>
+                      </DescriptionListGroup>
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>Batch size</DescriptionListTerm>
+                        <DescriptionListDescription>10% (m)</DescriptionListDescription>
+                      </DescriptionListGroup>
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>Maintenance window</DescriptionListTerm>
+                        <DescriptionListDescription>--</DescriptionListDescription>
+                      </DescriptionListGroup>
+                    </>
+                  )}
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Sources</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <SourceUrlList sourceUrls={sourceUrls} />
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                </DescriptionList>
+              </GridItem>
               {experimentalFeatures && (
                 <>
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>Fail threshold</DescriptionListTerm>
-                    <DescriptionListDescription>20% of batch (m)</DescriptionListDescription>
-                  </DescriptionListGroup>
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>Batch size</DescriptionListTerm>
-                    <DescriptionListDescription>10% (m)</DescriptionListDescription>
-                  </DescriptionListGroup>
-                  <DescriptionListGroup>
-                    <DescriptionListTerm>Maintenance window</DescriptionListTerm>
-                    <DescriptionListDescription>--</DescriptionListDescription>
-                  </DescriptionListGroup>
+                  <GridItem md={6}>
+                    <Card>
+                      <CardTitle>Service status (m)</CardTitle>
+                      <CardBody>
+                        <FleetServiceStatus />
+                      </CardBody>
+                    </Card>
+                  </GridItem>
+                  <GridItem md={6}>
+                    <Card>
+                      <CardTitle>Events (m)</CardTitle>
+                      <CardBody>
+                        <EventList />
+                      </CardBody>
+                    </Card>
+                  </GridItem>
+                  <GridItem md={6}>
+                    <Card>
+                      <CardTitle>Update status (m)</CardTitle>
+                      <CardBody>
+                        <DevicesDonuts fleetDevicesStatus={fakeDevicesStatus} totalDevices={1000}></DevicesDonuts>
+                      </CardBody>
+                    </Card>
+                  </GridItem>
                 </>
               )}
-              <DescriptionListGroup>
-                <DescriptionListTerm>Sources</DescriptionListTerm>
-                <DescriptionListDescription>
-                  <SourceUrlList sourceUrls={sourceUrls} />
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-            </DescriptionList>
+            </Grid>
           </CardBody>
         </Card>
-      </GridItem>
-      {experimentalFeatures && (
-        <>
-          <GridItem md={6}>
-            <Card>
-              <CardTitle>Service status (m)</CardTitle>
-              <CardBody>
-                <FleetServiceStatus />
-              </CardBody>
-            </Card>
-          </GridItem>
-          <GridItem md={6}>
-            <Card>
-              <CardTitle>Events (m)</CardTitle>
-              <CardBody>
-                <EventList />
-              </CardBody>
-            </Card>
-          </GridItem>
-          <GridItem md={6}>
-            <Card>
-              <CardTitle>Update status (m)</CardTitle>
-              <CardBody>
-                <DevicesDonuts fleetDevicesStatus={fakeDevicesStatus} totalDevices={1000}></DevicesDonuts>
-              </CardBody>
-            </Card>
-          </GridItem>
-        </>
-      )}
-    </Grid>
+      </Tab>
+      <Tab
+        eventKey={1}
+        title={<TabTitleText>Devices ({deviceCount === undefined ? '-' : deviceCount})</TabTitleText>}
+        aria-label="Fleet devices"
+      >
+        <FleetDevicesTab fleetName={fleet.metadata.name as string} onDevicesLoaded={setDeviceCount} />
+      </Tab>
+    </Tabs>
   );
 };
 

--- a/src/app/components/Fleet/FleetDevicesTab.tsx
+++ b/src/app/components/Fleet/FleetDevicesTab.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { Alert, EmptyState, EmptyStateBody, Spinner } from '@patternfly/react-core';
+
+import { getErrorMessage } from '@app/utils/error';
+import { DeviceTable } from '@app/components/Device/DeviceList';
+import { useFetchPeriodically } from '@app/hooks/useFetchPeriodically';
+import { DeviceList } from '@types';
+
+const FleetDevicesTab = ({
+  fleetName,
+  onDevicesLoaded,
+}: {
+  fleetName: string;
+  onDevicesLoaded: (deviceCount: number) => void;
+}) => {
+  const [deviceList, loadingDevices, devicesError, refetch] = useFetchPeriodically<DeviceList>({
+    endpoint: `devices?owner=${fleetName}`,
+  });
+
+  React.useEffect(() => {
+    onDevicesLoaded(deviceList?.items?.length || 0);
+  }, [deviceList, onDevicesLoaded]);
+
+  let tabContent;
+  if (loadingDevices || deviceList === undefined) {
+    tabContent = <Spinner />;
+  }
+  if (deviceList?.items) {
+    tabContent =
+      deviceList.items.length === 0 ? (
+        <EmptyState>
+          <EmptyStateBody>The fleet has no associated devices</EmptyStateBody>
+        </EmptyState>
+      ) : (
+        <DeviceTable devices={deviceList.items} refetch={refetch} showFleet={false} />
+      );
+  }
+
+  return (
+    <>
+      {devicesError && <Alert title="Error loading the fleet devices">{getErrorMessage(devicesError)}</Alert>}
+      {tabContent}
+    </>
+  );
+};
+
+export default FleetDevicesTab;


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-17051

In the Fleet details page, we're adding a new tab to show the devices belonging to that Fleet.
The comparison is done by querying the API for devices whose owner is the specified Fleet.

Added the number of devices to the tab title.

![fleet-devices-2](https://github.com/flightctl/flightctl-ui/assets/829045/6f54ca0a-47ea-4a0d-ba1c-b1e826b10512)