### PR TITLE
MGMT-17750 Show extra details on invalid RS configuration

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -304,6 +304,8 @@
   "Resource syncs table": "Resource syncs table",
   "This repository does not have associated resource syncs yet": "This repository does not have associated resource syncs yet",
   "Failed to load the repository's resource syncs": "Failed to load the repository's resource syncs",
+  "Invalid resource sync configuration": "Invalid resource sync configuration",
+  "Use the links below to review the resource sync settings and correct the configuration.": "Use the links below to review the resource sync settings and correct the configuration.",
   "Resource sync {{rsId}} is not linked to a repository": "Resource sync {{rsId}} is not linked to a repository",
   "Resource sync {{rsId}} could not be found": "Resource sync {{rsId}} could not be found",
   "Resource sync {{rsId}}": "Resource sync {{rsId}}",

--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -305,7 +305,7 @@
   "This repository does not have associated resource syncs yet": "This repository does not have associated resource syncs yet",
   "Failed to load the repository's resource syncs": "Failed to load the repository's resource syncs",
   "Invalid resource sync configuration": "Invalid resource sync configuration",
-  "Use the links below to review the resource sync settings and correct the configuration.": "Use the links below to review the resource sync settings and correct the configuration.",
+  "An error occurred when trying to apply the resource sync <1>{rsName}</1> from repository <4>{repositoryName}</4>:": "An error occurred when trying to apply the resource sync <1>{rsName}</1> from repository <4>{repositoryName}</4>:",
   "Resource sync {{rsId}} is not linked to a repository": "Resource sync {{rsId}} is not linked to a repository",
   "Resource sync {{rsId}} could not be found": "Resource sync {{rsId}} could not be found",
   "Resource sync {{rsId}}": "Resource sync {{rsId}}",

--- a/libs/ui-components/src/components/Fleet/FleetDetails/FleetOwnerLink.tsx
+++ b/libs/ui-components/src/components/Fleet/FleetDetails/FleetOwnerLink.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Label } from '@patternfly/react-core';
 import { CodeBranchIcon } from '@patternfly/react-icons/dist/js/icons/code-branch-icon';
 import { Link, ROUTE } from '../../../hooks/useNavigate';
 import WithTooltip from '../../common/WithTooltip';
@@ -11,7 +10,7 @@ export const getOwnerName = (owner: string | undefined) => rsOwnerRegex.exec(own
 
 export const RSLink = ({ rsName }: { rsName: string }) => (
   <div>
-    <Label color="green">RS</Label> <Link to={{ route: ROUTE.RESOURCE_SYNC_DETAILS, postfix: rsName }}>{rsName}</Link>
+    <CodeBranchIcon /> <Link to={{ route: ROUTE.RESOURCE_SYNC_DETAILS, postfix: rsName }}>{rsName}</Link>
   </div>
 );
 

--- a/libs/ui-components/src/components/Fleet/ResourceSyncRow.tsx
+++ b/libs/ui-components/src/components/Fleet/ResourceSyncRow.tsx
@@ -38,7 +38,7 @@ const ResourceSyncRow: React.FC<ResourceSyncRowProps> = ({
       <Td dataLabel={t('System image')}>-</Td>
       <Td dataLabel={t('Label selector')}>-</Td>
       <Td dataLabel={t('Status')}>
-        <ResourceSyncStatus resourceSync={resourceSync} />
+        <ResourceSyncStatus resourceSync={resourceSync} showLinksOnError />
       </Td>
       <Td isActionCell>
         <ActionsColumn

--- a/libs/ui-components/src/components/ResourceSync/RepositoryResourceSyncList.tsx
+++ b/libs/ui-components/src/components/ResourceSync/RepositoryResourceSyncList.tsx
@@ -10,6 +10,7 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from '@patternfly/react-core';
+import { TFunction } from 'i18next';
 
 import { useFetchPeriodically } from '../../hooks/useFetchPeriodically';
 import { useFetch } from '../../hooks/useFetch';
@@ -30,12 +31,12 @@ import TableTextSearch from '../Table/TableTextSearch';
 import { useTableSelect } from '../../hooks/useTableSelect';
 import TableActions from '../Table/TableActions';
 
-import './RepositoryResourceSyncList.css';
 import MassDeleteResourceSyncModal from '../modals/massModals/MassDeleteResourceSyncModal/MassDeleteResourceSyncModal';
 import ResourceSyncStatus from './ResourceSyncStatus';
-import { TFunction } from 'i18next';
 import { useTranslation } from '../../hooks/useTranslation';
 import { useAppContext } from '../../hooks/useAppContext';
+
+import './RepositoryResourceSyncList.css';
 
 const getColumns = (t: TFunction): TableColumn<ResourceSync>[] => [
   {

--- a/libs/ui-components/src/components/ResourceSync/ResourceSyncStatus.tsx
+++ b/libs/ui-components/src/components/ResourceSync/ResourceSyncStatus.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Label, LabelProps, List, ListItem, Popover, Stack, StackItem } from '@patternfly/react-core';
+import { Label, LabelProps, Popover, Stack, StackItem } from '@patternfly/react-core';
 import { CheckCircleIcon } from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import { InProgressIcon } from '@patternfly/react-icons/dist/js/icons/in-progress-icon';
 import { QuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
@@ -10,6 +10,7 @@ import WithTooltip from '../common/WithTooltip';
 import { getRepositorySyncStatus, repositoryStatusLabels } from '../../utils/status/repository';
 import { useTranslation } from '../../hooks/useTranslation';
 import { Link, ROUTE } from '../../hooks/useNavigate';
+import { Trans } from 'react-i18next';
 
 type ResourceSyncStatusProps = {
   resourceSync: ResourceSync;
@@ -49,29 +50,25 @@ const ResourceSyncStatus = ({ resourceSync, showLinksOnError = false }: Resource
 
   if (color === 'red' && showLinksOnError) {
     const repositoryName = resourceSync.spec.repository;
+    const rsName = resourceSync.metadata.name;
     return (
       <Popover
-        alertSeverityVariant="danger"
         triggerAction="hover"
         aria-label={t('Invalid resource sync configuration')}
         headerContent={t('Invalid resource sync configuration')}
         bodyContent={
           <Stack hasGutter>
+            <StackItem>
+              <Trans t={t}>
+                An error occurred when trying to apply the resource sync <strong>{rsName}</strong> from repository{' '}
+                <strong>{repositoryName}</strong>:
+              </Trans>
+            </StackItem>
             <StackItem>{statusType.message}</StackItem>
             <StackItem>
-              {t('Use the links below to review the resource sync settings and correct the configuration.')}
-              <List>
-                <ListItem>
-                  {t('Resource sync')}:{' '}
-                  <Link to={{ route: ROUTE.RESOURCE_SYNC_DETAILS, postfix: resourceSync.metadata.name }}>
-                    {resourceSync.metadata.name}
-                  </Link>
-                </ListItem>
-                <ListItem>
-                  {t('Repository')}:{' '}
-                  <Link to={{ route: ROUTE.REPO_DETAILS, postfix: repositoryName }}>{repositoryName}</Link>
-                </ListItem>
-              </List>
+              <Link to={{ route: ROUTE.RESOURCE_SYNC_DETAILS, postfix: resourceSync.metadata.name }}>
+                Review and fix the configuration
+              </Link>
             </StackItem>
           </Stack>
         }

--- a/libs/ui-components/src/components/ResourceSync/ResourceSyncStatus.tsx
+++ b/libs/ui-components/src/components/ResourceSync/ResourceSyncStatus.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Label, LabelProps } from '@patternfly/react-core';
+import { Label, LabelProps, List, ListItem, Popover, Stack, StackItem } from '@patternfly/react-core';
 import { CheckCircleIcon } from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import { InProgressIcon } from '@patternfly/react-icons/dist/js/icons/in-progress-icon';
 import { QuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
@@ -9,8 +9,14 @@ import { ConditionType, ResourceSync } from '@flightctl/types';
 import WithTooltip from '../common/WithTooltip';
 import { getRepositorySyncStatus, repositoryStatusLabels } from '../../utils/status/repository';
 import { useTranslation } from '../../hooks/useTranslation';
+import { Link, ROUTE } from '../../hooks/useNavigate';
 
-const ResourceSyncStatus = ({ resourceSync }: { resourceSync: ResourceSync }) => {
+type ResourceSyncStatusProps = {
+  resourceSync: ResourceSync;
+  showLinksOnError?: boolean;
+};
+
+const ResourceSyncStatus = ({ resourceSync, showLinksOnError = false }: ResourceSyncStatusProps) => {
   const { t } = useTranslation();
   const statusType = getRepositorySyncStatus(resourceSync, t);
   const statusLabels = repositoryStatusLabels(t);
@@ -39,6 +45,42 @@ const ResourceSyncStatus = ({ resourceSync }: { resourceSync: ResourceSync }) =>
       color = 'grey';
       icon = <QuestionCircleIcon />;
       break;
+  }
+
+  if (color === 'red' && showLinksOnError) {
+    const repositoryName = resourceSync.spec.repository;
+    return (
+      <Popover
+        alertSeverityVariant="danger"
+        triggerAction="hover"
+        aria-label={t('Invalid resource sync configuration')}
+        headerContent={t('Invalid resource sync configuration')}
+        bodyContent={
+          <Stack hasGutter>
+            <StackItem>{statusType.message}</StackItem>
+            <StackItem>
+              {t('Use the links below to review the resource sync settings and correct the configuration.')}
+              <List>
+                <ListItem>
+                  {t('Resource sync')}:{' '}
+                  <Link to={{ route: ROUTE.RESOURCE_SYNC_DETAILS, postfix: resourceSync.metadata.name }}>
+                    {resourceSync.metadata.name}
+                  </Link>
+                </ListItem>
+                <ListItem>
+                  {t('Repository')}:{' '}
+                  <Link to={{ route: ROUTE.REPO_DETAILS, postfix: repositoryName }}>{repositoryName}</Link>
+                </ListItem>
+              </List>
+            </StackItem>
+          </Stack>
+        }
+      >
+        <Label color={color} icon={icon}>
+          {statusLabels[statusType.status]}
+        </Label>
+      </Popover>
+    );
   }
 
   return (

--- a/libs/ui-components/src/utils/error.ts
+++ b/libs/ui-components/src/utils/error.ts
@@ -1,3 +1,8 @@
+import upperFirst from 'lodash/upperFirst';
+import toLower from 'lodash/toLower';
+
+import type { Condition } from '@flightctl/types';
+
 export const getErrorMessage = (error: unknown): string => {
   if (error instanceof Error) {
     return error.message || '';
@@ -10,3 +15,8 @@ export const getErrorMessage = (error: unknown): string => {
   }
   return 'Unexpected error';
 };
+
+const uppercaseSentence = (s: string | undefined) => (s ? upperFirst(toLower(s)) : '');
+
+export const getConditionMessage = (condition: Condition): string =>
+  [uppercaseSentence(condition.reason), uppercaseSentence(condition.message)].filter((msg) => !!msg).join('. ');

--- a/libs/ui-components/src/utils/status/fleet.ts
+++ b/libs/ui-components/src/utils/status/fleet.ts
@@ -1,6 +1,7 @@
 import { ConditionStatus, ConditionType, Fleet } from '@flightctl/types';
 import { FleetConditionType } from '../../types/extraTypes';
 import { TFunction } from 'i18next';
+import { getConditionMessage } from '../error';
 
 const fleetStatusLabels = (t: TFunction) => ({
   [ConditionType.FleetOverlappingSelectors]: t('Selectors overlap'),
@@ -31,8 +32,9 @@ const getFleetSyncStatus = (
   const validCondition = (fleet.status?.conditions || []).find((c) => c.type === ConditionType.FleetValid);
   if (validCondition) {
     const isOK = validCondition.status === ConditionStatus.ConditionStatusTrue;
+    const message = isOK ? '' : getConditionMessage(validCondition);
     return {
-      message: isOK ? '' : validCondition.message,
+      message,
       status: isOK ? ConditionType.FleetValid : 'Invalid',
     };
   }

--- a/libs/ui-components/src/utils/status/repository.ts
+++ b/libs/ui-components/src/utils/status/repository.ts
@@ -1,6 +1,7 @@
 import { TFunction } from 'i18next';
 import { ConditionStatus, ConditionType, Repository, ResourceSync } from '@flightctl/types';
 import { timeSinceText } from '../dates';
+import { getConditionMessage } from '../error';
 
 export type RepositorySyncStatus =
   | ConditionType.ResourceSyncSynced
@@ -34,7 +35,7 @@ const getRepositorySyncStatus = (
   if (accessibleCondition?.status === ConditionStatus.ConditionStatusFalse) {
     return {
       status: 'Not accessible',
-      message: accessibleCondition.message,
+      message: getConditionMessage(accessibleCondition),
     };
   }
 
@@ -42,7 +43,7 @@ const getRepositorySyncStatus = (
   if (parsedCondition?.status === ConditionStatus.ConditionStatusFalse) {
     return {
       status: 'Not parsed',
-      message: parsedCondition.message,
+      message: getConditionMessage(parsedCondition),
     };
   }
 
@@ -50,7 +51,7 @@ const getRepositorySyncStatus = (
   if (syncedCondition?.status === ConditionStatus.ConditionStatusFalse) {
     return {
       status: 'Not synced',
-      message: syncedCondition.message,
+      message: getConditionMessage(syncedCondition),
     };
   }
 


### PR DESCRIPTION
Currently, if a RS has an invalid configuration such as wrong branch / path, the UI only shows partially the error from the Backend. But it doesn't help to fix the problem, as there's no details about the RS itself.

I discussed it with Nir and he suggested to add the information of the RS / Repository on the tooltip.
Updated following his feedback on the previous screenshot.
![invalid-rs-config-2](https://github.com/flightctl/flightctl-ui/assets/829045/a3e74d56-4804-4a6f-9e09-650eafaffbe9)


