### PR TITLE
EDM-239: Fully disable actions when no table rows are selected

### DIFF
--- a/libs/ui-components/src/components/Device/DevicesPage/EnrollmentRequestList.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/EnrollmentRequestList.tsx
@@ -76,14 +76,10 @@ export const EnrollmentRequestTable = ({
     <>
       <EnrollmentRequestTableToolbar search={search} setSearch={setSearch} enrollments={pendingEnrollments}>
         <ToolbarItem>
-          <TableActions>
+          <TableActions isDisabled={!hasSelectedRows}>
             <SelectList>
-              <SelectOption isDisabled={!hasSelectedRows} onClick={() => setIsMassApproveModalOpen(true)}>
-                {t('Approve')}
-              </SelectOption>
-              <SelectOption isDisabled={!hasSelectedRows} onClick={() => setIsMassDeleteModalOpen(true)}>
-                {t('Delete')}
-              </SelectOption>
+              <SelectOption onClick={() => setIsMassApproveModalOpen(true)}>{t('Approve')}</SelectOption>
+              <SelectOption onClick={() => setIsMassDeleteModalOpen(true)}>{t('Delete')}</SelectOption>
             </SelectList>
           </TableActions>
         </ToolbarItem>

--- a/libs/ui-components/src/components/Fleet/FleetsPage.tsx
+++ b/libs/ui-components/src/components/Fleet/FleetsPage.tsx
@@ -124,11 +124,9 @@ const FleetTable = ({ fleetLoad }: { fleetLoad: FleetLoad }) => {
             <FleetPageActions createText={t('Create fleet')} />
           </ToolbarItem>
           <ToolbarItem>
-            <TableActions>
+            <TableActions isDisabled={!hasSelectedRows}>
               <SelectList>
-                <SelectOption isDisabled={!hasSelectedRows} onClick={() => setIsMassDeleteModalOpen(true)}>
-                  {t('Delete')}
-                </SelectOption>
+                <SelectOption onClick={() => setIsMassDeleteModalOpen(true)}>{t('Delete')}</SelectOption>
               </SelectList>
             </TableActions>
           </ToolbarItem>

--- a/libs/ui-components/src/components/Repository/RepositoryList.tsx
+++ b/libs/ui-components/src/components/Repository/RepositoryList.tsx
@@ -126,11 +126,9 @@ const RepositoryTable = () => {
             <CreateRepositoryButton buttonText={t('Create repository')} />
           </ToolbarItem>
           <ToolbarItem>
-            <TableActions>
+            <TableActions isDisabled={!hasSelectedRows}>
               <DropdownList>
-                <SelectOption isDisabled={!hasSelectedRows} onClick={() => setIsMassDeleteModalOpen(true)}>
-                  {t('Delete')}
-                </SelectOption>
+                <SelectOption onClick={() => setIsMassDeleteModalOpen(true)}>{t('Delete')}</SelectOption>
               </DropdownList>
             </TableActions>
           </ToolbarItem>

--- a/libs/ui-components/src/components/ResourceSync/RepositoryResourceSyncList.tsx
+++ b/libs/ui-components/src/components/ResourceSync/RepositoryResourceSyncList.tsx
@@ -227,11 +227,9 @@ const RepositoryResourceSyncList = ({ repositoryId }: { repositoryId: string }) 
             </ToolbarItem>
           </ToolbarGroup>
           <ToolbarItem>
-            <TableActions>
+            <TableActions isDisabled={!hasSelectedRows}>
               <SelectList>
-                <SelectOption isDisabled={!hasSelectedRows} onClick={() => setIsMassDeleteModalOpen(true)}>
-                  {t('Delete')}
-                </SelectOption>
+                <SelectOption onClick={() => setIsMassDeleteModalOpen(true)}>{t('Delete')}</SelectOption>
               </SelectList>
             </TableActions>
           </ToolbarItem>

--- a/libs/ui-components/src/components/Table/TableActions.tsx
+++ b/libs/ui-components/src/components/Table/TableActions.tsx
@@ -1,12 +1,13 @@
-import { MenuToggle, Select } from '@patternfly/react-core';
 import * as React from 'react';
+import { MenuToggle, Select } from '@patternfly/react-core';
+
 import { useTranslation } from '../../hooks/useTranslation';
 
 type TableActionsProps = {
-  children: React.ReactNode;
+  isDisabled: boolean;
 };
 
-const TableActions: React.FC<TableActionsProps> = ({ children }) => {
+const TableActions = ({ isDisabled, children }: React.PropsWithChildren<TableActionsProps>) => {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = React.useState(false);
   const onToggle = () => {
@@ -16,9 +17,10 @@ const TableActions: React.FC<TableActionsProps> = ({ children }) => {
     <Select
       isOpen={isOpen}
       onSelect={onToggle}
+      aria-disabled={isDisabled}
       onOpenChange={setIsOpen}
       toggle={(toggleRef) => (
-        <MenuToggle ref={toggleRef} onClick={onToggle} id="actions" isExpanded={isOpen}>
+        <MenuToggle ref={toggleRef} onClick={onToggle} id="actions" isExpanded={isOpen} isDisabled={isDisabled}>
           {t('Actions')}
         </MenuToggle>
       )}


### PR DESCRIPTION
For all tables, the "Actions" menu is disabled unless some rows are selected.
![disabled-actions](https://github.com/user-attachments/assets/243c0da6-8216-41b0-aae2-5b3d8c091a6f)
