### PR TITLE
MGMT-17783 Handle errors for labels with missing keys

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -209,6 +209,7 @@
   "Resource syncs": "Resource syncs",
   "Target revision": "Target revision",
   "Fleets will appear in the fleets table list and their status will be reflecting the resource sync process status. After a few minutes, they should be synced and enabled.": "Fleets will appear in the fleets table list and their status will be reflecting the resource sync process status. After a few minutes, they should be synced and enabled.",
+  "Label keys are required. Invalid labels: {{invalidLabels}}": "Label keys are required. Invalid labels: {{invalidLabels}}",
   "Label keys must be unique": "Label keys must be unique",
   "Device names must be unique. Add a number to the template to generate unique names.": "Device names must be unique. Add a number to the template to generate unique names.",
   "Region is required.": "Region is required.",

--- a/libs/ui-components/src/components/form/validations.ts
+++ b/libs/ui-components/src/components/form/validations.ts
@@ -1,10 +1,8 @@
 import * as Yup from 'yup';
 import { TFunction } from 'i18next';
+import { FlightCtlLabel } from '../../types/extraTypes';
 
-export interface UnvalidatedLabel {
-  key?: string;
-  value?: string;
-}
+type UnvalidatedLabel = Partial<FlightCtlLabel>;
 
 export const uniqueLabelKeysSchema = (t: TFunction) =>
   Yup.array()

--- a/libs/ui-components/src/components/form/validations.ts
+++ b/libs/ui-components/src/components/form/validations.ts
@@ -1,18 +1,33 @@
 import * as Yup from 'yup';
 import { TFunction } from 'i18next';
 
-import { FlightCtlLabel } from '../../types/extraTypes';
+export interface UnvalidatedLabel {
+  key?: string;
+  value?: string;
+}
 
 export const uniqueLabelKeysSchema = (t: TFunction) =>
   Yup.array()
     .of(
-      Yup.object<FlightCtlLabel>().shape({
-        key: Yup.string().required(),
+      Yup.object<UnvalidatedLabel>().shape({
+        // We'll define the mandatory key restriction for all labels, not individually
+        key: Yup.string(),
         value: Yup.string(),
       }),
     )
     .required()
-    .test('unique keys', t('Label keys must be unique'), (labels: FlightCtlLabel[]) => {
+    .test('missing keys', (labels: UnvalidatedLabel[], testContext) => {
+      const missingKeyLabels = labels.filter((label) => !label.key).map((label) => label.value);
+      if (missingKeyLabels.length > 0) {
+        return testContext.createError({
+          message: t('Label keys are required. Invalid labels: {{invalidLabels}}', {
+            invalidLabels: `=${missingKeyLabels.join(', =')}`,
+          }),
+        });
+      }
+      return true;
+    })
+    .test('unique keys', t('Label keys must be unique'), (labels: UnvalidatedLabel[]) => {
       const uniqueKeys = new Set(labels.map((label) => label.key));
       return uniqueKeys.size === labels.length;
     });


### PR DESCRIPTION
Adds validation to labels to ensure the have the mandatory `key` property.
In case there are invalid labels, the message will indicate all the labels (values) which are missing the keys.

![label-keys-validation](https://github.com/flightctl/flightctl-ui/assets/829045/dd794478-4b89-4561-92a1-bc3fd9d48dc3)
