### PR TITLE
EDM-274: Pass auth info for terminal session

### DIFF
--- a/apps/ocp-plugin/src/hooks/useFetch.ts
+++ b/apps/ocp-plugin/src/hooks/useFetch.ts
@@ -21,8 +21,16 @@ export const useFetch = () => {
     [],
   );
 
+  const getWsEndpoint = React.useCallback(
+    () => ({
+      wsEndpoint,
+      protocols: ['flightctl.ocp.auth'],
+    }),
+    [],
+  );
+
   return {
-    wsEndpoint,
+    getWsEndpoint,
     get,
     post,
     remove,

--- a/apps/ocp-plugin/start-ocp-console.sh
+++ b/apps/ocp-plugin/start-ocp-console.sh
@@ -62,7 +62,7 @@ if [ -x "$(command -v podman)" ]; then
           -v $PWD/ocp-console/ca.crt:/tmp/ca.crt:Z \
           --pull always \
           --rm --network=host \
-          --env BRIDGE_PLUGIN_PROXY='{"services": [{"consoleAPIPath": "/api/proxy/plugin/flightctl-plugin/api-proxy/", "endpoint":"http://localhost:3001","authorize":false},{"consoleAPIPath": "/api/proxy/plugin/mce/console/", "endpoint":"https://localhost:2000","authorize":true},{"consoleAPIPath": "/api/proxy/plugin/acm/console/", "endpoint":"https://localhost:2000","authorize":true}]}' \
+          --env BRIDGE_PLUGIN_PROXY='{"services": [{"consoleAPIPath": "/api/proxy/plugin/flightctl-plugin/api-proxy/", "endpoint":"http://localhost:3001","authorize":true},{"consoleAPIPath": "/api/proxy/plugin/mce/console/", "endpoint":"https://localhost:2000","authorize":true},{"consoleAPIPath": "/api/proxy/plugin/acm/console/", "endpoint":"https://localhost:2000","authorize":true}]}' \
           --env-file <(set | grep BRIDGE) \
           $CONSOLE_IMAGE
     else

--- a/apps/standalone/src/app/hooks/useFetch.ts
+++ b/apps/standalone/src/app/hooks/useFetch.ts
@@ -29,8 +29,16 @@ export const useFetch = () => {
     [userToken],
   );
 
+  const getWsEndpoint = React.useCallback(
+    () => ({
+      wsEndpoint,
+      protocols: ['flightctl.standalone.auth', userToken || ''],
+    }),
+    [userToken],
+  );
+
   return {
-    wsEndpoint,
+    getWsEndpoint,
     get,
     post,
     remove,

--- a/libs/ui-components/src/hooks/useAppContext.tsx
+++ b/libs/ui-components/src/hooks/useAppContext.tsx
@@ -60,7 +60,7 @@ export type AppContextProps = {
     Prompt?: PromptFC;
   };
   fetch: {
-    wsEndpoint: string;
+    getWsEndpoint: () => { wsEndpoint: string; protocols: string[] };
     get: <R>(kind: string, abortSignal?: AbortSignal) => Promise<R>;
     post: <R>(kind: string, data: R, abortSignal?: AbortSignal) => Promise<R>;
     remove: <R>(kind: string, abortSignal?: AbortSignal) => Promise<R>;
@@ -93,7 +93,7 @@ export const AppContext = React.createContext<AppContextProps>({
   },
   /* eslint-disable */
   fetch: {
-    wsEndpoint: '',
+    getWsEndpoint: () => ({ wsEndpoint: '', protocols: [''] }),
     get: async () => ({}) as any,
     post: async () => ({}) as any,
     remove: async () => ({}) as any,

--- a/libs/ui-components/src/hooks/useWebSocket.ts
+++ b/libs/ui-components/src/hooks/useWebSocket.ts
@@ -13,7 +13,7 @@ export const useWebSocket = <T extends string>(
   reconnect: VoidFunction;
 } => {
   const {
-    fetch: { wsEndpoint },
+    fetch: { getWsEndpoint },
   } = useAppContext();
   const { t } = useTranslation();
   const wsRef = React.useRef<WebSocket>();
@@ -30,7 +30,8 @@ export const useWebSocket = <T extends string>(
     try {
       setIsConnecting(true);
       setIsClosed(false);
-      const ws = new WebSocket(`${wsEndpoint}${endpoint}`);
+      const { wsEndpoint, protocols } = getWsEndpoint();
+      const ws = new WebSocket(`${wsEndpoint}${endpoint}`, protocols);
       ws.addEventListener('open', () => setIsConnecting(false));
       ws.addEventListener('close', () => setIsClosed(true));
       ws.addEventListener('error', (evt) => {
@@ -47,7 +48,7 @@ export const useWebSocket = <T extends string>(
       wsRef.current?.close();
       wsRef.current = undefined;
     };
-  }, [endpoint, t, wsEndpoint, reset]);
+  }, [endpoint, t, getWsEndpoint, reset]);
 
   const reconnect = React.useCallback(() => {
     wsRef.current?.close();

--- a/proxy/bridge/auth.go
+++ b/proxy/bridge/auth.go
@@ -3,13 +3,30 @@ package bridge
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"net/http"
+	"net/textproto"
 	"os"
 	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/flightctl/flightctl-ui/utils"
 )
+
+var protocolHeader = textproto.CanonicalMIMEHeaderKey("Sec-WebSocket-Protocol")
+
+func getAuthHeaderValue(r *http.Request) (string, error) {
+	authHeader, ok := r.Header["Authorization"]
+	if !ok || len(authHeader) != 1 {
+		return "", errors.New("missing Authorization header")
+	}
+
+	authHeaderValueSplit := strings.Split(authHeader[0], "Bearer ")
+	if len(authHeaderValueSplit) != 2 {
+		return "", errors.New("incorrect Authorization header")
+	}
+	return authHeaderValueSplit[1], nil
+}
 
 func AuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -18,17 +35,42 @@ func AuthMiddleware(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
-		authHeader, ok := r.Header["Authorization"]
-		if !ok || len(authHeader) != 1 {
-			http.Error(w, "Missing Authorization header", http.StatusForbidden)
-			return
+
+		bearer := ""
+
+		if strings.HasPrefix(r.RequestURI, "/api/terminal/") {
+			protocolHeaderVal, ok := r.Header[protocolHeader]
+			if !ok || len(protocolHeaderVal) != 1 {
+				http.Error(w, "Missing protocol header", http.StatusForbidden)
+				return
+			}
+			protocols := strings.Split(protocolHeaderVal[0], ",")
+			if protocols[0] == wsStandaloneSubprotocol {
+				if len(protocols) != 2 {
+					http.Error(w, "Missing Authorization header", http.StatusForbidden)
+					return
+				}
+
+				bearer = strings.TrimSpace(protocols[1])
+			} else if protocols[0] == wsOcpSubprotocol {
+				bearerVal, err := getAuthHeaderValue(r)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusForbidden)
+				}
+				bearer = bearerVal
+			} else {
+				http.Error(w, "Unknown auth subprotocol", http.StatusForbidden)
+				return
+			}
+
+		} else {
+			bearerVal, err := getAuthHeaderValue(r)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusForbidden)
+			}
+			bearer = bearerVal
 		}
 
-		bearer := strings.Split(authHeader[0], "Bearer ")
-		if len(bearer) != 2 {
-			http.Error(w, "Incorrect Authorization header", http.StatusForbidden)
-			return
-		}
 		provider, err := oidc.NewProvider(r.Context(), keycloakAuth)
 		if err != nil {
 			http.Error(w, "Failed to verify auth token: "+err.Error(), http.StatusForbidden)
@@ -37,7 +79,7 @@ func AuthMiddleware(next http.Handler) http.Handler {
 
 		verifier := provider.Verifier(&oidc.Config{SkipClientIDCheck: true, SkipIssuerCheck: true})
 
-		_, err = verifier.Verify(r.Context(), bearer[1])
+		_, err = verifier.Verify(r.Context(), bearer)
 		if err != nil {
 			http.Error(w, "Failed to verify auth token: "+err.Error(), http.StatusForbidden)
 			return

--- a/proxy/bridge/terminal.go
+++ b/proxy/bridge/terminal.go
@@ -17,6 +17,11 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
+const (
+	wsStandaloneSubprotocol = "flightctl.standalone.auth"
+	wsOcpSubprotocol        = "flightctl.ocp.auth"
+)
+
 var upgrader = websocket.Upgrader{} // use default options
 
 type TerminalBridge struct {
@@ -88,6 +93,7 @@ func (b TerminalBridge) HandleTerminal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	upgrader.CheckOrigin = func(r *http.Request) bool { return true }
+	upgrader.Subprotocols = []string{wsStandaloneSubprotocol, wsOcpSubprotocol}
 	c, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Note that this is only for standalone deployments where UI proxy is currently the one which verifies the token validity.

For OCP plugin, we will need backend to do the validation so that part is TBD