### PR TITLE
EDM-286 Showing default device labels in Approve Device Modal

### DIFF
--- a/libs/ui-components/src/components/form/LabelsField.tsx
+++ b/libs/ui-components/src/components/form/LabelsField.tsx
@@ -8,18 +8,21 @@ import ErrorHelperText, { DefaultHelperText } from './FieldHelperText';
 
 type LabelsFieldProps = {
   name: string;
-  isEditable?: boolean;
+  isFormEditable?: boolean;
   addButtonText?: string;
   helperText?: React.ReactNode;
   onChangeCallback?: (newLabels: FlightCtlLabel[], hasErrors: boolean) => void;
 };
+
+const maxWidthDefaultLabel = '18ch'; // Can fit more chars as it doesn't have a "Close" button
+const maxWidthNonDefaultLabel = '16ch'; // Can fit less chars due to the "Close" button
 
 const LabelsField: React.FC<LabelsFieldProps> = ({
   name,
   onChangeCallback,
   addButtonText,
   helperText,
-  isEditable = true,
+  isFormEditable = true,
 }) => {
   const [{ value: labels }, meta, { setValue: setLabels }] = useField<FlightCtlLabel[]>(name);
   const updateLabels = async (newLabels: FlightCtlLabel[]) => {
@@ -30,7 +33,7 @@ const LabelsField: React.FC<LabelsFieldProps> = ({
   };
 
   const onDelete = async (_ev: React.MouseEvent<Element, MouseEvent>, index: number) => {
-    if (!isEditable) {
+    if (!isFormEditable) {
       return;
     }
     const newLabels = [...labels];
@@ -64,33 +67,40 @@ const LabelsField: React.FC<LabelsFieldProps> = ({
     <>
       <LabelGroup
         numLabels={5}
-        isEditable={isEditable}
+        isEditable={isFormEditable}
         addLabelControl={
           <EditableLabelControl
             defaultLabel="key=value"
             addButtonText={addButtonText}
             onAddLabel={onAdd}
-            isEditable={isEditable}
+            isEditable={isFormEditable}
           />
         }
       >
         {labels.map(({ key, value, isDefault }, index) => {
           const text = value ? `${key}=${value}` : key;
           const elKey = `${key}__${index}`;
-          if (isDefault || !isEditable) {
+          if (isDefault) {
             return (
-              <Label key={elKey} textMaxWidth="18ch">
+              <Label key={elKey} textMaxWidth={maxWidthDefaultLabel}>
                 {text}
               </Label>
             );
           }
+
+          const closeButtonProps = !isFormEditable && { isDisabled: true };
+          const isLabelEditable = isFormEditable && !isDefault;
           return (
             <Label
               key={elKey}
+              textMaxWidth={maxWidthNonDefaultLabel}
+              closeBtnProps={closeButtonProps}
               onClose={(e) => onDelete(e, index)}
               onEditCancel={(_, prevText) => onEdit(index, prevText)}
               onEditComplete={(_, newText) => onEdit(index, newText)}
-              isEditable
+              /* Add a basic tooltip as the PF tooltip doesn't work for editable labels */
+              title={isLabelEditable ? text : undefined}
+              isEditable={isLabelEditable}
             >
               {text}
             </Label>

--- a/libs/ui-components/src/components/form/LabelsField.tsx
+++ b/libs/ui-components/src/components/form/LabelsField.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
 import { useField } from 'formik';
-import { Button, Label, LabelGroup } from '@patternfly/react-core';
-import { TimesIcon } from '@patternfly/react-icons/dist/js/icons/times-icon';
+import { Label, LabelGroup } from '@patternfly/react-core';
 
 import { FlightCtlLabel } from '../../types/extraTypes';
 import EditableLabelControl from '../common/EditableLabelControl';
-import { useTranslation } from '../../hooks/useTranslation';
 import ErrorHelperText, { DefaultHelperText } from './FieldHelperText';
 
 type LabelsFieldProps = {
@@ -24,7 +22,6 @@ const LabelsField: React.FC<LabelsFieldProps> = ({
   isEditable = true,
 }) => {
   const [{ value: labels }, meta, { setValue: setLabels }] = useField<FlightCtlLabel[]>(name);
-  const { t } = useTranslation();
   const updateLabels = async (newLabels: FlightCtlLabel[]) => {
     const errors = await setLabels(newLabels, true);
     const hasErrors = Object.keys(errors || {}).length > 0;
@@ -77,23 +74,28 @@ const LabelsField: React.FC<LabelsFieldProps> = ({
           />
         }
       >
-        {labels.map(({ key, value }, index) => (
-          <Label
-            key={index}
-            id={`${index}`}
-            closeBtn={
-              isEditable ? undefined : (
-                <Button variant="plain" aria-label={t('Delete')} isDisabled icon={<TimesIcon />} />
-              )
-            }
-            onClose={(e) => onDelete(e, index)}
-            onEditCancel={(_, prevText) => onEdit(index, prevText)}
-            onEditComplete={(_, newText) => onEdit(index, newText)}
-            isEditable={isEditable}
-          >
-            {value ? `${key}=${value}` : key}
-          </Label>
-        ))}
+        {labels.map(({ key, value, isDefault }, index) => {
+          const text = value ? `${key}=${value}` : key;
+          const elKey = `${key}__${index}`;
+          if (isDefault || !isEditable) {
+            return (
+              <Label key={elKey} textMaxWidth="18ch">
+                {text}
+              </Label>
+            );
+          }
+          return (
+            <Label
+              key={elKey}
+              onClose={(e) => onDelete(e, index)}
+              onEditCancel={(_, prevText) => onEdit(index, prevText)}
+              onEditComplete={(_, newText) => onEdit(index, newText)}
+              isEditable
+            >
+              {text}
+            </Label>
+          );
+        })}
       </LabelGroup>
       <DefaultHelperText helperText={helperText} />
       <ErrorHelperText meta={meta} touchRequired={false} />

--- a/libs/ui-components/src/components/modals/ApproveDeviceModal/ApproveDeviceModal.tsx
+++ b/libs/ui-components/src/components/modals/ApproveDeviceModal/ApproveDeviceModal.tsx
@@ -13,7 +13,7 @@ import {
 import { useTranslation } from '../../../hooks/useTranslation';
 import { deviceApprovalValidationSchema } from '../../form/validations';
 
-import { toAPILabel } from '../../../utils/labels';
+import { fromAPILabel, toAPILabel } from '../../../utils/labels';
 import { useAppContext } from '../../../hooks/useAppContext';
 
 type DeviceEnrollmentModalProps = Omit<ApproveDeviceFormProps, 'error'>;
@@ -26,7 +26,7 @@ const DeviceEnrollmentModal: React.FC<DeviceEnrollmentModalProps> = ({ enrollmen
   return (
     <Formik<ApproveDeviceFormValues>
       initialValues={{
-        labels: [],
+        labels: fromAPILabel(enrollmentRequest.spec.labels || {}, { isDefault: true }),
         deviceAlias: '',
       }}
       validationSchema={deviceApprovalValidationSchema(t, { isSingleDevice: true })}

--- a/libs/ui-components/src/components/modals/EditLabelsModal/EditLabelsForm.tsx
+++ b/libs/ui-components/src/components/modals/EditLabelsModal/EditLabelsForm.tsx
@@ -30,6 +30,8 @@ const getValidationSchema = (t: TFunction) => {
   });
 };
 
+const delayResponse = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 const EditLabelsFormContent = ({ isSubmitting, submitForm }: EditLabelsFormContentProps) => {
   const { t } = useTranslation();
   const [submitError, setSubmitError] = React.useState<string>();
@@ -51,7 +53,7 @@ const EditLabelsFormContent = ({ isSubmitting, submitForm }: EditLabelsFormConte
         <LabelsField
           name="labels"
           addButtonText={isSubmitting ? t('Saving...') : undefined}
-          isEditable={!isSubmitting}
+          isFormEditable={!isSubmitting}
           onChangeCallback={debouncedSubmit}
         />
       </FormGroup>
@@ -81,6 +83,8 @@ const EditLabelsForm = ({ device, onDeviceUpdate }: EditLabelsFormProps) => {
           const labelsPatch = getLabelPatches('/metadata/labels', currentLabels, values.labels);
           if (labelsPatch.length > 0) {
             await patch(`devices/${device.metadata.name}`, labelsPatch);
+            // The API call is "too" quick, allow the "Saving" button to be briefly seen
+            await delayResponse(150);
             onDeviceUpdate();
           }
           return null;

--- a/libs/ui-components/src/types/extraTypes.ts
+++ b/libs/ui-components/src/types/extraTypes.ts
@@ -19,6 +19,7 @@ export interface PrometheusMetric {
 export interface FlightCtlLabel {
   key: string;
   value?: string;
+  isDefault?: boolean;
 }
 
 export interface ApiQuery {

--- a/libs/ui-components/src/utils/labels.ts
+++ b/libs/ui-components/src/utils/labels.ts
@@ -1,16 +1,23 @@
 import { DeviceLikeResource, FlightCtlLabel } from '../types/extraTypes';
 import { fuzzySeach } from './search';
 
-export const fromAPILabel = (labels: Record<string, string>): FlightCtlLabel[] =>
+type LabelOptions = {
+  isDefault?: boolean;
+};
+
+export const fromAPILabel = (labels: Record<string, string>, options?: LabelOptions): FlightCtlLabel[] =>
   Object.entries(labels).map((labelEntry) => ({
     key: labelEntry[0],
     value: labelEntry[1],
+    isDefault: options?.isDefault || false,
   }));
 
 export const toAPILabel = (labels: FlightCtlLabel[]): Record<string, string> =>
   labels.reduce(
     (acc, curr) => {
-      acc[curr.key] = curr.value || '';
+      if (!curr.isDefault) {
+        acc[curr.key] = curr.value || '';
+      }
       return acc;
     },
     {} as Record<string, string>,


### PR DESCRIPTION
EDM-286: When a new device enrolls into Flight Control, it's possible that the enrollment request contains a set of pre-defined labels.

The UI will now show them, and these are read only, and their values cannot be overwritten by a new label.

EDM-269: Fixed the effect that could be seen when labels where saved. It was caused because the API call is very quick, and the label changed from editable to non-editable. Now the effect is much smoother.


https://github.com/user-attachments/assets/f411d147-8403-45b0-ab78-3617ecaf41d1

