### PR TITLE
Adjust label selector display in FleetList

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -29,7 +29,7 @@
   "Unexpected error occurred": "Unexpected error occurred",
   "Please reload the page and try again.": "Please reload the page and try again.",
   "Show less": "Show less",
-  "${remaining} more": "${remaining} more",
+  "{{remaining}} more": "{{remaining}} more",
   "There are unsaved changes": "There are unsaved changes",
   "Discard changes": "Discard changes",
   "Stay here": "Stay here",

--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -28,6 +28,8 @@
   "Add label": "Add label",
   "Unexpected error occurred": "Unexpected error occurred",
   "Please reload the page and try again.": "Please reload the page and try again.",
+  "Show less": "Show less",
+  "${remaining} more": "${remaining} more",
   "There are unsaved changes": "There are unsaved changes",
   "Discard changes": "Discard changes",
   "Stay here": "Stay here",

--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -29,7 +29,7 @@
   "Unexpected error occurred": "Unexpected error occurred",
   "Please reload the page and try again.": "Please reload the page and try again.",
   "Show less": "Show less",
-  "{{remaining}} more": "{{remaining}} more",
+  "more": "more",
   "There are unsaved changes": "There are unsaved changes",
   "Discard changes": "Discard changes",
   "Stay here": "Stay here",

--- a/libs/ui-components/src/components/Fleet/FleetRow.tsx
+++ b/libs/ui-components/src/components/Fleet/FleetRow.tsx
@@ -71,7 +71,7 @@ const FleetRow: React.FC<FleetRowProps> = ({ fleet, rowIndex, onRowSelect, isRow
       </Td>
       <Td dataLabel={t('System image')}>{fleet.spec.template.spec.os?.image || '-'}</Td>
       <Td dataLabel={t('Label selector')}>
-        <LabelsView prefix={fleetName} labels={fleet.spec.selector?.matchLabels} />
+        <LabelsView prefix={fleetName} labels={fleet.spec.selector?.matchLabels} variant="collapsed" />
       </Td>
       <Td dataLabel={t('Status')}>
         <FleetStatus fleet={fleet} />

--- a/libs/ui-components/src/components/common/LabelsView.css
+++ b/libs/ui-components/src/components/common/LabelsView.css
@@ -1,0 +1,9 @@
+.fctl-labels-view__collapsed {
+  /* Set a maximum width on larger breakpoints */
+  @media (min-width: 769px) {
+    max-width: 400px;
+  }
+}
+
+
+

--- a/libs/ui-components/src/components/common/LabelsView.tsx
+++ b/libs/ui-components/src/components/common/LabelsView.tsx
@@ -24,9 +24,7 @@ const LabelsView = ({ variant, prefix, labels }: LabelsViewProps) => {
       numLabels={isLimited ? 2 : 5}
       className={isLimited ? 'fctl-labels-view__collapsed' : undefined}
       expandedText={t('Show less')}
-      // Label group will use this template and inject the correct count of labels.
-      // For it to work, the variable name must be "remaining"
-      collapsedText={t('{{remaining}} more', { remaining: 0 })}
+      collapsedText={'${remaining} ' + t('more')}
     >
       {labelItems.map(([key, value], index: number) => (
         <Label key={`${prefix}_${index}`} id={`${prefix}_${index}`} color="blue">

--- a/libs/ui-components/src/components/common/LabelsView.tsx
+++ b/libs/ui-components/src/components/common/LabelsView.tsx
@@ -19,13 +19,14 @@ const LabelsView = ({ variant, prefix, labels }: LabelsViewProps) => {
   }
 
   const isLimited = variant === 'collapsed';
-
   return (
     <LabelGroup
       numLabels={isLimited ? 2 : 5}
       className={isLimited ? 'fctl-labels-view__collapsed' : undefined}
       expandedText={t('Show less')}
-      collapsedText={t('${remaining} more')}
+      // Label group will use this template and inject the correct count of labels.
+      // For it to work, the variable name must be "remaining"
+      collapsedText={t('{{remaining}} more', { remaining: 0 })}
     >
       {labelItems.map(([key, value], index: number) => (
         <Label key={`${prefix}_${index}`} id={`${prefix}_${index}`} color="blue">

--- a/libs/ui-components/src/components/common/LabelsView.tsx
+++ b/libs/ui-components/src/components/common/LabelsView.tsx
@@ -1,14 +1,32 @@
 import * as React from 'react';
-
 import { Label, LabelGroup } from '@patternfly/react-core';
 
-const LabelsView = ({ prefix, labels }: { prefix: string; labels: Record<string, string | undefined> | undefined }) => {
+import { useTranslation } from '../../hooks/useTranslation';
+
+import './LabelsView.css';
+
+interface LabelsViewProps {
+  prefix: string;
+  labels: Record<string, string | undefined> | undefined;
+  variant?: 'default' | 'collapsed';
+}
+
+const LabelsView = ({ variant, prefix, labels }: LabelsViewProps) => {
+  const { t } = useTranslation();
   const labelItems = Object.entries(labels || {});
   if (labelItems.length === 0) {
     return '-';
   }
+
+  const isLimited = variant === 'collapsed';
+
   return (
-    <LabelGroup numLabels={5}>
+    <LabelGroup
+      numLabels={isLimited ? 2 : 5}
+      className={isLimited ? 'fctl-labels-view__collapsed' : undefined}
+      expandedText={t('Show less')}
+      collapsedText={t('${remaining} more')}
+    >
       {labelItems.map(([key, value], index: number) => (
         <Label key={`${prefix}_${index}`} id={`${prefix}_${index}`} color="blue">
           {value ? `${key}=${value}` : key}

--- a/libs/ui-components/src/components/form/LabelsField.tsx
+++ b/libs/ui-components/src/components/form/LabelsField.tsx
@@ -15,16 +15,10 @@ type LabelsFieldProps = {
   onChangeCallback?: (newLabels: FlightCtlLabel[], hasErrors: boolean) => void;
 };
 
-const LabelsField: React.FC<LabelsFieldProps> = ({
-  name,
-  onChangeCallback,
-  addButtonText,
-  isEditable: isEditableProp,
-}) => {
+const LabelsField: React.FC<LabelsFieldProps> = ({ name, onChangeCallback, addButtonText, isEditable = true }) => {
   const [{ value: labels }, meta, { setValue: setLabels }] = useField<FlightCtlLabel[]>(name);
   const { t } = useTranslation();
 
-  const isEditable = isEditableProp ?? true;
   const updateLabels = async (newLabels: FlightCtlLabel[]) => {
     const errors = await setLabels(newLabels, true);
     const hasErrors = Object.keys(errors || {}).length > 0;

--- a/libs/ui-components/src/components/form/LabelsField.tsx
+++ b/libs/ui-components/src/components/form/LabelsField.tsx
@@ -15,10 +15,16 @@ type LabelsFieldProps = {
   onChangeCallback?: (newLabels: FlightCtlLabel[], hasErrors: boolean) => void;
 };
 
-const LabelsField: React.FC<LabelsFieldProps> = ({ name, onChangeCallback, addButtonText, isEditable }) => {
+const LabelsField: React.FC<LabelsFieldProps> = ({
+  name,
+  onChangeCallback,
+  addButtonText,
+  isEditable: isEditableProp,
+}) => {
   const [{ value: labels }, meta, { setValue: setLabels }] = useField<FlightCtlLabel[]>(name);
   const { t } = useTranslation();
 
+  const isEditable = isEditableProp ?? true;
   const updateLabels = async (newLabels: FlightCtlLabel[]) => {
     const errors = await setLabels(newLabels, true);
     const hasErrors = Object.keys(errors || {}).length > 0;
@@ -61,13 +67,13 @@ const LabelsField: React.FC<LabelsFieldProps> = ({ name, onChangeCallback, addBu
     <>
       <LabelGroup
         numLabels={5}
-        isEditable={isEditable ?? true}
+        isEditable={isEditable}
         addLabelControl={
           <EditableLabelControl
             defaultLabel="key=value"
             addButtonText={addButtonText}
             onAddLabel={onAdd}
-            isEditable={isEditable ?? true}
+            isEditable={isEditable}
           />
         }
       >
@@ -84,7 +90,7 @@ const LabelsField: React.FC<LabelsFieldProps> = ({ name, onChangeCallback, addBu
             onClose={(e) => onDelete(e, index)}
             onEditCancel={(_, prevText) => onEdit(index, prevText)}
             onEditComplete={(_, newText) => onEdit(index, newText)}
-            isEditable={isEditable ?? true}
+            isEditable={isEditable}
           >
             {value ? `${key}=${value}` : key}
           </Label>


### PR DESCRIPTION
In FleetList, if a fleet has many labels, or they are long, the column for the label grew accordingly.
To prevent that, we add a new variant to the  `LabelsView` which sets a maximum width on larger viewports.

![labels-2](https://github.com/flightctl/flightctl-ui/assets/829045/0662a261-4322-4d93-a575-07b80acc8f56)
![labels-1](https://github.com/flightctl/flightctl-ui/assets/829045/5fda6e32-2179-4150-8e8b-5160ba903f3c)


**Note**: This PR also fixes an issue whereby most of the forms including a LabelsField would not allow to edit or delete the labels after adding them.
