### PR TITLE
Fix frontend access to UI on OCP plugin mode

### DIFF
--- a/apps/ocp-plugin/deploy/helm/flightctl-ocp-ui/templates/flightctl-ui-network-policy.yaml
+++ b/apps/ocp-plugin/deploy/helm/flightctl-ocp-ui/templates/flightctl-ui-network-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: flightctl-ui-from-ingress 
+  namespace:  {{ .Release.Namespace }}
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+  podSelector:
+    matchLabels:
+      app: flightctl-ui 
+  policyTypes:
+  - Ingress

--- a/apps/standalone/deploy/helm/flightctl-ui/templates/flightctl-ui-network-policy.yaml
+++ b/apps/standalone/deploy/helm/flightctl-ui/templates/flightctl-ui-network-policy.yaml
@@ -1,17 +1,1 @@
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-ui-from-router
-  namespace: {{ .Values.flightctlUi.namespace }}
-spec:
-  ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          policy-group.network.openshift.io/ingress: ""
-      podSelector: {}
-  podSelector:
-    matchLabels:
-      role: frontend
-  policyTypes:
-  - Ingress
+../../../../../ocp-plugin/deploy/helm/flightctl-ocp-ui/templates/flightctl-ui-network-policy.yaml


### PR DESCRIPTION
Also make the network policy more specific to target only the UI pods, otherwise on deployments where the "internal" and "external" services live on the same namespace, the policy was also providing access to DB/rabbitmq/etc.

Related: https://issues.redhat.com/browse/EDM-463