### PR TITLE
Upgrade xterm to @xterm/xterm v5.5.0

### DIFF
--- a/apps/standalone/package.json
+++ b/apps/standalone/package.json
@@ -41,11 +41,11 @@
     "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {
+    "@patternfly/react-charts": "^7.2.2",
     "@patternfly/react-core": "^5.0.0",
     "@patternfly/react-icons": "^5.0.0",
     "@patternfly/react-styles": "^5.1.2",
     "@patternfly/react-table": "^5.0.0",
-    "@patternfly/react-charts": "^7.2.2",
     "@types/jest-axe": "^3.5.9",
     "formik": "^2.4.5",
     "fuzzysearch": "^1.0.3",

--- a/libs/ui-components/package.json
+++ b/libs/ui-components/package.json
@@ -22,12 +22,12 @@
   "dependencies": {
     "@types/js-yaml": "^4.0.9",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "formik": "^2.4.5",
     "fuzzysearch": "^1.0.3",
     "js-yaml": "^4.1.0",
     "percent-round": "^2.3.1",
     "use-debounce": "^10.0.1",
-    "xterm": "^5.3.0",
     "yup": "^1.3.3"
   },
   "peerDependencies": {

--- a/libs/ui-components/src/components/Terminal/Terminal.css
+++ b/libs/ui-components/src/components/Terminal/Terminal.css
@@ -1,1 +1,1 @@
-@import '~xterm/css/xterm.css';
+@import '@xterm/xterm/css/xterm.css';

--- a/libs/ui-components/src/components/Terminal/Terminal.tsx
+++ b/libs/ui-components/src/components/Terminal/Terminal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ITerminalAddon, ITerminalInitOnlyOptions, ITerminalOptions, Terminal as XTerminal } from 'xterm';
+import { ITerminalAddon, ITerminalInitOnlyOptions, ITerminalOptions, Terminal as XTerminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { Spinner, Stack, StackItem } from '@patternfly/react-core';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -270,12 +270,12 @@
       "dependencies": {
         "@types/js-yaml": "^4.0.9",
         "@xterm/addon-fit": "^0.10.0",
+        "@xterm/xterm": "^5.5.0",
         "formik": "^2.4.5",
         "fuzzysearch": "^1.0.3",
         "js-yaml": "^4.1.0",
         "percent-round": "^2.3.1",
         "use-debounce": "^10.0.1",
-        "xterm": "^5.3.0",
         "yup": "^1.3.3"
       },
       "devDependencies": {
@@ -4916,9 +4916,7 @@
     "node_modules/@xterm/xterm": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
-      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT",
-      "peer": true
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A=="
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -20245,13 +20243,6 @@
       "engines": {
         "node": ">=0.4"
       }
-    },
-    "node_modules/xterm": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
-      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
-      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
-      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",


### PR DESCRIPTION
The `xterm` package has been deprecated, and there was a message about that in our [builds](https://github.com/flightctl/flightctl-ui/actions/runs/10736829241/job/29777047293#step:4:5) 

There are no breaking changes between the version we were using from `xterm` to the latest `@xterm/xterm` `v5.5.0`  version, and as seen in the video, the behaviour remains unchanged.

https://github.com/user-attachments/assets/b8715ecc-f908-4bdd-a47a-317515fbc3fc

