### PR TITLE
Fix removing the last device selector label

### DIFF
--- a/libs/ui-components/src/components/Fleet/CreateFleet/utils.ts
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/utils.ts
@@ -40,20 +40,28 @@ export const getFleetPatches = (currentFleet: Fleet, updatedFleet: FleetFormValu
   // Device label selector
   const currentDeviceSelectLabels = currentFleet.spec.selector?.matchLabels || {};
   const updatedDeviceSelectLabels = updatedFleet.labels || {};
+  const updatedDeviceSelectLabelCount = Object.keys(updatedDeviceSelectLabels).length;
 
-  if (currentFleet.spec.selector) {
-    const deviceSelectLabelPatches = getLabelPatches(
-      '/spec/selector/matchLabels',
-      currentDeviceSelectLabels,
-      updatedDeviceSelectLabels,
-    );
-    allPatches = allPatches.concat(deviceSelectLabelPatches);
-  } else {
-    const newLabelMap = toAPILabel(updatedDeviceSelectLabels);
+  if (updatedDeviceSelectLabelCount > 0) {
+    if (currentFleet.spec.selector) {
+      const deviceSelectLabelPatches = getLabelPatches(
+        '/spec/selector/matchLabels',
+        currentDeviceSelectLabels,
+        updatedDeviceSelectLabels,
+      );
+      allPatches = allPatches.concat(deviceSelectLabelPatches);
+    } else {
+      const newLabelMap = toAPILabel(updatedDeviceSelectLabels);
+      allPatches.push({
+        path: '/spec/selector',
+        op: 'add',
+        value: { matchLabels: newLabelMap },
+      });
+    }
+  } else if (currentFleet.spec.selector) {
     allPatches.push({
       path: '/spec/selector',
-      op: 'add',
-      value: { matchLabels: newLabelMap },
+      op: 'remove',
     });
   }
 


### PR DESCRIPTION
When the last device selector label was removed, the request sent to the API was incorrect.

Instead of:
```
{
  "path": "/spec/selector/matchLabels",
  "op": "remove"
}
```

the request should be:

```
{
  "path": "/spec/selector",
  "op": "remove"
}
```
