### PR TITLE
EDM-302: Do not submit form on Enter in form fields

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -74,6 +74,11 @@ module.exports = {
             message: 'Use FlightCtlActionGroup to wrap the footer actions',
           },
           {
+            name: '@patternfly/react-core',
+            importNames: ['Form'],
+            message: 'Use FlightCtlForm to wrap forms',
+          },
+          {
             name: 'react-i18next',
             importNames: ['useTranslation'],
             message: 'Import useTranslation from @flightctl/ui-components/hooks/useTranslation instead',

--- a/libs/ui-components/src/components/Device/AddDeviceModal/AddDeviceModal.tsx
+++ b/libs/ui-components/src/components/Device/AddDeviceModal/AddDeviceModal.tsx
@@ -1,8 +1,8 @@
+import * as React from 'react';
 import {
   Alert,
   Button,
   ClipboardCopy,
-  Form,
   FormGroup,
   Grid,
   GridItem,
@@ -15,10 +15,11 @@ import {
   TextList,
   TextListItem,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
+import FlightCtlForm from '../../form/FlightCtlForm';
+
 import { useTranslation } from '../../../hooks/useTranslation';
 import { useAppContext } from '../../../hooks/useAppContext';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
 const AddDeviceModal = ({ onClose }: { onClose: VoidFunction }) => {
   const { t } = useTranslation();
@@ -121,7 +122,7 @@ const AddDeviceModal = ({ onClose }: { onClose: VoidFunction }) => {
                 </Alert>
               </StackItem>
               <StackItem>
-                <Form>
+                <FlightCtlForm>
                   <FormGroup label={t('Disk URL')}>
                     <ClipboardCopy isReadOnly hoverTip={t('Copy')} clickTip={t('Copied')}>
                       {qcow2ImgUrl}
@@ -132,7 +133,7 @@ const AddDeviceModal = ({ onClose }: { onClose: VoidFunction }) => {
                       {`wget -O disk.qcow2 ${qcow2ImgUrl}`}
                     </ClipboardCopy>
                   </FormGroup>
-                </Form>
+                </FlightCtlForm>
               </StackItem>
             </Stack>
           )}

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/steps/DeviceTemplateStep.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/steps/DeviceTemplateStep.tsx
@@ -25,7 +25,7 @@ const DeviceTemplateStep = ({ isFleet }: { isFleet: boolean }) => {
 
   return (
     <Grid span={8}>
-      <Form>
+      <Form onSubmit={(ev) => ev.preventDefault()}>
         {isFleet && (
           <Alert isInline variant="info" title={t('Using template variables')}>
             <ExpandableSection toggleTextCollapsed={t('Show more')} toggleTextExpanded={t('Show less')}>

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/steps/DeviceTemplateStep.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/steps/DeviceTemplateStep.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { Alert, CodeBlock, CodeBlockCode, ExpandableSection, Form, FormGroup, Grid } from '@patternfly/react-core';
+import { Alert, CodeBlock, CodeBlockCode, ExpandableSection, FormGroup, Grid } from '@patternfly/react-core';
 import { FormikErrors, useFormikContext } from 'formik';
 import { Trans } from 'react-i18next';
 
 import { useTranslation } from '../../../../hooks/useTranslation';
 import WithHelperText from '../../../common/WithHelperText';
 import TextField from '../../../form/TextField';
+import FlightCtlForm from '../../../form/FlightCtlForm';
 import { DeviceSpecConfigFormValues } from '../types';
 import ConfigTemplateForm from './ConfigTemplateForm';
 
@@ -25,7 +26,7 @@ const DeviceTemplateStep = ({ isFleet }: { isFleet: boolean }) => {
 
   return (
     <Grid span={8}>
-      <Form onSubmit={(ev) => ev.preventDefault()}>
+      <FlightCtlForm>
         {isFleet && (
           <Alert isInline variant="info" title={t('Using template variables')}>
             <ExpandableSection toggleTextCollapsed={t('Show more')} toggleTextExpanded={t('Show less')}>
@@ -65,7 +66,7 @@ const DeviceTemplateStep = ({ isFleet }: { isFleet: boolean }) => {
         <FormGroup>
           <ConfigTemplateForm />
         </FormGroup>
-      </Form>
+      </FlightCtlForm>
     </Grid>
   );
 };

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/steps/GeneralInfoStep.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/steps/GeneralInfoStep.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { Form, FormGroup, Grid } from '@patternfly/react-core';
+import { FormGroup, Grid } from '@patternfly/react-core';
 import { FormikErrors, useFormikContext } from 'formik';
 
 import { useTranslation } from '../../../../hooks/useTranslation';
 import useDeviceLabelMatch from '../../../../hooks/useDeviceLabelMatch';
+import FlightCtlForm from '../../../form/FlightCtlForm';
 import LabelsField from '../../../form/LabelsField';
 import RichValidationTextField from '../../../form/RichValidationTextField';
 import { getLabelValueValidations } from '../../../form/validations';
@@ -40,7 +41,7 @@ const GeneralInfoStep = () => {
 
   return (
     <Grid lg={5} span={8}>
-      <Form>
+      <FlightCtlForm>
         <RichValidationTextField
           fieldName="deviceAlias"
           aria-label={t('Alias')}
@@ -52,7 +53,7 @@ const GeneralInfoStep = () => {
         <FormGroup label={t('Fleet name')}>
           <DeviceLabelMatch matchStatus={matchStatus} />
         </FormGroup>
-      </Form>
+      </FlightCtlForm>
     </Grid>
   );
 };

--- a/libs/ui-components/src/components/Device/MatchPatternsModal/MatchPatternsForm.tsx
+++ b/libs/ui-components/src/components/Device/MatchPatternsModal/MatchPatternsForm.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { Alert, Button, Form, Label, LabelGroup } from '@patternfly/react-core';
+import { Alert, Button, Label, LabelGroup } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 
+import ErrorHelperText from '../../form/FieldHelperText';
 import FlightCtlActionGroup from '../../form/FlightCtlActionGroup';
+import FlightCtlForm from '../../form/FlightCtlForm';
 import { useTranslation } from '../../../hooks/useTranslation';
 import EditableLabelControl from '../../common/EditableLabelControl';
-import ErrorHelperText from '../../form/FieldHelperText';
 
 export type MatchPatternsFormValues = {
   matchPatterns: string[];
@@ -46,11 +47,7 @@ const MatchPatternsForm: React.FC<MatchPatternsFormProps> = ({ onClose, error })
   const hasFormErrors = !!formErrors.matchPatterns;
 
   return (
-    <Form
-      onSubmit={(e) => {
-        e.preventDefault();
-      }}
-    >
+    <FlightCtlForm>
       <LabelGroup
         isEditable
         addLabelControl={
@@ -88,7 +85,7 @@ const MatchPatternsForm: React.FC<MatchPatternsFormProps> = ({ onClose, error })
           {t('Cancel')}
         </Button>
       </FlightCtlActionGroup>
-    </Form>
+    </FlightCtlForm>
   );
 };
 

--- a/libs/ui-components/src/components/Fleet/CreateFleet/steps/GeneralInfoStep.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/steps/GeneralInfoStep.tsx
@@ -1,10 +1,12 @@
-import { Form, FormGroup, Grid } from '@patternfly/react-core';
 import * as React from 'react';
+import { FormGroup, Grid } from '@patternfly/react-core';
 import { FormikErrors } from 'formik';
+
 import { FleetFormValues } from '../types';
 import { useTranslation } from '../../../../hooks/useTranslation';
 import NameField from '../../../form/NameField';
 import LabelsField from '../../../form/LabelsField';
+import FlightCtlForm from '../../../form/FlightCtlForm';
 import { getDnsSubdomainValidations } from '../../../form/validations';
 import WithHelperText from '../../../common/WithHelperText';
 import DeviceLabelSelector from './DeviceLabelSelector';
@@ -20,7 +22,7 @@ const GeneralInfoStep = ({ isEdit }: { isEdit: boolean }) => {
 
   return (
     <Grid lg={5} span={8}>
-      <Form onSubmit={(ev) => ev.preventDefault()}>
+      <FlightCtlForm>
         <NameField
           name="name"
           aria-label={t('Name')}
@@ -45,7 +47,7 @@ const GeneralInfoStep = ({ isEdit }: { isEdit: boolean }) => {
         >
           <DeviceLabelSelector />
         </FormGroup>
-      </Form>
+      </FlightCtlForm>
     </Grid>
   );
 };

--- a/libs/ui-components/src/components/Fleet/CreateFleet/steps/GeneralInfoStep.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/steps/GeneralInfoStep.tsx
@@ -20,7 +20,7 @@ const GeneralInfoStep = ({ isEdit }: { isEdit: boolean }) => {
 
   return (
     <Grid lg={5} span={8}>
-      <Form>
+      <Form onSubmit={(ev) => ev.preventDefault()}>
         <NameField
           name="name"
           aria-label={t('Name')}

--- a/libs/ui-components/src/components/Fleet/ImportFleetWizard/steps/RepositoryStep.tsx
+++ b/libs/ui-components/src/components/Fleet/ImportFleetWizard/steps/RepositoryStep.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Form, FormGroup, FormSection, Grid, Radio } from '@patternfly/react-core';
+import { FormGroup, FormSection, Grid, Radio } from '@patternfly/react-core';
 import { FormikErrors, useFormikContext } from 'formik';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
@@ -11,6 +11,7 @@ import RepositoryStatus from '../../../Status/RepositoryStatus';
 import { getRepositoryLastTransitionTime, getRepositorySyncStatus } from '../../../../utils/status/repository';
 import { useTranslation } from '../../../../hooks/useTranslation';
 import FormSelect from '../../../form/FormSelect';
+import FlightCtlForm from '../../../form/FlightCtlForm';
 
 export const repositoryStepId = 'repository';
 
@@ -82,7 +83,7 @@ const RepositoryStep = ({ repositories, hasLoaded }: { repositories: Repository[
   }, [setFieldValue, values.useExistingRepo, noRepositoriesExist]);
 
   return (
-    <Form>
+    <FlightCtlForm>
       <Grid span={8}>
         <FormSection>
           <FormGroup isInline>
@@ -107,7 +108,7 @@ const RepositoryStep = ({ repositories, hasLoaded }: { repositories: Repository[
           {values.useExistingRepo ? <ExistingRepoForm repositories={repositories} /> : <RepositoryForm />}
         </FormSection>
       </Grid>
-    </Form>
+    </FlightCtlForm>
   );
 };
 

--- a/libs/ui-components/src/components/Fleet/ImportFleetWizard/steps/ResourceSyncStep.tsx
+++ b/libs/ui-components/src/components/Fleet/ImportFleetWizard/steps/ResourceSyncStep.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { Form, Grid, Stack, StackItem, Text, TextContent } from '@patternfly/react-core';
+import { Grid, Stack, StackItem, Text, TextContent } from '@patternfly/react-core';
 import { FormikErrors } from 'formik';
-import { useTranslation } from '../../../../hooks/useTranslation';
 
+import { useTranslation } from '../../../../hooks/useTranslation';
+import FlightControlForm from '../../../form/FlightCtlForm';
 import CreateResourceSyncsForm from '../../../Repository/CreateRepository/CreateResourceSyncsForm';
 import { ImportFleetFormValues } from '../types';
 
@@ -28,11 +29,11 @@ const ResourceSyncStep = () => {
         </TextContent>
       </StackItem>
       <StackItem>
-        <Form>
+        <FlightControlForm>
           <Grid span={8}>
             <CreateResourceSyncsForm />
           </Grid>
-        </Form>
+        </FlightControlForm>
       </StackItem>
     </Stack>
   );

--- a/libs/ui-components/src/components/Fleet/ImportFleetWizard/steps/ReviewStep.tsx
+++ b/libs/ui-components/src/components/Fleet/ImportFleetWizard/steps/ReviewStep.tsx
@@ -1,8 +1,11 @@
-import { Alert, Form, FormGroup, Stack, StackItem, TextInput } from '@patternfly/react-core';
-import { useFormikContext } from 'formik';
 import * as React from 'react';
-import { ImportFleetFormValues } from '../types';
+import { Alert, FormGroup, Stack, StackItem, TextInput } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { useFormikContext } from 'formik';
+
+import { ImportFleetFormValues } from '../types';
+import FlightCtlForm from '../../../form/FlightCtlForm';
+
 import { useTranslation } from '../../../../hooks/useTranslation';
 
 export const reviewStepId = 'review';
@@ -13,7 +16,7 @@ const ReviewStep = ({ errors }: { errors?: string[] }) => {
   return (
     <Stack hasGutter>
       <StackItem isFilled>
-        <Form>
+        <FlightCtlForm>
           <FormGroup label={t('Repository')}>
             <TextInput
               value={values.useExistingRepo ? values.existingRepo : values.name}
@@ -42,7 +45,7 @@ const ReviewStep = ({ errors }: { errors?: string[] }) => {
               </Tbody>
             </Table>
           </FormGroup>
-        </Form>
+        </FlightCtlForm>
       </StackItem>
       <StackItem>
         <Alert

--- a/libs/ui-components/src/components/Repository/CreateRepository/CreateRepositoryForm.tsx
+++ b/libs/ui-components/src/components/Repository/CreateRepository/CreateRepositoryForm.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   ButtonVariant,
   Checkbox,
-  Form,
   FormGroup,
   FormSection,
   Grid,
@@ -14,6 +13,7 @@ import {
 } from '@patternfly/react-core';
 import { Formik, useFormikContext } from 'formik';
 import * as Yup from 'yup';
+
 import { useTranslation } from '../../../hooks/useTranslation';
 import { useFetch } from '../../../hooks/useFetch';
 import FlightCtlActionGroup from '../../form/FlightCtlActionGroup';
@@ -38,6 +38,8 @@ import TextAreaField from '../../form/TextAreaField';
 import CheckboxField from '../../form/CheckboxField';
 import RadioField from '../../form/RadioField';
 import TextField from '../../form/TextField';
+import FlightCtlForm from '../../form/FlightCtlForm';
+
 import { getDnsSubdomainValidations } from '../../form/validations';
 
 import './CreateRepositoryForm.css';
@@ -255,7 +257,7 @@ const CreateRepositoryFormContent = ({ isEdit, isReadOnly, onClose, children }: 
 
   const showResourceSyncs = values.canUseResourceSyncs && values.repoType === RepoSpecType.GIT;
   return (
-    <Form className="fctl-create-repo">
+    <FlightCtlForm className="fctl-create-repo">
       <fieldset disabled={isReadOnly}>
         <Grid hasGutter span={8}>
           <RepositoryForm isEdit={isEdit} />
@@ -290,7 +292,7 @@ const CreateRepositoryFormContent = ({ isEdit, isReadOnly, onClose, children }: 
           {t('Cancel')}
         </Button>
       </FlightCtlActionGroup>
-    </Form>
+    </FlightCtlForm>
   );
 };
 

--- a/libs/ui-components/src/components/UserPreferences/UserPreferencesModal.tsx
+++ b/libs/ui-components/src/components/UserPreferences/UserPreferencesModal.tsx
@@ -1,6 +1,7 @@
+import * as React from 'react';
+import { TFunction } from 'i18next';
 import {
   Button,
-  Form,
   FormGroup,
   MenuToggle,
   MenuToggleElement,
@@ -10,12 +11,12 @@ import {
   Stack,
   StackItem,
 } from '@patternfly/react-core';
-import * as React from 'react';
-import { UserPreferencesContext } from './UserPreferencesProvider';
+
 import { Theme } from '../../hooks/useThemePreferences';
-import FlightCtlActionGroup from '../form/FlightCtlActionGroup';
 import { useTranslation } from '../../hooks/useTranslation';
-import { TFunction } from 'i18next';
+import FlightCtlActionGroup from '../form/FlightCtlActionGroup';
+import FlightCtlForm from '../form/FlightCtlForm';
+import { UserPreferencesContext } from './UserPreferencesProvider';
 
 const getThemeLabels = (t: TFunction): { [key in Theme]: string } => ({
   system: t('System default'),
@@ -38,7 +39,7 @@ const UserPreferencesModal: React.FC<UserPreferencesModalProps> = ({ onClose }) 
     <Modal title={t('User preferences')} isOpen variant="small" onClose={onClose}>
       <Stack hasGutter>
         <StackItem>
-          <Form>
+          <FlightCtlForm>
             <FormGroup label={t('Theme')}>
               <Select
                 toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
@@ -67,7 +68,7 @@ const UserPreferencesModal: React.FC<UserPreferencesModalProps> = ({ onClose }) 
                 ))}
               </Select>
             </FormGroup>
-          </Form>
+          </FlightCtlForm>
         </StackItem>
         <StackItem>
           <FlightCtlActionGroup>

--- a/libs/ui-components/src/components/form/FlightCtlForm.tsx
+++ b/libs/ui-components/src/components/form/FlightCtlForm.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+// eslint-disable-next-line no-restricted-imports
+import { Form } from '@patternfly/react-core';
+
+const FlightCtlForm = ({ className, children }: React.PropsWithChildren<{ className?: string }>) => {
+  return (
+    <Form
+      className={className}
+      onSubmit={(ev) => {
+        ev.preventDefault();
+      }}
+    >
+      {children}
+    </Form>
+  );
+};
+
+export default FlightCtlForm;

--- a/libs/ui-components/src/components/modals/ApproveDeviceModal/ApproveDeviceForm.tsx
+++ b/libs/ui-components/src/components/modals/ApproveDeviceModal/ApproveDeviceForm.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { useFormikContext } from 'formik';
-
-import { Alert, Button, Form, FormGroup } from '@patternfly/react-core';
+import { Alert, Button, FormGroup } from '@patternfly/react-core';
 
 import { EnrollmentRequest } from '@flightctl/types';
 import RichValidationTextField from '../../form/RichValidationTextField';
 import LabelsField from '../../form/LabelsField';
 import { getLabelValueValidations } from '../../form/validations';
 import FlightCtlActionGroup from '../../form/FlightCtlActionGroup';
+import FlightCtlForm from '../../form/FlightCtlForm';
 import { FlightCtlLabel } from '../../../types/extraTypes';
 import { useTranslation } from '../../../hooks/useTranslation';
 import useDeviceLabelMatch from '../../../hooks/useDeviceLabelMatch';
@@ -34,7 +34,7 @@ const ApproveDeviceForm: React.FC<ApproveDeviceFormProps> = ({ enrollmentRequest
   const [matchLabelsOnChange, matchStatus] = useDeviceLabelMatch();
 
   return (
-    <Form onSubmit={(ev) => ev.preventDefault()}>
+    <FlightCtlForm>
       <RichValidationTextField
         fieldName="deviceAlias"
         aria-label={t('Alias')}
@@ -67,7 +67,7 @@ const ApproveDeviceForm: React.FC<ApproveDeviceFormProps> = ({ enrollmentRequest
           {t('Cancel')}
         </Button>
       </FlightCtlActionGroup>
-    </Form>
+    </FlightCtlForm>
   );
 };
 

--- a/libs/ui-components/src/components/modals/EditLabelsModal/EditLabelsForm.tsx
+++ b/libs/ui-components/src/components/modals/EditLabelsModal/EditLabelsForm.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { Formik, FormikProps } from 'formik';
-import { Alert, Form, FormGroup } from '@patternfly/react-core';
+import { Alert, FormGroup } from '@patternfly/react-core';
 import { TFunction } from 'i18next';
 import * as Yup from 'yup';
 import debounce from 'lodash/debounce';
 
 import { Device } from '@flightctl/types';
 import LabelsField from '../../form/LabelsField';
+import FlightCtlForm from '../../form/FlightCtlForm';
 import { FlightCtlLabel } from '../../../types/extraTypes';
 import { useFetch } from '../../../hooks/useFetch';
 import { useTranslation } from '../../../hooks/useTranslation';
@@ -48,7 +49,7 @@ const EditLabelsFormContent = ({ isSubmitting, submitForm }: EditLabelsFormConte
   const debouncedSubmit = React.useCallback(debounce(onChangedLabels, 2000), []);
 
   return (
-    <Form onSubmit={(ev) => ev.preventDefault()}>
+    <FlightCtlForm>
       <FormGroup label={t('Device labels')}>
         <LabelsField
           name="labels"
@@ -58,7 +59,7 @@ const EditLabelsFormContent = ({ isSubmitting, submitForm }: EditLabelsFormConte
         />
       </FormGroup>
       {submitError && <Alert isInline title={submitError} variant="danger" />}
-    </Form>
+    </FlightCtlForm>
   );
 };
 

--- a/libs/ui-components/src/components/modals/massModals/MassApproveDeviceModal/MassApproveDeviceModal.tsx
+++ b/libs/ui-components/src/components/modals/massModals/MassApproveDeviceModal/MassApproveDeviceModal.tsx
@@ -1,10 +1,9 @@
-import { Device, EnrollmentRequest, EnrollmentRequestApproval } from '@flightctl/types';
 import * as React from 'react';
+import { Device, EnrollmentRequest, EnrollmentRequestApproval } from '@flightctl/types';
 import {
   Alert,
   Button,
   ExpandableSection,
-  Form,
   FormGroup,
   Modal,
   Progress,
@@ -17,6 +16,7 @@ import { Formik } from 'formik';
 
 import TextField from '../../../form/TextField';
 import LabelsField from '../../../form/LabelsField';
+import FlightCtlForm from '../../../form/FlightCtlForm';
 import { deviceApprovalValidationSchema } from '../../../form/validations';
 import ResourceLink from '../../../common/ResourceLink';
 import { isPromiseRejected } from '../../../../types/typeUtils';
@@ -199,7 +199,7 @@ const MassApproveDeviceModal: React.FC<MassApproveDeviceModalProps> = ({ onClose
               </Table>
             </StackItem>
             <StackItem>
-              <Form onSubmit={(ev) => ev.preventDefault()}>
+              <FlightCtlForm>
                 <FormGroup label={t('Labels')}>
                   <LabelsField name="labels" />
                 </FormGroup>
@@ -216,7 +216,7 @@ const MassApproveDeviceModal: React.FC<MassApproveDeviceModalProps> = ({ onClose
                     }
                   />
                 </FormGroup>
-              </Form>
+              </FlightCtlForm>
             </StackItem>
             {resourcesToSkip.length > 0 && (
               <>

--- a/libs/ui-components/src/components/modals/massModals/MassApproveDeviceModal/MassApproveDeviceModal.tsx
+++ b/libs/ui-components/src/components/modals/massModals/MassApproveDeviceModal/MassApproveDeviceModal.tsx
@@ -199,7 +199,7 @@ const MassApproveDeviceModal: React.FC<MassApproveDeviceModalProps> = ({ onClose
               </Table>
             </StackItem>
             <StackItem>
-              <Form>
+              <Form onSubmit={(ev) => ev.preventDefault()}>
                 <FormGroup label={t('Labels')}>
                   <LabelsField name="labels" />
                 </FormGroup>


### PR DESCRIPTION
Prevent form submitting and reloading the current page when clicking enter while on a Form input field.

It was happening in:
- Create Fleet Wizard (General info + Device template step).
- Mass Approve Devices modal.