### PR TITLE
Fix bad HTML structure in table headers of button inside a button

### DIFF
--- a/libs/ui-components/src/components/common/WithHelperText.tsx
+++ b/libs/ui-components/src/components/common/WithHelperText.tsx
@@ -16,6 +16,7 @@ const WithHelperText = ({ ariaLabel, showLabel, content, triggerAction }: WithHe
     {showLabel && ariaLabel}
     <Popover aria-label={ariaLabel} bodyContent={content} withFocusTrap triggerAction={triggerAction}>
       <Button
+        component="a"
         className="fctl-helper-text__icon"
         isInline
         variant="plain"


### PR DESCRIPTION
Fixes the problem found in the column headers of the device table.

Since the sortable headers are already `<button>`, the HelperText icon inside them must not also be a button.

![fix-button-dom](https://github.com/user-attachments/assets/6bccb60a-b0e5-4055-b0db-ddb55f19794f)
