### PR TITLE
EDM-237: Correct location of tooltip for managed by RS

### DIFF
--- a/libs/ui-components/src/components/Fleet/FleetDetails/FleetOwnerLink.tsx
+++ b/libs/ui-components/src/components/Fleet/FleetDetails/FleetOwnerLink.tsx
@@ -35,14 +35,15 @@ export const FleetOwnerLinkIcon = ({
   }
 
   return (
-    <WithTooltip
-      content={t('Managed by the resource sync {{resourceSyncName}}', { resourceSyncName: ownerName })}
-      showTooltip
-    >
-      <span style={{ display: 'flex', alignItems: 'center' }}>
-        <CodeBranchIcon /> {children}
-      </span>
-    </WithTooltip>
+    <span style={{ display: 'flex', alignItems: 'center' }}>
+      <WithTooltip
+        content={t('Managed by the resource sync {{resourceSyncName}}', { resourceSyncName: ownerName })}
+        showTooltip
+      >
+        <CodeBranchIcon />
+      </WithTooltip>
+      {children}
+    </span>
   );
 };
 

--- a/libs/ui-components/src/components/Repository/CreateRepository/CreateRepositoryForm.tsx
+++ b/libs/ui-components/src/components/Repository/CreateRepository/CreateRepositoryForm.tsx
@@ -260,7 +260,15 @@ const CreateRepositoryFormContent = ({ isEdit, children, onClose }: CreateReposi
         {showResourceSyncs && (
           <Checkbox
             id="use-resource-syncs"
-            label={t('Use resource syncs')}
+            label={
+              <WithHelperText
+                showLabel
+                ariaLabel={t('Use resource syncs')}
+                content={t(
+                  "A resource sync is an automated Gitops way to manage imported fleets. The resource sync monitors changes made to the source repository and update the fleet's configurations accordingly.",
+                )}
+              />
+            }
             isChecked={values.useResourceSyncs}
             onChange={(_, checked) => {
               // Trigger validation of the resource syncs items

--- a/libs/ui-components/src/components/common/WithHelperText.tsx
+++ b/libs/ui-components/src/components/common/WithHelperText.tsx
@@ -20,6 +20,10 @@ const WithHelperText = ({ ariaLabel, showLabel, content, triggerAction }: WithHe
         className="fctl-helper-text__icon"
         isInline
         variant="plain"
+        onClick={(ev) => {
+          ev.preventDefault();
+          ev.stopPropagation();
+        }}
         aria-label={`${ariaLabel} help text`}
         icon={<OutlinedQuestionCircleIcon />}
       />


### PR DESCRIPTION
The tooltip is now only in the icon, and not in the Fleet name.
![tooltip-icon](https://github.com/user-attachments/assets/5145ab20-7dc4-40fc-add0-2743f1b561cc)


Also added the missing helper text icon to the "Create / Edit" repository wizards.
![tooltip-added](https://github.com/user-attachments/assets/06d43e34-0153-4c01-941b-571f2fe21cd9)
