### PR TITLE
MGMT-17163 handle details 404

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,11 +54,12 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
+    'react/prop-types': 'off',
     '@typescript-eslint/interface-name-prefix': 'off',
     'prettier/prettier': 'off',
     'import/no-unresolved': 'off',
     'import/extensions': 'off',
-    'react/prop-types': 'off',
+    'no-console': 'error',
   },
   env: {
     browser: true,

--- a/src/app/components/DetailsPage/DetailsNotFound.tsx
+++ b/src/app/components/DetailsPage/DetailsNotFound.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import {
+  Button,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  PageSection,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { useNavigate } from 'react-router-dom';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+
+interface DetailsInfo {
+  kind: string;
+  id: string;
+}
+
+const getKindTitle = (kind: string) => {
+  switch (kind) {
+    case 'Fleets':
+      return 'fleet';
+    case 'Devices':
+      return 'device';
+    case 'Repositories':
+      return 'repository';
+    case 'Enrollment requests':
+      return 'Enrollment request';
+    default:
+      return kind.toLowerCase();
+  }
+};
+
+const DetailsNotFound = (props: DetailsInfo) => {
+  const navigate = useNavigate();
+
+  const tryAgain = () => {
+    navigate('/refresh');
+  };
+
+  const kindTitle = getKindTitle(props.kind);
+
+  return (
+    <PageSection>
+      <EmptyState variant="full">
+        <EmptyStateHeader
+          titleText={`${getKindTitle(props.kind)} not found`}
+          icon={<EmptyStateIcon icon={ExclamationTriangleIcon} />}
+          headingLevel="h1"
+        />
+        <EmptyStateBody>
+          <Stack>
+            <StackItem>
+              We couldn&apos;t find the {kindTitle} with id <strong>{props.id}</strong>
+            </StackItem>
+            <StackItem>
+              <small>This page will continue to attempt to fetch the details</small>
+            </StackItem>
+          </Stack>
+        </EmptyStateBody>
+        <EmptyStateFooter>
+          <EmptyStateActions>
+            <Button variant="primary" onClick={() => navigate('/')}>
+              Take me home
+            </Button>
+          </EmptyStateActions>
+          <EmptyStateActions>
+            <Button variant="link" onClick={tryAgain}>
+              Try refreshing manually
+            </Button>
+          </EmptyStateActions>
+        </EmptyStateFooter>
+      </EmptyState>
+    </PageSection>
+  );
+};
+
+export default DetailsNotFound;

--- a/src/app/components/DetailsPage/DetailsPage.tsx
+++ b/src/app/components/DetailsPage/DetailsPage.tsx
@@ -41,7 +41,7 @@ const DetailsPage: React.FC<DetailsPageProps> = ({
   let content = children;
   if (error) {
     const msg = getErrorMessage(error);
-    if (msg === 'Not Found') {
+    if (msg === 'Error 404:Not Found') {
       return <DetailsNotFound kind={resourceType} id={id} />;
     }
     content = (

--- a/src/app/components/DetailsPage/DetailsPage.tsx
+++ b/src/app/components/DetailsPage/DetailsPage.tsx
@@ -1,4 +1,4 @@
-import { getErrorMessage } from '@app/utils/error';
+import * as React from 'react';
 import {
   Alert,
   Breadcrumb,
@@ -10,32 +10,40 @@ import {
   SplitItem,
   Title,
 } from '@patternfly/react-core';
-import * as React from 'react';
 import { Link } from 'react-router-dom';
 
+import { getErrorMessage } from '@app/utils/error';
+import DetailsNotFound from './DetailsNotFound';
+
 type DetailsPageProps = {
-  title: string | undefined;
+  id: string;
+  title?: string;
   children: React.ReactNode;
   error: unknown;
   loading: boolean;
-  resourceName: string;
+  resourceType: 'Fleets' | 'Devices' | 'Repositories' | 'Enrollment requests';
   resourceLink: string;
   actions?: React.ReactNode;
   nav?: React.ReactNode;
 };
 
 const DetailsPage: React.FC<DetailsPageProps> = ({
+  id,
   title,
   children,
   error,
   loading,
   resourceLink,
-  resourceName,
+  resourceType,
   actions,
   nav,
 }) => {
   let content = children;
   if (error) {
+    const msg = getErrorMessage(error);
+    if (msg === 'Not Found') {
+      return <DetailsNotFound kind={resourceType} id={id} />;
+    }
     content = (
       <Alert isInline variant="danger" title="Failed to retrieve resource details">
         {getErrorMessage(error)}
@@ -54,16 +62,16 @@ const DetailsPage: React.FC<DetailsPageProps> = ({
       <PageSection variant="light" type="breadcrumb">
         <Breadcrumb>
           <BreadcrumbItem>
-            <Link to={resourceLink}>{resourceName}</Link>
+            <Link to={resourceLink}>{resourceType}</Link>
           </BreadcrumbItem>
-          <BreadcrumbItem isActive>{title}</BreadcrumbItem>
+          <BreadcrumbItem isActive>{title || id}</BreadcrumbItem>
         </Breadcrumb>
       </PageSection>
       <PageSection variant="light">
         <Split hasGutter>
           <SplitItem isFilled>
             <Title headingLevel="h1" size="3xl">
-              {title}
+              {title || id}
             </Title>
           </SplitItem>
           <SplitItem>{actions}</SplitItem>

--- a/src/app/components/Device/DeviceDetails/DeviceDetails.tsx
+++ b/src/app/components/Device/DeviceDetails/DeviceDetails.tsx
@@ -34,14 +34,14 @@ const DeviceDetails = () => {
   const navigate = useNavigate();
   const { remove } = useFetch();
 
-  const name = device?.metadata.labels?.displayName || device?.metadata.name;
+  const name = (device?.metadata.labels?.displayName || device?.metadata.name) as string;
 
   const { deleteAction, deleteModal } = useDeleteAction({
     onDelete: async () => {
       await remove(`devices/${deviceId}`);
       navigate('/devicemanagement/devices');
     },
-    resourceName: name || '',
+    resourceName: name,
     resourceType: 'Device',
   });
 
@@ -49,9 +49,10 @@ const DeviceDetails = () => {
     <DetailsPage
       loading={loading}
       error={error}
+      id={deviceId}
       title={name}
       resourceLink="/devicemanagement/devices"
-      resourceName="Devices"
+      resourceType="Devices"
       actions={
         <DetailsPageActions>
           <DropdownList>{deleteAction}</DropdownList>

--- a/src/app/components/EnrollmentRequest/EnrollmentRequestDetails/EnrollmentRequestDetails.tsx
+++ b/src/app/components/EnrollmentRequest/EnrollmentRequestDetails/EnrollmentRequestDetails.tsx
@@ -59,9 +59,9 @@ const EnrollmentRequestDetails = () => {
     <DetailsPage
       loading={loading}
       error={error}
-      title={er?.metadata.name}
+      id={er?.metadata.name as string}
       resourceLink="/devicemanagement/enrollmentrequests"
-      resourceName="Enrollment requests"
+      resourceType="Enrollment requests"
       actions={
         <DetailsPageActions>
           <DropdownList>

--- a/src/app/components/Fleet/FleetDetails/FleetDetails.tsx
+++ b/src/app/components/Fleet/FleetDetails/FleetDetails.tsx
@@ -13,8 +13,9 @@ import FleetDevicesTab from './Tabs/FleetDevicesTab';
 import NavItem from '@app/components/NavItem/NavItem';
 
 const FleetDetails = () => {
-  const { fleetId } = useParams();
+  const { fleetId } = useParams() as { fleetId: string };
   const [fleet, isLoading, error] = useFetchPeriodically<Required<Fleet>>({ endpoint: `fleets/${fleetId}` });
+
   const { remove } = useFetch();
   const navigate = useNavigate();
   const { deleteAction, deleteModal } = useDeleteAction({
@@ -31,9 +32,9 @@ const FleetDetails = () => {
     <DetailsPage
       loading={isLoading}
       error={error}
-      title={fleetId}
+      id={fleetId}
       resourceLink="/devicemanagement/fleets"
-      resourceName="Fleets"
+      resourceType="Fleets"
       actions={
         <DetailsPageActions>
           <DropdownList>{deleteAction}</DropdownList>

--- a/src/app/components/Repository/RepositoryDetails/RepositoryDetails.tsx
+++ b/src/app/components/Repository/RepositoryDetails/RepositoryDetails.tsx
@@ -33,9 +33,10 @@ const RepositoryDetails = () => {
     <DetailsPage
       loading={isLoading}
       error={error}
-      title={repoDetails?.metadata.name}
+      id={repositoryId}
+      title={repoDetails?.metadata.name as string}
       resourceLink="/administration/repositories"
-      resourceName="Repositories"
+      resourceType="Repositories"
       actions={
         <DetailsPageActions>
           <DropdownList>{deleteAction}</DropdownList>

--- a/src/app/hooks/useFetchPeriodically.ts
+++ b/src/app/hooks/useFetchPeriodically.ts
@@ -46,7 +46,7 @@ export const useFetchPeriodically = <R>(
             setIsLoading(false);
           }
           setIsRefreshing(false);
-          setData(data);
+          setData(isAPI ? data : data.data.result);
           setError(undefined);
         } catch (err) {
           // aborting fetch trows 'AbortError', we can ignore it

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -24,7 +24,7 @@ const App: React.FunctionComponent = () => {
   }
 
   if (auth.error) {
-    console.log(auth.error);
+    console.log(auth.error); // eslint-disable-line no-console
     return <div>Auth Error: {auth.error.toString() as React.ReactNode}</div>;
   }
 

--- a/src/app/old/utils/commonFunctions.tsx
+++ b/src/app/old/utils/commonFunctions.tsx
@@ -8,10 +8,7 @@ const handleApiJSONResponse = async (response) => {
     const data = await response.json();
     return data;
   }
-  if (response.status === 500) {
-    throw new Error('Server error');
-  }
-  throw new Error('Not Found')
+  throw new Error(`Error ${response.status}:${response.statusText}`)
 }
 
 export const fetchMetrics = async (metricQuery: string, token: string | undefined, abortSignal?: AbortSignal) => {

--- a/src/app/old/utils/commonFunctions.tsx
+++ b/src/app/old/utils/commonFunctions.tsx
@@ -3,6 +3,17 @@ const apiServer = `${window.location.protocol}//${window.location.hostname}${win
 const flightCtlAPI = `${apiServer}/api/flightctl`;
 const metricsAPI = `${apiServer}/api/metrics`;
 
+const handleApiJSONResponse = async (response) => {
+  if (response.ok) {
+    const data = await response.json();
+    return data;
+  }
+  if (response.status === 500) {
+    throw new Error('Server error');
+  }
+  throw new Error('Not Found')
+}
+
 export const fetchMetrics = async (metricQuery: string, token: string | undefined, abortSignal?: AbortSignal) => {
   try {
     const response = await fetch(`${metricsAPI}/api/v1/query_range?${metricQuery}`, {
@@ -11,9 +22,7 @@ export const fetchMetrics = async (metricQuery: string, token: string | undefine
       },
       signal: abortSignal,
     });
-
-    const resp = await response.json();
-    return resp.data.result;
+    return handleApiJSONResponse(response);
   } catch (error) {
     console.error('Error making request:', error);
     throw error;
@@ -30,8 +39,7 @@ export const postData = async (kind: string, token: string | undefined, data: un
       method: 'POST',
       body: JSON.stringify(data),
     });
-    const resp = await response.json();
-    return resp;
+    return handleApiJSONResponse(response);
   } catch (error) {
     console.error('Error making request:', error);
     throw error;
@@ -48,8 +56,7 @@ export const putData = async (kind: string, token: string | undefined, data: unk
       method: 'PUT',
       body: JSON.stringify(data),
     });
-    const resp = await response.json();
-    return resp;
+    return handleApiJSONResponse(response);
   } catch (error) {
     console.error('Error making request:', error);
     throw error;
@@ -64,8 +71,7 @@ export const deleteData = async (kind: string, token: string | undefined) => {
       },
       method: 'DELETE',
     });
-    const resp = await response.json();
-    return resp;
+    return handleApiJSONResponse(response);
   } catch (error) {
     console.error('Error making request:', error);
     throw error;
@@ -80,8 +86,7 @@ export const fetchData = async (kind: string, token: string | undefined, abortSi
       },
       signal: abortSignal,
     });
-    const data = await response.json();
-    return data;
+    return handleApiJSONResponse(response);
   } catch (error) {
     console.error('Error making request:', error);
     throw error;
@@ -96,8 +101,7 @@ export const fetchDataObj = async (kind: string, name: string, token: string) =>
           Authorization: `Bearer ${token}`,
         },
       });
-      const data = await response.json();
-      return data;
+      return handleApiJSONResponse(response);
     } catch (error) {
       console.error('Error making request:', error);
     }
@@ -114,8 +118,7 @@ export const deleteObject = async (kind: string, name: string, token: string) =>
         Authorization: `Bearer ${token}`,
       },
     });
-    const data = await response.json();
-    return data;
+    return handleApiJSONResponse(response);
   } catch (error) {
     console.error('Error making request:', error);
   }
@@ -145,8 +148,7 @@ export const rejectEnrollmentRequest = async (name: string, token: string) => {
         Authorization: `Bearer ${token}`,
       },
     });
-    const data = await response.json();
-    return data;
+    return handleApiJSONResponse(response);
   } catch (error) {
     console.error('Error making request:', error);
     return error;

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,7 +1,15 @@
 import * as React from 'react';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useEffect } from 'react';
 
-import { Navigate, RouteObject, RouterProvider, createBrowserRouter, useParams, useRouteError } from 'react-router-dom';
+import {
+  Navigate,
+  RouteObject,
+  RouterProvider,
+  createBrowserRouter,
+  useNavigate,
+  useParams,
+  useRouteError,
+} from 'react-router-dom';
 import { Overview } from '@app/old/Overview/Overview';
 import { Experimental } from '@app/old/Experimental/Experimental';
 import { Experimental2 } from '@app/old/Experimental/Experimental2';
@@ -52,6 +60,12 @@ const ErrorPage = () => {
 const TitledRoute = ({ title, children }: PropsWithChildren<{ title: string }>) => {
   useDocumentTitle(`${APP_TITLE} | ${title}`);
   return children;
+};
+
+const Refresh = () => {
+  const navigate = useNavigate();
+  useEffect(() => navigate(-1), [navigate]);
+  return <></>;
 };
 
 const experimentalRoutes: ExtendedRouteObject[] = [
@@ -283,6 +297,10 @@ const administrationRoutes: ExtendedRouteObject[] = [
         <ImageBuilder />
       </TitledRoute>
     ),
+  },
+  {
+    path: '/refresh',
+    element: <Refresh />,
   },
 ];
 


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-17163

We need to handle the case of attempting to navigate to the details page of a Fleet / Device... which doesn't exist.

We'll show a specific error page instead. Since the page is included in `DetailsPage`, it will continue querying for the resource, and in the event that it is found, the details will be shown.

![error-page-404](https://github.com/flightctl/flightctl-ui/assets/829045/6e75da89-ef4b-4d72-8943-9268b0624015)

