### PR TITLE
EDM-527: Intercept get repository details request to avoid 401

### DIFF
--- a/libs/cypress/support/interceptors/repositories.ts
+++ b/libs/cypress/support/interceptors/repositories.ts
@@ -14,6 +14,18 @@ const loadInterceptors = () => {
       body: buildRepositoriesResponse(repoList),
     });
   }).as('repository-list');
+
+  cy.intercept('GET', '/api/flightctl/api/v1/repositories/**', (req) => {
+    const repoName = req.url.match(/\/repositories\/(.+)$/)[1];
+    const found = repoList.find((repo) => repo.metadata.name === repoName);
+    if (found) {
+      req.reply({
+        body: repoList.find((repo) => repo.metadata.name === repoName),
+      });
+    } else {
+      req.reply(404);
+    }
+  }).as('get-repo-details');
 };
 
 export { loadInterceptors };


### PR DESCRIPTION
The flake was caused because a request for getting the repository details was not being intercepted, and it resulted in 401.

We may need to make adjustments to the tests so that they run with AUTH disabled and we won't have to worry about this going forward.