### PR TITLE
EDM-547: Configuration links point to the directory or file

### DIFF
--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsTab.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsTab.tsx
@@ -25,7 +25,6 @@ import DeviceFleet from './DeviceFleet';
 import DetailsPageCard, { DetailsPageCardBody } from '../../DetailsPage/DetailsPageCard';
 import SystemdTable from './SystemdTable';
 import RepositorySourceList from '../../Repository/RepositoryDetails/RepositorySourceList';
-import { getSourceItems } from '../../../utils/devices';
 import { getErrorMessage } from '../../../utils/error';
 import ApplicationSummaryStatus from '../../Status/ApplicationSummaryStatus';
 import WithHelperText from '../../common/WithHelperText';
@@ -50,7 +49,6 @@ const DeviceDetailsTab = ({
 }: React.PropsWithChildren<DeviceDetailsTabProps>) => {
   const { t } = useTranslation();
 
-  const sourceItems = getSourceItems(device.spec.config);
   return (
     <Grid hasGutter>
       {!!errorTv && (
@@ -186,9 +184,11 @@ const DeviceDetailsTab = ({
                 </DescriptionListDescription>
               </DescriptionListGroup>
               <DescriptionListGroup>
-                <DescriptionListTerm>{t('Sources ({{size}})', { size: sourceItems.length })}</DescriptionListTerm>
+                <DescriptionListTerm>
+                  {t('Sources ({{size}})', { size: device.spec?.config?.length || 0 })}
+                </DescriptionListTerm>
                 <DescriptionListDescription>
-                  <RepositorySourceList sourceItems={sourceItems} />
+                  <RepositorySourceList configs={device.spec.config || []} />
                 </DescriptionListDescription>
               </DescriptionListGroup>
             </DescriptionList>

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/deviceSpecUtils.ts
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/deviceSpecUtils.ts
@@ -10,6 +10,7 @@ import {
   PatchRequest,
 } from '@flightctl/types';
 import {
+  ConfigSourceProvider,
   GitConfigTemplate,
   HttpConfigTemplate,
   InlineConfigTemplate,
@@ -22,12 +23,6 @@ import {
   isKubeProviderSpec,
   isKubeSecretTemplate,
 } from '../../../types/deviceSpec';
-
-export type ConfigSourceProvider =
-  | GitConfigProviderSpec
-  | KubernetesSecretProviderSpec
-  | InlineConfigProviderSpec
-  | HttpConfigProviderSpec;
 
 const isSameGitConf = (a: GitConfigProviderSpec, b: GitConfigProviderSpec) => {
   const aRef = a.gitRef;

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ReviewDeviceStep.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ReviewDeviceStep.tsx
@@ -14,7 +14,6 @@ import { EditDeviceFormValues } from '../types';
 import { useTranslation } from '../../../../hooks/useTranslation';
 import LabelsView from '../../../common/LabelsView';
 import { toAPILabel } from '../../../../utils/labels';
-import { getSourceItems } from '../../../../utils/devices';
 import { getErrorMessage } from '../../../../utils/error';
 import RepositorySourceList from '../../../Repository/RepositoryDetails/RepositorySourceList';
 import { getAPIConfig } from '../deviceSpecUtils';
@@ -58,7 +57,7 @@ const ReviewStep = ({ error }: { error?: string }) => {
           <DescriptionListGroup>
             <DescriptionListTerm>{t('Configurations/applications')}</DescriptionListTerm>
             <DescriptionListDescription>
-              <RepositorySourceList sourceItems={getSourceItems(values.configTemplates.map(getAPIConfig))} />
+              <RepositorySourceList configs={values.configTemplates.map(getAPIConfig)} />
             </DescriptionListDescription>
           </DescriptionListGroup>
         </DescriptionList>

--- a/libs/ui-components/src/components/Fleet/CreateFleet/steps/ReviewStep.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/steps/ReviewStep.tsx
@@ -15,7 +15,6 @@ import LabelsView from '../../../common/LabelsView';
 import { toAPILabel } from '../../../../utils/labels';
 import RepositorySourceList from '../../../Repository/RepositoryDetails/RepositorySourceList';
 import { getErrorMessage } from '../../../../utils/error';
-import { getSourceItems } from '../../../../utils/devices';
 import { getAPIConfig } from '../../../Device/EditDeviceWizard/deviceSpecUtils';
 
 export const reviewStepId = 'review';
@@ -57,7 +56,7 @@ const ReviewStep = ({ error }: { error?: unknown }) => {
           <DescriptionListGroup>
             <DescriptionListTerm>{t('Configurations/applications')}</DescriptionListTerm>
             <DescriptionListDescription>
-              <RepositorySourceList sourceItems={getSourceItems(values.configTemplates.map(getAPIConfig))} />
+              <RepositorySourceList configs={values.configTemplates.map(getAPIConfig)} />
             </DescriptionListDescription>
           </DescriptionListGroup>
         </DescriptionList>

--- a/libs/ui-components/src/components/Fleet/FleetDetails/FleetDetailsContent.tsx
+++ b/libs/ui-components/src/components/Fleet/FleetDetails/FleetDetailsContent.tsx
@@ -19,12 +19,10 @@ import FleetDevices from './FleetDevices';
 import FleetStatus from '../FleetStatus';
 import { useTranslation } from '../../../hooks/useTranslation';
 import RepositorySourceList from '../../Repository/RepositoryDetails/RepositorySourceList';
-import { getSourceItems } from '../../../utils/devices';
 import FleetDevicesLink from './FleetDevicesLink';
 
 const FleetDetailsContent = ({ fleet }: { fleet: Fleet }) => {
   const { t } = useTranslation();
-  const sourceItems = getSourceItems(fleet.spec.template.spec.config);
   const fleetId = fleet.metadata.name as string;
   const devicesSummary = fleet.status?.devicesSummary;
   return (
@@ -69,9 +67,11 @@ const FleetDetailsContent = ({ fleet }: { fleet: Fleet }) => {
                 </DescriptionListDescription>
               </DescriptionListGroup>
               <DescriptionListGroup>
-                <DescriptionListTerm>{t('Sources ({{size}})', { size: sourceItems.length })}</DescriptionListTerm>
+                <DescriptionListTerm>
+                  {t('Sources ({{size}})', { size: fleet.spec.template.spec.config?.length || 0 })}
+                </DescriptionListTerm>
                 <DescriptionListDescription>
-                  <RepositorySourceList sourceItems={sourceItems} />
+                  <RepositorySourceList configs={fleet.spec.template.spec.config || []} />
                 </DescriptionListDescription>
               </DescriptionListGroup>
             </DescriptionList>

--- a/libs/ui-components/src/components/Repository/RepositoryDetails/RepositoryGeneralDetailsCard.tsx
+++ b/libs/ui-components/src/components/Repository/RepositoryDetails/RepositoryGeneralDetailsCard.tsx
@@ -15,9 +15,9 @@ import { LockOpenIcon } from '@patternfly/react-icons/dist/js/icons/lock-open-ic
 import { getLastTransitionTimeText, getRepositorySyncStatus } from '../../../utils/status/repository';
 import { RepoSpecType, Repository } from '@flightctl/types';
 import { useTranslation } from '../../../hooks/useTranslation';
-import RepositorySource from './RepositorySource';
 import RepositoryStatus from '../../Status/RepositoryStatus';
 import { isHttpRepoSpec, isSshRepoSpec } from '../CreateRepository/utils';
+import { RepositoryLink } from './RepositorySource';
 
 const RepoPrivacy = ({ repo }: { repo: Repository }) => {
   const { t } = useTranslation();
@@ -59,7 +59,7 @@ const DetailsTab = ({ repoDetails }: { repoDetails: Repository }) => {
           <DescriptionListGroup>
             <DescriptionListTerm>{t('Url')}</DescriptionListTerm>
             <DescriptionListDescription>
-              <RepositorySource sourceDetails={{ type: 'git', details: repoDetails.spec.url }} />
+              <RepositoryLink url={repoDetails.spec.url} />
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>

--- a/libs/ui-components/src/components/Repository/RepositoryDetails/RepositorySource.tsx
+++ b/libs/ui-components/src/components/Repository/RepositoryDetails/RepositorySource.tsx
@@ -1,23 +1,51 @@
 import React from 'react';
 import { Button, Icon, Tooltip } from '@patternfly/react-core';
-import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 
-import { ConfigTemplate } from '../../../types/deviceSpec';
+import {
+  GitConfigProviderSpec,
+  HttpConfigProviderSpec,
+  InlineConfigProviderSpec,
+  KubernetesSecretProviderSpec,
+} from '@flightctl/types';
+import { ConfigSourceProvider, RepoConfig, getConfigFullRepoUrl, getRepoName } from '../../../types/deviceSpec';
+import { useTranslation } from '../../../hooks/useTranslation';
 
-export type RepositorySourceDetails = {
-  name?: string;
-  details?: string;
-  errorMessage?: string;
-  type: ConfigTemplate['type'];
+type ExtraArgs = Record<string, string>;
+
+export const DefaultConfigDetails = ({
+  config,
+}: {
+  config: InlineConfigProviderSpec | KubernetesSecretProviderSpec;
+}) => {
+  return <>{config.name}</>;
 };
 
-const RepositorySource = ({ sourceDetails }: { sourceDetails: RepositorySourceDetails }) => {
-  if (sourceDetails.errorMessage) {
+export const RepositoryLink = ({ name, url }: { name?: string; url: string }) => (
+  <Button
+    component="a"
+    variant="link"
+    isInline
+    href={url}
+    target="_blank"
+    icon={<ExternalLinkAltIcon />}
+    iconPosition="end"
+  >
+    {name || url}
+  </Button>
+);
+
+export const RepositoryConfigDetails = ({ config, extraArgs }: { config: RepoConfig; extraArgs: ExtraArgs }) => {
+  const { t } = useTranslation();
+  if (extraArgs.errorMsg) {
+    const fullError = `${t('The repository "{{name}}" defined for this source failed to load.', {
+      name: getRepoName(config),
+    })} ${extraArgs.errorMsg}`;
     return (
       <>
-        {sourceDetails.name}{' '}
-        <Tooltip content={sourceDetails.errorMessage}>
+        {config.name}{' '}
+        <Tooltip content={fullError}>
           <Icon status="danger">
             <ExclamationCircleIcon />
           </Icon>
@@ -25,23 +53,21 @@ const RepositorySource = ({ sourceDetails }: { sourceDetails: RepositorySourceDe
       </>
     );
   }
-  if (['secret', 'inline'].includes(sourceDetails.type)) {
-    return <>{sourceDetails.name}</>;
-  }
-  // Configurations related to a repository whose details could be obtained
-  return (
-    <Button
-      component="a"
-      variant="link"
-      isInline
-      href={sourceDetails.details}
-      target="_blank"
-      icon={<ExternalLinkAltIcon />}
-      iconPosition="end"
-    >
-      {sourceDetails.name || sourceDetails.details}
-    </Button>
-  );
+
+  return <RepositoryLink name={config.name} url={getConfigFullRepoUrl(config, extraArgs.url)} />;
 };
 
-export default RepositorySource;
+export const getConfigDetails = (config: ConfigSourceProvider, extraArgs: ExtraArgs) => {
+  switch (config.configType) {
+    case 'GitConfigProviderSpec':
+    case 'HttpConfigProviderSpec':
+      return (
+        <RepositoryConfigDetails
+          config={config as GitConfigProviderSpec | HttpConfigProviderSpec}
+          extraArgs={extraArgs}
+        />
+      );
+    default:
+      return <DefaultConfigDetails config={config as KubernetesSecretProviderSpec | InlineConfigProviderSpec} />;
+  }
+};

--- a/libs/ui-components/src/utils/devices.ts
+++ b/libs/ui-components/src/utils/devices.ts
@@ -1,11 +1,4 @@
-import { DeviceSpec, ObjectMeta } from '@flightctl/types';
-import { ConfigTemplate, isGitProviderSpec, isHttpProviderSpec, isKubeProviderSpec } from '../types/deviceSpec';
-
-export type SourceItem = {
-  type: ConfigTemplate['type'];
-  name: string;
-  details: string;
-};
+import { ObjectMeta } from '@flightctl/types';
 
 const deviceFleetRegExp = /^Fleet\/(?<fleetName>.*)$/;
 
@@ -14,26 +7,4 @@ const getDeviceFleet = (metadata: ObjectMeta) => {
   return match?.groups?.fleetName || null;
 };
 
-const getSourceItems = (specConfigs: DeviceSpec['config'] | undefined): SourceItem[] => {
-  return (specConfigs ?? [])
-    .map((config) => {
-      let sourceItem: SourceItem;
-      if (isGitProviderSpec(config)) {
-        sourceItem = { type: 'git', name: config.name, details: config.gitRef.repository };
-      } else if (isHttpProviderSpec(config)) {
-        sourceItem = { type: 'http', name: config.name, details: config.httpRef.repository };
-      } else if (isKubeProviderSpec(config)) {
-        sourceItem = {
-          type: 'secret',
-          name: config.name,
-          details: `${config.secretRef.namespace || ''}/${config.secretRef.name || ''}`,
-        };
-      } else {
-        sourceItem = { type: 'inline', name: config.name, details: '' };
-      }
-      return sourceItem;
-    })
-    .filter((repoName) => !!repoName);
-};
-
-export { getDeviceFleet, getSourceItems };
+export { getDeviceFleet };


### PR DESCRIPTION
For repository configurations, the link to the repository attempts to point to the exact folder or file defined in the the configuration source.

Supported cases:
- Git Repositories using Github and Gitlab domains behave the same and the URL format is known. Both files and folders are supported, as well as target revisions using either branches or tags.
- Http repositories will link to `repositoryUrl/suffix`

Unsupported cases:
- GitConfigs using other providers, such as bitbucket. We'd need to know which url format they use.
- GitConfigs / HttpConfigs that use template variables for defining their urls.


Github folder:
![github-folder](https://github.com/user-attachments/assets/f230ed36-67d0-42c7-95e8-8e52969c1b92)

Github file:
![github-file](https://github.com/user-attachments/assets/37038ffd-d942-4f97-a788-dd066dbf4ad9)