### PR TITLE
Fix isPendingEnrollmentRequest function

### DIFF
--- a/libs/ui-components/src/components/modals/massModals/MassApproveDeviceModal/MassApproveDeviceModal.tsx
+++ b/libs/ui-components/src/components/modals/massModals/MassApproveDeviceModal/MassApproveDeviceModal.tsx
@@ -34,7 +34,7 @@ const templateToName = (index: number, nameTemplate: string) =>
   nameTemplate ? nameTemplate.replace(/{{n+}}/g, `${index + 1}`) : '';
 
 const isPendingEnrollmentRequest = (r: DeviceLikeResource): r is EnrollmentRequest => {
-  return isEnrollmentRequest(r) && getApprovalStatus(r) === EnrollmentRequestStatus.Approved;
+  return isEnrollmentRequest(r) && getApprovalStatus(r) === EnrollmentRequestStatus.Pending;
 };
 
 type DeviceEnrollmentFormValues = {

--- a/libs/ui-components/src/utils/status/enrollmentRequest.ts
+++ b/libs/ui-components/src/utils/status/enrollmentRequest.ts
@@ -37,14 +37,12 @@ export const getApprovalStatus = (enrollmentRequest: EnrollmentRequest): Enrollm
   const approvedCondition = enrollmentRequest.status?.conditions?.find(
     (c) => c.type === ConditionType.EnrollmentRequestApproved,
   );
-  if (!approvedCondition) {
-    return EnrollmentRequestStatus.Pending;
+
+  switch (approvedCondition?.status) {
+    case 'True':
+      return EnrollmentRequestStatus.Approved;
+    case 'False':
+      return EnrollmentRequestStatus.Denied;
   }
-  if (approvedCondition.status === 'True') {
-    return EnrollmentRequestStatus.Approved;
-  }
-  if (approvedCondition.status === 'False') {
-    return EnrollmentRequestStatus.Denied;
-  }
-  return EnrollmentRequestStatus.Unknown;
+  return EnrollmentRequestStatus.Pending;
 };


### PR DESCRIPTION
[This change](https://github.com/flightctl/flightctl-ui/pull/22/files#diff-1cdee6b7851bafbd9f96a11cbf0073700f81fe2cad791471fe15698e60e85057R36) has broken the MassDeviceApproveModal, as it was doing the wrong comparison.

I wanted to avoid ER in statuses than "Pending" (like the denied ones),  to be considered pending approval.

I updated the `getApprovalStatus` function to prevent that.