### PR TITLE
EDM-228: Only show selection checkbox when elements exist in the table

### DIFF
--- a/libs/ui-components/src/components/Device/DeviceList/DeviceList.tsx
+++ b/libs/ui-components/src/components/Device/DeviceList/DeviceList.tsx
@@ -201,6 +201,7 @@ export const DeviceTable = ({
         aria-label={t('Devices table')}
         columns={deviceColumns}
         emptyFilters={filteredData.length === 0 && (hasFiltersEnabled || hasUIFiltersEnabled)}
+        emptyData={resources.length === 0}
         getSortParams={getSortParams}
         isAllSelected={isAllSelected}
         onSelectAll={setAllSelected}

--- a/libs/ui-components/src/components/Fleet/FleetList.tsx
+++ b/libs/ui-components/src/components/Fleet/FleetList.tsx
@@ -162,7 +162,8 @@ const FleetTable = () => {
       <Table
         aria-label={t('Fleets table')}
         columns={columns}
-        emptyFilters={filteredData.length === 0 && data.length > 0}
+        emptyFilters={filteredData.length === 0}
+        emptyData={data.length === 0}
         getSortParams={getSortParams}
         isAllSelected={isAllSelected}
         onSelectAll={setAllSelected}

--- a/libs/ui-components/src/components/Repository/RepositoryList.tsx
+++ b/libs/ui-components/src/components/Repository/RepositoryList.tsx
@@ -138,7 +138,8 @@ const RepositoryTable = () => {
       </Toolbar>
       <Table
         aria-label={t('Repositories table')}
-        emptyFilters={filteredData.length === 0 && (repositoryList?.items.length || 0) > 0}
+        emptyFilters={filteredData.length === 0}
+        emptyData={(repositoryList?.items.length || 0) === 0}
         isAllSelected={isAllSelected}
         onSelectAll={setAllSelected}
         columns={columns}

--- a/libs/ui-components/src/components/ResourceSync/RepositoryResourceSyncList.tsx
+++ b/libs/ui-components/src/components/ResourceSync/RepositoryResourceSyncList.tsx
@@ -134,7 +134,8 @@ const ResourceSyncTable = ({ resourceSyncs, refetch }: { resourceSyncs: Resource
         isAllSelected={isAllSelected}
         onSelectAll={setAllSelected}
         columns={columns}
-        emptyFilters={filteredData.length === 0 && resourceSyncs.length > 0}
+        emptyFilters={filteredData.length === 0}
+        emptyData={resourceSyncs.length === 0}
         getSortParams={getSortParams}
       >
         <Tbody>

--- a/libs/ui-components/src/components/Table/Table.tsx
+++ b/libs/ui-components/src/components/Table/Table.tsx
@@ -18,6 +18,7 @@ type TableProps<D> = {
   columns: TableColumn<D>[];
   children: React.ReactNode;
   emptyFilters: boolean;
+  emptyData: boolean;
   'aria-label': string;
   getSortParams: (columnIndex: number) => ThProps['sort'];
   onSelectAll?: (isSelected: boolean) => void;
@@ -26,9 +27,18 @@ type TableProps<D> = {
 
 type TableFC = <D>(props: TableProps<D>) => JSX.Element;
 
-const Table: TableFC = ({ columns, children, emptyFilters, getSortParams, onSelectAll, isAllSelected, ...rest }) => {
+const Table: TableFC = ({
+  columns,
+  children,
+  emptyFilters,
+  emptyData,
+  getSortParams,
+  onSelectAll,
+  isAllSelected,
+  ...rest
+}) => {
   const { t } = useTranslation();
-  if (emptyFilters) {
+  if (emptyFilters && !emptyData) {
     return (
       <PageSection variant="light">
         <Bullseye>{t('No resources are matching the current filters.')}</Bullseye>
@@ -40,7 +50,7 @@ const Table: TableFC = ({ columns, children, emptyFilters, getSortParams, onSele
     <PFTable {...rest}>
       <Thead>
         <Tr>
-          {onSelectAll && (
+          {!emptyData && onSelectAll && (
             <Th
               select={{
                 onSelect: (_event, isSelecting) => onSelectAll(isSelecting),


### PR DESCRIPTION
The checkbox for selecting items is only shown when there are actual items in the Table.

![select-checkbox](https://github.com/user-attachments/assets/2738a6da-6ab6-4918-8e2b-6bbe6980e413)
