### PR TITLE
Helm Releases: Add missing output to access the variable correctly later

### DIFF
--- a/.github/workflows/push-to-main.yaml
+++ b/.github/workflows/push-to-main.yaml
@@ -33,8 +33,9 @@ jobs:
             image_tags=${image_tags#v} # remove the leading v prefix for version
 
             echo "image_tags=${image_tags[@]}" >> $GITHUB_OUTPUT
-            echo "image_tags=${image_tags[@]}"
-            echo "helm_tags=${image_tags[@]}"
+            echo "helm_tags=${image_tags[@]}" >> $GITHUB_OUTPUT
+            echo "image_tags,helm_tags=${image_tags[@]}"
+
           else
             # The images tags are taken from git
             image_tags=( latest-${GITHUB_SHA} latest )


### PR DESCRIPTION
The `helm_tags` variable wasn't added to GIthub actions output, and it was not working. 
So helm charts would be pushed with version 0.0.1.

Fixed as seen in this [job](https://github.com/celdrake/flightctl-ui/actions/runs/10814497236/job/30001109991#step:3:13)
(The actions fail after this point because I intentionally don't have the Quay.io settings in my fork).