### PR TITLE
EDM-292: Show MicroShift cluster link

### DIFF
--- a/apps/ocp-plugin/src/components/Devices/DeviceDetailsPage.css
+++ b/apps/ocp-plugin/src/components/Devices/DeviceDetailsPage.css
@@ -1,3 +1,0 @@
-.fctl-device-details__mc-btn {
-    padding-left: 0;
-}

--- a/apps/ocp-plugin/src/components/Devices/DeviceDetailsPage.css
+++ b/apps/ocp-plugin/src/components/Devices/DeviceDetailsPage.css
@@ -1,0 +1,3 @@
+.fctl-device-details__mc-btn {
+    padding-left: 0;
+}

--- a/apps/ocp-plugin/src/components/Devices/DeviceDetailsPage.tsx
+++ b/apps/ocp-plugin/src/components/Devices/DeviceDetailsPage.tsx
@@ -1,8 +1,66 @@
 import * as React from 'react';
 import DeviceDetails from '@flightctl/ui-components/src/components/Device/DeviceDetails/DeviceDetailsPage';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { useAppContext } from '@flightctl/ui-components/src/hooks/useAppContext';
+import {
+  Alert,
+  Button,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Spinner,
+} from '@patternfly/react-core';
+import { useTranslation } from '@flightctl/ui-components/src/hooks/useTranslation';
+import { getDisplayText } from '@flightctl/ui-components/src/components/common/ResourceLink';
+import { ManagedCluster } from '../../types/k8s';
+
+import './DeviceDetailsPage.css';
+
+const isMicroShiftCluster = (mc: ManagedCluster) =>
+  mc?.status?.clusterClaims?.some(
+    (claim) =>
+      claim.name === 'product.open-cluster-management.io' && (claim.value || '').toUpperCase() === 'MICROSHIFT',
+  );
 
 const DeviceDetailsPage = () => {
-  return <DeviceDetails />;
+  const { t } = useTranslation();
+  const {
+    router: { useParams, Link },
+  } = useAppContext();
+  const { deviceId } = useParams() as { deviceId: string };
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const [mc, loaded, error] = useK8sWatchResource<ManagedCluster>({
+    groupVersionKind: {
+      kind: 'ManagedCluster',
+      group: 'cluster.open-cluster-management.io',
+      version: 'v1',
+    },
+    name: deviceId,
+  });
+
+  let mcContent: React.ReactNode = <Spinner size="sm" />;
+  if (error) {
+    mcContent = <Alert isInline title={error as string} />;
+  } else if (loaded && mc) {
+    const displayText = getDisplayText(mc.metadata?.name);
+    mcContent = isMicroShiftCluster(mc) ? (
+      <Button variant="plain" className="fctl-device-details__mc-btn">
+        <Link to={`/multicloud/infrastructure/clusters/details/${mc.metadata?.name}/${mc.metadata?.name}`}>
+          {displayText}
+        </Link>
+      </Button>
+    ) : (
+      '-'
+    );
+  }
+  return (
+    <DeviceDetails>
+      <DescriptionListGroup>
+        <DescriptionListTerm>{t('MicroShift cluster')}</DescriptionListTerm>
+        <DescriptionListDescription>{mcContent}</DescriptionListDescription>
+      </DescriptionListGroup>
+    </DeviceDetails>
+  );
 };
 
 export default DeviceDetailsPage;

--- a/apps/ocp-plugin/src/components/Devices/DeviceDetailsPage.tsx
+++ b/apps/ocp-plugin/src/components/Devices/DeviceDetailsPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
-import { Icon, Popover, Spinner, Stack, StackItem } from '@patternfly/react-core';
+import { Icon, Popover, Stack, StackItem } from '@patternfly/react-core';
 import { useAppContext } from '@flightctl/ui-components/src/hooks/useAppContext';
 import { useTranslation } from '@flightctl/ui-components/src/hooks/useTranslation';
 import DeviceDetails from '@flightctl/ui-components/src/components/Device/DeviceDetails/DeviceDetailsPage';
@@ -28,11 +28,11 @@ const DeviceDetailsPage = () => {
   });
 
   const watchResultError = getWatchK8sResourceResult(k8sError as K8sWatchResourceError, true);
-  if (k8sError && !watchResultError) {
+  if (!loaded || (k8sError && !watchResultError)) {
     return <DeviceDetails />;
   }
 
-  let mcContent: React.ReactNode = <Spinner size="sm" />;
+  let mcContent: React.ReactNode;
   if (watchResultError) {
     mcContent = (
       <Popover

--- a/apps/ocp-plugin/src/types/k8s.ts
+++ b/apps/ocp-plugin/src/types/k8s.ts
@@ -1,0 +1,10 @@
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+
+export type ManagedCluster = K8sResourceCommon & {
+  status?: {
+    clusterClaims?: {
+      name?: string;
+      value?: string;
+    }[];
+  };
+};

--- a/apps/ocp-plugin/src/utils/clusters.ts
+++ b/apps/ocp-plugin/src/utils/clusters.ts
@@ -1,0 +1,20 @@
+import { ManagedCluster } from '../types/k8s';
+import { getErrorMessage } from '@flightctl/ui-components/src/utils/error';
+
+const isMicroShiftCluster = (mc: ManagedCluster) =>
+  mc?.status?.clusterClaims?.some(
+    (claim) =>
+      claim.name === 'product.open-cluster-management.io' && (claim.value || '').toUpperCase() === 'MICROSHIFT',
+  );
+
+const getWatchK8sResourceResult = (error: string | object | undefined, accept404: boolean) => {
+  if (error === undefined || typeof error === 'string') {
+    return error;
+  }
+  if ('code' in error && error.code === 404 && accept404) {
+    return undefined;
+  }
+  return getErrorMessage(error);
+};
+
+export { isMicroShiftCluster, getWatchK8sResourceResult };

--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -1,4 +1,7 @@
 {
+  "The cluster details failed to load": "The cluster details failed to load",
+  "Failed to load": "Failed to load",
+  "View": "View",
   "MicroShift cluster": "MicroShift cluster",
   "Global navigation": "Global navigation",
   "Skip to Content": "Skip to Content",

--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -1,4 +1,5 @@
 {
+  "MicroShift cluster": "MicroShift cluster",
   "Global navigation": "Global navigation",
   "Skip to Content": "Skip to Content",
   "User preferences": "User preferences",

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsPage.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsPage.tsx
@@ -15,7 +15,7 @@ import TerminalTab from './TerminalTab';
 import NavItem from '../../NavItem/NavItem';
 import DeviceStatusDebugModal from './DeviceStatusDebugModal';
 
-const DeviceDetailsPage = () => {
+const DeviceDetailsPage = ({ children }: React.PropsWithChildren<Record<never, never>>) => {
   const { t } = useTranslation();
   const {
     router: { useParams, Routes, Route, Navigate },
@@ -79,7 +79,11 @@ const DeviceDetailsPage = () => {
           <Route index element={<Navigate to="details" replace />} />
           <Route
             path="details"
-            element={<DeviceDetailsTab device={device} errorTv={errorTv} tv={tv} refetch={refetch} />}
+            element={
+              <DeviceDetailsTab device={device} errorTv={errorTv} tv={tv} refetch={refetch}>
+                {children}
+              </DeviceDetailsTab>
+            }
           />
           <Route path="terminal" element={<TerminalTab device={device} />} />
         </Routes>

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsTab.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsTab.tsx
@@ -34,17 +34,20 @@ import DeviceResourceStatus from '../../Status/DeviceResourceStatus';
 
 import './DeviceDetailsTab.css';
 
+type DeviceDetailsTabProps = {
+  device: Required<Device>;
+  refetch: VoidFunction;
+  tv: TemplateVersion | undefined;
+  errorTv: unknown;
+};
+
 const DeviceDetailsTab = ({
   device,
   refetch,
   tv,
   errorTv,
-}: {
-  device: Required<Device>;
-  refetch: VoidFunction;
-  tv: TemplateVersion | undefined;
-  errorTv: unknown;
-}) => {
+  children,
+}: React.PropsWithChildren<DeviceDetailsTabProps>) => {
   const { t } = useTranslation();
 
   const sourceItems = getSourceItems(device.spec.config);
@@ -78,6 +81,7 @@ const DeviceDetailsTab = ({
               </FlexItem>
               <FlexItem flex={{ default: 'flex_1' }}>
                 <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
+                  {children}
                   <FlexItem>
                     <Stack>
                       <StackItem className="fctl-device-details-tab__label">{t('Fleet name')}</StackItem>


### PR DESCRIPTION
Continuation of https://github.com/flightctl/flightctl-ui/pull/15

Mostly added error handling, although I will work on adding `ErrorBoundary` to the OCP pages in a separate PR.

When the device has an associated MicroShift cluster:
![without-error](https://github.com/user-attachments/assets/cd50d7bf-eb5d-4b76-bf6d-a6453087f8eb)


When the device has an associated MicroShift cluster, but the k8s API returns an error:
![with-error](https://github.com/user-attachments/assets/7078768e-18a2-4aff-8bca-068aea3fee09)

(details appear when hovering over the message)
