### PR TITLE
EDM-411: Remove v prefix on helm chart versions

### DIFF
--- a/.github/workflows/push-to-main.yaml
+++ b/.github/workflows/push-to-main.yaml
@@ -42,6 +42,7 @@ jobs:
             echo "image_tags=${image_tags[@]}"
 
             helm_tags=$(git describe --long --tags)
+            helm_tags=${helm_tags#v} # remove the leading v prefix for version
             echo "helm_tags=${helm_tags}" >> $GITHUB_OUTPUT
             echo "helm_tags=${helm_tags}"
           fi


### PR DESCRIPTION
The previous PR had a bug for the helm chart image versions, the "v" prefix was not being removed.

See
https://github.com/flightctl/flightctl-ui/actions/runs/10769558487/job/29861031551#step:5:11