### PR TITLE
MGMT-17783 Define error boundaries in the UI

### DIFF
--- a/apps/standalone/src/app/routes.tsx
+++ b/apps/standalone/src/app/routes.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from '@flightctl/ui-components/src/hooks/useTranslatio
 
 import AppLayout from './components/AppLayout/AppLayout';
 import NotFound from './components/AppLayout/NotFound';
+import ErrorBoundary from '@flightctl/ui-components/src/components/common/ErrorBoundary';
 
 const EnrollmentRequestDetails = React.lazy(
   () =>
@@ -74,7 +75,7 @@ const TitledRoute = ({ title, children }: React.PropsWithChildren<{ title: strin
         </Bullseye>
       }
     >
-      {children}
+      <ErrorBoundary>{children}</ErrorBoundary>
     </React.Suspense>
   );
 };

--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -26,6 +26,8 @@
   "Copy text": "Copy text",
   "New label": "New label",
   "Add label": "Add label",
+  "Unexpected error occurred": "Unexpected error occurred",
+  "Please reload the page and try again.": "Please reload the page and try again.",
   "There are unsaved changes": "There are unsaved changes",
   "Discard changes": "Discard changes",
   "Stay here": "Stay here",

--- a/libs/ui-components/src/components/DetailsPage/DetailsPage.tsx
+++ b/libs/ui-components/src/components/DetailsPage/DetailsPage.tsx
@@ -15,6 +15,7 @@ import { getErrorMessage } from '../../utils/error';
 import DetailsNotFound from './DetailsNotFound';
 import { useTranslation } from '../../hooks/useTranslation';
 import { Link, Route } from '../../hooks/useNavigate';
+import ErrorBoundary from '../common/ErrorBoundary';
 
 export type DetailsPageProps = {
   id: string;
@@ -86,7 +87,9 @@ const DetailsPage: React.FC<DetailsPageProps> = ({
           {nav}
         </PageSection>
       )}
-      <PageSection>{content}</PageSection>
+      <PageSection>
+        <ErrorBoundary>{content}</ErrorBoundary>
+      </PageSection>
     </>
   );
 };

--- a/libs/ui-components/src/components/Fleet/CreateFleet/CreateFleetWizard.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/CreateFleetWizard.tsx
@@ -27,6 +27,7 @@ import { getFleetResource, getInitialValues, getValidationSchema } from './utils
 import CreateFleetWizardFooter from './CreateFleetWizardFooter';
 import { useEditFleet } from './useEditFleet';
 import LeaveFormConfirmation from '../../common/LeaveFormConfirmation';
+import ErrorBoundary from '../../common/ErrorBoundary';
 
 import './CreateFleetWizard.css';
 
@@ -135,7 +136,7 @@ const CreateFleetWizard = () => {
         </Title>
       </PageSection>
       <PageSection variant={PageSectionVariants.light} type="wizard">
-        {body}
+        <ErrorBoundary>{body}</ErrorBoundary>
       </PageSection>
     </>
   );

--- a/libs/ui-components/src/components/Fleet/ImportFleetWizard/ImportFleetWizard.tsx
+++ b/libs/ui-components/src/components/Fleet/ImportFleetWizard/ImportFleetWizard.tsx
@@ -38,6 +38,7 @@ import { useFetchPeriodically } from '../../../hooks/useFetchPeriodically';
 import { useTranslation } from '../../../hooks/useTranslation';
 import { Link, ROUTE, useNavigate } from '../../../hooks/useNavigate';
 import LeaveFormConfirmation from '../../common/LeaveFormConfirmation';
+import ErrorBoundary from '../../common/ErrorBoundary';
 
 import './ImportFleetWizard.css';
 
@@ -206,7 +207,7 @@ const ImportFleetWizard = () => {
         </Title>
       </PageSection>
       <PageSection variant={PageSectionVariants.light} type="wizard">
-        {body}
+        <ErrorBoundary>{body}</ErrorBoundary>
       </PageSection>
     </>
   );

--- a/libs/ui-components/src/components/ListPage/ListPageBody.tsx
+++ b/libs/ui-components/src/components/ListPage/ListPageBody.tsx
@@ -1,7 +1,9 @@
-import { getErrorMessage } from '../../utils/error';
-import { Alert, Bullseye, Spinner } from '@patternfly/react-core';
 import * as React from 'react';
+import { Alert, Bullseye, Spinner } from '@patternfly/react-core';
+
+import { getErrorMessage } from '../../utils/error';
 import { useTranslation } from '../../hooks/useTranslation';
+import ErrorBoundary from '../common/ErrorBoundary';
 
 type ListPageBodyProps = {
   error: unknown;
@@ -26,7 +28,7 @@ const ListPageBody: React.FC<ListPageBodyProps> = ({ error, loading, children })
       </Bullseye>
     );
   }
-  return children;
+  return <ErrorBoundary>{children}</ErrorBoundary>;
 };
 
 export default ListPageBody;

--- a/libs/ui-components/src/components/common/ErrorBoundary.tsx
+++ b/libs/ui-components/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { TFunction, withTranslation } from 'react-i18next';
+import { Alert } from '@patternfly/react-core';
+
+import { getErrorMessage } from '../../utils/error';
+
+interface Props {
+  children?: React.ReactNode;
+  t: TFunction;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error;
+  info: React.ErrorInfo;
+}
+
+class ErrorBoundary extends React.Component<Props, State> {
+  state = {
+    hasError: false,
+    error: { message: '', stack: '' } as Error,
+    info: { componentStack: '' },
+  };
+
+  static getDerivedStateFromError = (/* error */) => {
+    return { hasError: true };
+  };
+
+  componentDidCatch = (error: Error, info: React.ErrorInfo) => {
+    this.setState({ error, info });
+  };
+
+  render() {
+    const { hasError, error } = this.state;
+    const { children, t } = this.props;
+
+    return hasError ? (
+      <Alert variant="danger" title={t('Unexpected error occurred')} isInline>
+        {t('Please reload the page and try again.')}
+        <details>{getErrorMessage(error)}</details>
+      </Alert>
+    ) : (
+      children
+    );
+  }
+}
+
+const TranslatedErrorBoundary = withTranslation()(ErrorBoundary);
+
+export default TranslatedErrorBoundary;


### PR DESCRIPTION
Adds ErrorBoundary to several sections in the UI to handle better rendering errors.

Added to:
- List pages
- Detail pages
- CreateFleetWizard, ImportFleetWizard

In the future, we could capture the error detail to something like Sentry and output a friendlier message to the user.
![error-boundary](https://github.com/flightctl/flightctl-ui/assets/829045/4c8cc377-387c-45c7-938b-a21adefd674a)
