### PR TITLE
EDM-283: Limit popover error size

### DIFF
--- a/libs/ui-components/src/components/Status/StatusDisplay.css
+++ b/libs/ui-components/src/components/Status/StatusDisplay.css
@@ -2,3 +2,8 @@
   /* Reduce the space between the icon and the label, caused by the table rules */
   --pf-v5-l-flex--spacer--column: 0.5rem;
 }
+
+.fctl-status-display-content__popover .pf-v5-c-popover__body {
+  overflow-y: scroll;
+  max-height: 30vh;
+}

--- a/libs/ui-components/src/components/Status/StatusDisplay.tsx
+++ b/libs/ui-components/src/components/Status/StatusDisplay.tsx
@@ -22,7 +22,13 @@ export const StatusDisplayContent = ({ label, messageTitle, message, level, cust
 
   if (message) {
     return (
-      <Popover aria-label="status popover" headerContent={messageTitle || label} bodyContent={message}>
+      <Popover
+        aria-label="status popover"
+        headerContent={messageTitle || label}
+        bodyContent={message}
+        className="fctl-status-display-content__popover"
+        hasAutoWidth={false}
+      >
         <Button
           variant="link"
           isInline


### PR DESCRIPTION
If the statuses info messages are too large, the UI adds a limit height to the Popover, and makes the content scrollable.

Long message:
![long-message](https://github.com/user-attachments/assets/8094b826-6102-46de-b2ff-a6507ae2fe0b)

Short message:
![short-message](https://github.com/user-attachments/assets/186e4720-7cfb-493f-bde5-3ed7dd29901d)
