### PR TITLE
Fix error boundary bug when content was undefined

### DIFF
--- a/libs/ui-components/src/components/common/ErrorBoundary.tsx
+++ b/libs/ui-components/src/components/common/ErrorBoundary.tsx
@@ -33,6 +33,9 @@ class ErrorBoundary extends React.Component<Props, State> {
   render() {
     const { hasError, error } = this.state;
     const { children, t } = this.props;
+    if (!hasError && !children) {
+      return null;
+    }
 
     return hasError ? (
       <Alert variant="danger" title={t('Unexpected error occurred')} isInline>


### PR DESCRIPTION
Fixes an error in `ErrorBoundary`  :cold_sweat:   when content is `undefined`, like for example in DetailsPage when data is still loading. 