### PR TITLE
EDM-296 Publish helm charts under quay.io/flightctl/charts

### DIFF
--- a/.github/workflows/push-to-main.yaml
+++ b/.github/workflows/push-to-main.yaml
@@ -7,6 +7,7 @@ on:
 
 env:
   QUAY_ORG: quay.io/flightctl
+  QUAY_CHARTS: quay.io/flightctl/charts
   QUAY_STANDALONE_REPO: flightctl-ui
   QUAY_OCP_REPO: flightctl-ocp-ui
 
@@ -117,5 +118,5 @@ jobs:
 
       - name: Push helm charts
         run: |
-          helm push flightctl-ui-*.tgz oci://${{ env.QUAY_ORG }}/
-          helm push flightctl-ocp-ui-*.tgz oci://${{ env.QUAY_ORG }}/
+          helm push flightctl-ui-*.tgz oci://${{ env.QUAY_CHARTS }}/
+          helm push flightctl-ocp-ui-*.tgz oci://${{ env.QUAY_CHARTS }}/

--- a/hack/publish_charts.sh
+++ b/hack/publish_charts.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+QUAY_CHARTS=${QUAY_CHARTS:-quay.io/flightctl/charts}
+VERSION=$(git describe --long --tags)
+VERSION=${VERSION#v} # remove the leading v prefix for version
+
+echo packaging "${VERSION}"
+helm package ./apps/standalone/deploy/helm/flightctl-ui --version "${VERSION}" --app-version "${VERSION}"
+helm package ./apps/ocp-plugin/deploy/helm/flightctl-ocp-ui --version "${VERSION}" --app-version "${VERSION}"
+
+#login with helm registry login quay.io -u ${USER} -p ${PASSWORD}
+helm push "flightctl-ui-${VERSION}.tgz" oci://${{ env.QUAY_CHARTS }}/
+helm push "flightctl-ocp-ui-${VERSION}.tgz" oci://${{ env.QUAY_CHARTS }}/


### PR DESCRIPTION
This is the standard with OCI helm charts. Consuming the charts from ArgoCD requires this, i.e. quay.io/flightctl cannot be supplied as base for charts.