### PR TITLE
Change sort direction to match arrow directions

### DIFF
--- a/libs/ui-components/src/utils/sort/generic.ts
+++ b/libs/ui-components/src/utils/sort/generic.ts
@@ -11,7 +11,7 @@ export const sortByCreationTimestamp = <R extends { metadata: ObjectMeta }>(reso
   resources.sort((a, b) => {
     const aDate = a.metadata.creationTimestamp || 0;
     const bDate = b.metadata.creationTimestamp || 0;
-    return new Date(bDate).getTime() - new Date(aDate).getTime();
+    return new Date(aDate).getTime() - new Date(bDate).getTime();
   });
 
 export const sortByDisplayName = <R extends { metadata: ObjectMeta }>(resources: R[]) =>


### PR DESCRIPTION
QE reported that direction of the arrows in the column didn't match the data being shown.
This was due to the comparison elements being reversed, whereas all sorting functions already applied a-b.


![asc](https://github.com/flightctl/flightctl-ui/assets/829045/50332a85-4f74-4d84-be99-b916bec04339)
![desc](https://github.com/flightctl/flightctl-ui/assets/829045/0f253780-1e0e-49b5-891b-e68f54ef3411)
