### PR TITLE
Fix resource sync selection color for dark theme

### DIFF
--- a/libs/ui-components/src/components/ResourceSync/RepositoryResourceSyncList.css
+++ b/libs/ui-components/src/components/ResourceSync/RepositoryResourceSyncList.css
@@ -1,3 +1,7 @@
 .fctl-rslist-row--selected {
   background-color: var(--pf-v5-global--palette--blue-50);
 }
+
+.pf-v5-theme-dark .fctl-rslist-row--selected {
+  background-color: var(--pf-v5-global--palette--blue-400);
+}


### PR DESCRIPTION
It would look like:

![color-fix-2](https://github.com/flightctl/flightctl-ui/assets/829045/92917438-8025-4343-8b29-ee4908ed2a45)

