### PR TITLE
Fix wrong match to fleets with no label selector

### DIFF
--- a/libs/ui-components/src/hooks/useDeviceLabelMatch.ts
+++ b/libs/ui-components/src/hooks/useDeviceLabelMatch.ts
@@ -22,6 +22,11 @@ type MatchLabelsFn = (labels: FlightCtlLabel[], hasErrors: boolean) => void;
 const getMatchResult = (fleets: Fleet[], deviceLabels: FlightCtlLabel[]): DeviceMatchStatus => {
   const matchingFleets = fleets.filter((fleet) => {
     const fleetMatch = fleet.spec.selector?.matchLabels || {};
+
+    if (Object.keys(fleetMatch).length === 0) {
+      // Fleets with no label selector don't match any devices
+      return false;
+    }
     return Object.entries(fleetMatch).every(([fleetMatchKey, fleetMatchValue]) => {
       const matchingDeviceLabel = deviceLabels.find((dLabel) => dLabel.key === fleetMatchKey);
       return matchingDeviceLabel && (matchingDeviceLabel.value || '') === (fleetMatchValue || '');


### PR DESCRIPTION
The match selector was identifying fleet with no labels as matching all devices, when in reality, they don't match any devices.