### PR TITLE
EDM-384: Use new query to retrieve the repository resource syncs

### DIFF
--- a/libs/types/models/DevicesSummary.ts
+++ b/libs/types/models/DevicesSummary.ts
@@ -13,10 +13,10 @@ export type DevicesSummary = {
   /**
    * A breakdown of the devices in the fleet by "summary" status.
    */
-  summaryStatus: Record<string, number>;
+  summaryStatus?: Record<string, number>;
   /**
    * A breakdown of the devices in the fleet by "updated" status.
    */
-  updateStatus: Record<string, number>;
+  updateStatus?: Record<string, number>;
 };
 

--- a/libs/ui-components/src/components/Fleet/FleetDetails/FleetDevices.tsx
+++ b/libs/ui-components/src/components/Fleet/FleetDetails/FleetDevices.tsx
@@ -19,14 +19,20 @@ interface FleetDevicesProps {
   devicesSummary: DevicesSummary;
 }
 
-const DevicesByUpdateStatusChart = ({ fleetId, devicesSummary }: FleetDevicesProps) => {
+const DevicesByUpdateStatusChart = ({
+  fleetId,
+  updateStatus,
+}: {
+  fleetId: string;
+  updateStatus: Record<string, number>;
+}) => {
   const { t } = useTranslation();
 
   const statusItems = getSystemUpdateStatusItems(t);
 
   const data = statusItems.reduce(
     (acc, currStatus) => {
-      acc[currStatus.id] = devicesSummary.updateStatus[currStatus.id] || 0;
+      acc[currStatus.id] = updateStatus[currStatus.id] || 0;
       return acc;
     },
     {} as Record<UpdateStatus, number>,
@@ -37,13 +43,19 @@ const DevicesByUpdateStatusChart = ({ fleetId, devicesSummary }: FleetDevicesPro
   return <DonutChart title={t('Update status')} data={updateStatusData} helperText={getUpdateStatusHelperText(t)} />;
 };
 
-const DevicesByDeviceStatusChart = ({ fleetId, devicesSummary }: FleetDevicesProps) => {
+const DevicesByDeviceStatusChart = ({
+  fleetId,
+  deviceStatus,
+}: {
+  fleetId: string;
+  deviceStatus: Record<string, number>;
+}) => {
   const { t } = useTranslation();
 
   const statusItems = getDeviceStatusItems(t);
   const data = statusItems.reduce(
     (acc, currStatus) => {
-      acc[currStatus.id] = devicesSummary.summaryStatus[currStatus.id] || 0;
+      acc[currStatus.id] = deviceStatus[currStatus.id] || 0;
       return acc;
     },
     {} as Record<DeviceStatus | EnrollmentRequestStatus.Pending, number>,
@@ -57,12 +69,16 @@ const DevicesByDeviceStatusChart = ({ fleetId, devicesSummary }: FleetDevicesPro
 const FleetDevices = ({ devicesSummary, fleetId }: FleetDevicesProps) => {
   return (
     <Grid hasGutter>
-      <GridItem md={6}>
-        <DevicesByDeviceStatusChart fleetId={fleetId} devicesSummary={devicesSummary} />
-      </GridItem>
-      <GridItem md={6}>
-        <DevicesByUpdateStatusChart fleetId={fleetId} devicesSummary={devicesSummary} />
-      </GridItem>
+      {devicesSummary.summaryStatus && (
+        <GridItem md={6}>
+          <DevicesByDeviceStatusChart fleetId={fleetId} deviceStatus={devicesSummary.summaryStatus} />
+        </GridItem>
+      )}
+      {devicesSummary.updateStatus && (
+        <GridItem md={6}>
+          <DevicesByUpdateStatusChart fleetId={fleetId} updateStatus={devicesSummary.updateStatus} />
+        </GridItem>
+      )}
     </Grid>
   );
 };

--- a/libs/ui-components/src/components/Repository/CreateRepository/CreateRepository.tsx
+++ b/libs/ui-components/src/components/Repository/CreateRepository/CreateRepository.tsx
@@ -44,7 +44,7 @@ const CreateRepository = () => {
       try {
         const results = await Promise.allSettled([
           get<Repository>(`repositories/${repositoryId}`),
-          get<ResourceSyncList>(`resourcesyncs?labelSelector=repository=${repositoryId}`),
+          get<ResourceSyncList>(`resourcesyncs?repository=${repositoryId}`),
         ]);
 
         if (isPromiseFulfilled(results[0])) {

--- a/libs/ui-components/src/components/Repository/CreateRepository/utils.ts
+++ b/libs/ui-components/src/components/Repository/CreateRepository/utils.ts
@@ -480,7 +480,6 @@ export const getResourceSync = (repositoryId: string, values: ResourceSyncFormVa
     kind: 'ResourceSync',
     metadata: {
       name: values.name,
-      labels: { repository: repositoryId },
     },
     spec: {
       repository: repositoryId,

--- a/libs/ui-components/src/components/Repository/RepositoryDetails/DeleteRepositoryModal.tsx
+++ b/libs/ui-components/src/components/Repository/RepositoryDetails/DeleteRepositoryModal.tsx
@@ -46,7 +46,7 @@ const DeleteRepositoryModal = ({ repositoryId, onClose, onDeleteSuccess }: Delet
 
   const loadRS = React.useCallback(async () => {
     try {
-      const resourceSyncs = await get<ResourceSyncList>(`resourcesyncs?labelSelector=repository=${repositoryId}`);
+      const resourceSyncs = await get<ResourceSyncList>(`resourcesyncs?repository=${repositoryId}`);
       setResourceSyncIds(resourceSyncs.items.map((rs) => rs.metadata.name || ''));
       setRsError(undefined);
     } catch (e) {

--- a/libs/ui-components/src/components/ResourceSync/RepositoryResourceSyncList.tsx
+++ b/libs/ui-components/src/components/ResourceSync/RepositoryResourceSyncList.tsx
@@ -203,7 +203,7 @@ const ResourceSyncEmptyState = ({ isLoading, error }: { isLoading: boolean; erro
 
 const RepositoryResourceSyncList = ({ repositoryId }: { repositoryId: string }) => {
   const [rsList, isLoading, error, refetch] = useFetchPeriodically<ResourceSyncList>({
-    endpoint: `resourcesyncs?labelSelector=repository=${repositoryId}`,
+    endpoint: `resourcesyncs?repository=${repositoryId}`,
   });
 
   const items = rsList?.items || [];

--- a/libs/ui-components/src/components/modals/massModals/MassDeleteRepositoryModal/MassDeleteRepositoryModal.tsx
+++ b/libs/ui-components/src/components/modals/massModals/MassDeleteRepositoryModal/MassDeleteRepositoryModal.tsx
@@ -37,9 +37,7 @@ const MassDeleteRepositoryModal: React.FC<MassDeleteRepositoryModalProps> = ({
     const rsCount = {};
     const promises = repositories.map(async (r) => {
       const repositoryId = r.metadata.name || '';
-      const resourceSyncs = await get<ResourceSyncList>(
-        `resourcesyncs?labelSelector=repository=${repositoryId}&limit=1`,
-      );
+      const resourceSyncs = await get<ResourceSyncList>(`resourcesyncs?repository=${repositoryId}&limit=1`);
       rsCount[repositoryId] = getApiListCount(resourceSyncs);
     });
     await Promise.allSettled(promises);
@@ -53,7 +51,7 @@ const MassDeleteRepositoryModal: React.FC<MassDeleteRepositoryModalProps> = ({
     setProgress(0);
     const promises = repositories.map(async (r) => {
       const repositoryId = r.metadata.name || '';
-      const resourceSyncs = await get<ResourceSyncList>(`resourcesyncs?labelSelector=repository=${repositoryId}`);
+      const resourceSyncs = await get<ResourceSyncList>(`resourcesyncs?repository=${repositoryId}`);
       const rsyncPromises = resourceSyncs.items.map((rsync) => remove(`resourcesyncs/${rsync.metadata.name}`));
       const rsyncResults = await Promise.allSettled(rsyncPromises);
       const rejectedResults = rsyncResults.filter(isPromiseRejected);


### PR DESCRIPTION
To obtain the RSs belonging to a repository, we were adding a label to the RS, and querying RSs based on this label.
The query would fail if the repository name is not a label (eg. it is longer than 63 characters).

Now we will use a dedicated query which is being added in https://github.com/flightctl/flightctl/pull/501
which allows us to query irrespective of the repository name.

![new-rs-query](https://github.com/user-attachments/assets/c39c2f53-c334-45d1-913e-b4d2915d3708)
