### PR TITLE
MGMT-17876 Adapt UI to change in templateVersion spec

### DIFF
--- a/libs/ui-components/src/hooks/useTemplateVersion.ts
+++ b/libs/ui-components/src/hooks/useTemplateVersion.ts
@@ -1,13 +1,19 @@
 import { Device, TemplateVersion } from '@flightctl/types';
 import { useFetchPeriodically } from './useFetchPeriodically';
 import { getDeviceFleet } from '../utils/devices';
+import { getMetadataAnnotation } from '../utils/api';
+import { DeviceAnnotation } from '../types/extraTypes';
 
 export const useTemplateVersion = (
   device: Device | undefined,
 ): [boolean, TemplateVersion | undefined, boolean, unknown] => {
-  const templateVersion = device?.spec?.templateVersion || '';
+  let templateVersion: string | undefined;
+  let ownerFleet: string | null | undefined;
+  if (device?.metadata) {
+    templateVersion = getMetadataAnnotation(device?.metadata, DeviceAnnotation.TemplateVersion);
+    ownerFleet = getDeviceFleet(device?.metadata);
+  }
 
-  const ownerFleet = device?.metadata ? getDeviceFleet(device?.metadata) : undefined;
   const shouldFetchTVs = !!(templateVersion && ownerFleet);
   const [tv, isLoading, error] = useFetchPeriodically<TemplateVersion>({
     endpoint: shouldFetchTVs ? `fleets/${ownerFleet}/templateversions/${templateVersion}` : '',

--- a/libs/ui-components/src/types/extraTypes.ts
+++ b/libs/ui-components/src/types/extraTypes.ts
@@ -40,6 +40,13 @@ export type FleetConditionType =
 
 export type FlightControlQuery = ApiQuery | MetricsQuery;
 
+export enum DeviceAnnotation {
+  TemplateVersion = 'TemplateVersion',
+  MultipleOwners = 'MultipleOwners',
+}
+
+export type AnnotationType = DeviceAnnotation; // Add more types when they are added to the API
+
 export const isEnrollmentRequest = (resource: Device | EnrollmentRequest): resource is EnrollmentRequest =>
   resource.kind === 'EnrollmentRequest';
 

--- a/libs/ui-components/src/utils/api.ts
+++ b/libs/ui-components/src/utils/api.ts
@@ -1,6 +1,6 @@
-import { ListMeta } from '@flightctl/types';
+import { ListMeta, ObjectMeta } from '@flightctl/types';
 
-import { ApiQuery, FlightControlQuery, MetricsQuery } from '../types/extraTypes';
+import { AnnotationType, ApiQuery, FlightControlQuery, MetricsQuery } from '../types/extraTypes';
 import { getPeriodTimestamps } from '../utils/metrics';
 
 const isApiQuery = (query: ApiQuery | MetricsQuery): query is ApiQuery => 'endpoint' in query;
@@ -56,10 +56,18 @@ const getApiListCount = (listResponse: ApiList | undefined): number | undefined 
   return hasItems ? 1 + extraItems : 0;
 };
 
+const getMetadataAnnotation = (metadata: ObjectMeta | undefined, annotation: AnnotationType) => {
+  if (metadata?.annotations) {
+    return metadata.annotations[annotation];
+  }
+  return undefined;
+};
+
 export {
   isApiQuery,
   getRequestQueryString,
   getQueryStringHash,
+  getMetadataAnnotation,
   getApiQueryString,
   getMetricsQueryString,
   getApiListCount,

--- a/libs/ui-components/src/utils/devices.ts
+++ b/libs/ui-components/src/utils/devices.ts
@@ -1,7 +1,8 @@
 import { Device, ObjectMeta } from '@flightctl/types';
-import { FlightCtlLabel } from '../types/extraTypes';
+import { DeviceAnnotation, FlightCtlLabel } from '../types/extraTypes';
 import { TFunction } from 'i18next';
 import { toAPILabel } from './labels';
+import { getMetadataAnnotation } from './api';
 
 const deviceFleetRegExp = /^Fleet\/(?<fleetName>.*)$/;
 
@@ -11,10 +12,10 @@ const getDeviceFleet = (metadata: ObjectMeta) => {
 };
 
 const getMissingFleetDetails = (t: TFunction, metadata: ObjectMeta): { message: string; owners: string[] } => {
-  const multipleOwnersInfo = Object.keys(metadata.annotations || {}).find((key) => key === 'MultipleOwners');
+  const multipleOwnersInfo = getMetadataAnnotation(metadata, DeviceAnnotation.MultipleOwners);
   if (multipleOwnersInfo) {
     // When the multiple owners issue is resolved, the annotation is still present
-    const owners = metadata.annotations?.MultipleOwners || '';
+    const owners = multipleOwnersInfo || '';
     if (owners.length > 0) {
       return {
         message: t('Device is owned by more than one fleet'),


### PR DESCRIPTION
The API will change the field which indicates what is the templateVersion for devices.

This PR will need to be merged when the [API PR ](https://github.com/flightctl/flightctl/pull/258) is merged. 

Device with details coming from the TV specified in the new annotation:
![tv-annotation](https://github.com/flightctl/flightctl-ui/assets/829045/f5aa602b-730e-4f72-b33c-6295e4a59bce)
