### PR TITLE
EDM-300: Import fleet - select correct repository option

### DIFF
--- a/libs/ui-components/src/components/Fleet/ImportFleetWizard/ImportFleetWizard.tsx
+++ b/libs/ui-components/src/components/Fleet/ImportFleetWizard/ImportFleetWizard.tsx
@@ -165,7 +165,7 @@ const ImportFleetWizard = () => {
             >
               <WizardStep name={t('Select or create repository')} id={repositoryStepId}>
                 {(!currentStep || currentStep?.id === repositoryStepId) && (
-                  <RepositoryStep repositories={gitRepositories} />
+                  <RepositoryStep repositories={gitRepositories} hasLoaded={!!repoList} />
                 )}
               </WizardStep>
               <WizardStep

--- a/libs/ui-components/src/components/Fleet/ImportFleetWizard/steps/RepositoryStep.tsx
+++ b/libs/ui-components/src/components/Fleet/ImportFleetWizard/steps/RepositoryStep.tsx
@@ -70,9 +70,16 @@ const ExistingRepoForm = ({ repositories }: { repositories: Repository[] }) => {
   );
 };
 
-const RepositoryStep = ({ repositories }: { repositories: Repository[] }) => {
+const RepositoryStep = ({ repositories, hasLoaded }: { repositories: Repository[]; hasLoaded: boolean }) => {
   const { t } = useTranslation();
   const { values, setFieldValue } = useFormikContext<ImportFleetFormValues>();
+
+  const noRepositoriesExist = hasLoaded && repositories.length === 0;
+  React.useEffect(() => {
+    if (values.useExistingRepo && noRepositoriesExist) {
+      void setFieldValue('useExistingRepo', false);
+    }
+  }, [setFieldValue, values.useExistingRepo, noRepositoriesExist]);
 
   return (
     <Form>
@@ -85,7 +92,7 @@ const RepositoryStep = ({ repositories }: { repositories: Repository[] }) => {
               id="existing-repo"
               name="repo"
               label={t('Use an existing Git repository')}
-              isDisabled={!repositories.length}
+              isDisabled={noRepositoriesExist}
             />
             <Radio
               isChecked={!values.useExistingRepo}


### PR DESCRIPTION
In the "Import fleet" wizard, the option to select a Git repository appeared as marked by default and disabled, even when no Git repositories existed.

After the fix, it will select the "New Git repository" option by default, and disable the other one.

Before:
![bad-import-settings](https://github.com/user-attachments/assets/3b46cb09-6c3c-4b2f-ac9f-884ecc869601)

After:
![correct-import-settings](https://github.com/user-attachments/assets/b67f142f-ba06-42b4-9946-435d70ab579c)

