### PR TITLE
MGMT-17154 Do not allow editing bound devices

### DIFF
--- a/src/app/components/Device/DeviceDetails/DeviceDetails.tsx
+++ b/src/app/components/Device/DeviceDetails/DeviceDetails.tsx
@@ -27,6 +27,7 @@ import DetailsPageCard, { DetailsPageCardBody } from '@app/components/DetailsPag
 import DetailsPageActions, { useDeleteAction } from '@app/components/DetailsPage/DetailsPageActions';
 import DeviceFleet from '@app/components/Device/DeviceDetails/DeviceFleet';
 import { useFetch } from '@app/hooks/useFetch';
+import { getDeviceFleet } from '@app/utils/devices';
 
 const DeviceDetails = () => {
   const { deviceId } = useParams() as { deviceId: string };
@@ -35,12 +36,14 @@ const DeviceDetails = () => {
   const { remove } = useFetch();
 
   const name = (device?.metadata.labels?.displayName || device?.metadata.name) as string;
+  const boundFleet = getDeviceFleet(device?.metadata || {});
 
   const { deleteAction, deleteModal } = useDeleteAction({
     onDelete: async () => {
       await remove(`devices/${deviceId}`);
       navigate('/devicemanagement/devices');
     },
+    disabledReason: boundFleet ? 'Devices bound to a fleet cannot be deleted' : '',
     resourceName: name,
     resourceType: 'Device',
   });

--- a/src/app/components/Device/DeviceDetails/SystemdTable.tsx
+++ b/src/app/components/Device/DeviceDetails/SystemdTable.tsx
@@ -1,14 +1,21 @@
-import { Button, Label, LabelGroup, Split, SplitItem, Stack, StackItem } from '@patternfly/react-core';
-import { Device } from '@types';
 import * as React from 'react';
+import { Button, Label, LabelGroup, Split, SplitItem, Stack, StackItem } from '@patternfly/react-core';
+import { PencilAltIcon } from '@patternfly/react-icons';
+
+import { Device } from '@types';
+import WithTooltip from '@app/components/common/WithTooltip';
+import { getDeviceFleet } from '@app/utils/devices';
+
 import MatchPatternsModal from '../MatchPatternsModal/MatchPatternsModal';
 import SystemdDetailsTable from '../../DetailsPage/Tables/SystemdTable';
-import { PencilAltIcon } from '@patternfly/react-icons';
 
 type SystemdTableProps = { device: Device; refetch: VoidFunction };
 
 const SystemdTable: React.FC<SystemdTableProps> = ({ refetch, device }) => {
   const [isModalOpen, setIsModalOpen] = React.useState(false);
+  const disabledEditReason = getDeviceFleet(device.metadata)
+    ? 'The device is owned by a fleet and it cannot be edited'
+    : '';
   return (
     <>
       <Stack hasGutter>
@@ -24,8 +31,15 @@ const SystemdTable: React.FC<SystemdTableProps> = ({ refetch, device }) => {
               </LabelGroup>
             </SplitItem>
             <SplitItem>
-              <Button variant="link" icon={<PencilAltIcon />} onClick={() => setIsModalOpen(true)}>
-                Edit
+              <Button
+                variant="link"
+                icon={<PencilAltIcon />}
+                onClick={() => setIsModalOpen(true)}
+                isAriaDisabled={!!disabledEditReason}
+              >
+                <WithTooltip showTooltip={!!disabledEditReason} content={disabledEditReason}>
+                  <span>Edit</span>
+                </WithTooltip>
               </Button>
             </SplitItem>
           </Split>

--- a/src/app/components/Device/DeviceList.tsx
+++ b/src/app/components/Device/DeviceList.tsx
@@ -11,6 +11,7 @@ import DeviceFleet from '@app/components/Device/DeviceDetails/DeviceFleet';
 import ListPage from '../ListPage/ListPage';
 import ListPageBody from '../ListPage/ListPageBody';
 import { useDeleteListAction } from '../ListPage/ListPageActions';
+import { getDeviceFleet } from '@app/utils/devices';
 
 interface DeviceTableProps {
   devices: Device[];
@@ -51,6 +52,7 @@ export const DeviceTable = ({ devices, showFleet, refetch }: DeviceTableProps) =
           {devices.map((device) => {
             const deviceName = device.metadata.name as string;
             const displayName = device.metadata.labels?.displayName;
+            const boundFleet = getDeviceFleet(device.metadata);
             return (
               <Tr key={deviceName}>
                 <Td dataLabel="Fingerprint">
@@ -65,7 +67,15 @@ export const DeviceTable = ({ devices, showFleet, refetch }: DeviceTableProps) =
                 <Td dataLabel="Creation timestamp">{device.metadata.creationTimestamp || '-'}</Td>
                 <Td dataLabel="Operating system">{device.spec.os?.image || '-'}</Td>
                 <Td isActionCell>
-                  <ActionsColumn items={[deleteAction({ resourceId: deviceName, resourceName: displayName })]} />
+                  <ActionsColumn
+                    items={[
+                      deleteAction({
+                        resourceId: deviceName,
+                        resourceName: displayName,
+                        disabledReason: boundFleet ? 'Devices bound to a fleet cannot be deleted' : '',
+                      }),
+                    ]}
+                  />
                 </Td>
               </Tr>
             );

--- a/src/app/components/ResourceSync/ResourceSyncToRepository.tsx
+++ b/src/app/components/ResourceSync/ResourceSyncToRepository.tsx
@@ -44,12 +44,12 @@ const ResourceSyncToRepository = () => {
         Resource sync {rsId}
       </Title>
       {error ? (
-          <EmptyState>
-            <EmptyStateHeader>
-              Could not find the details for the resourcesync <strong>{rsId}</strong>
-            </EmptyStateHeader>
-            <EmptyStateBody>{error}</EmptyStateBody>
-          </EmptyState>
+        <EmptyState>
+          <EmptyStateHeader>
+            Could not find the details for the resourcesync <strong>{rsId}</strong>
+          </EmptyStateHeader>
+          <EmptyStateBody>{error}</EmptyStateBody>
+        </EmptyState>
       ) : (
         <Bullseye>
           <Spinner />

--- a/src/app/components/common/WithTooltip.tsx
+++ b/src/app/components/common/WithTooltip.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { PropsWithChildren } from 'react';
+import { Tooltip } from '@patternfly/react-core';
+
+type WithTooltipProps = {
+  showTooltip: boolean;
+  content: React.ReactNode;
+  children: React.ReactElement;
+};
+
+const WithTooltip = ({ showTooltip, content, children }: PropsWithChildren<WithTooltipProps>) =>
+  showTooltip ? <Tooltip content={content}>{children}</Tooltip> : children;
+
+export default WithTooltip;


### PR DESCRIPTION
Devices bound to a fleet cannot be edited - this MR disables the edition of the Systemd units, for such devices.
![bound-device](https://github.com/flightctl/flightctl-ui/assets/829045/cb992f41-ed63-4736-bdba-630f94c99321)

-----------------
Additionally, we discussed that such devices shouldn't have a "delete" action, and have a "Decomission device" action (not yet available).  

Now, the "delete" action for bound devices are disabled with a tooltip explaining why that is.
