### PR TITLE
EDM-613: ConfigType discriminator is removed

### DIFF
--- a/libs/cypress/fixtures/fleets/initialFleets.ts
+++ b/libs/cypress/fixtures/fleets/initialFleets.ts
@@ -24,7 +24,6 @@ const basicFleets: Fleet[] = [
         spec: {
           config: [
             {
-              configType: 'GitConfigProviderSpec',
               gitRef: {
                 path: '/demos/basic-nginx-fleet/configuration/',
                 repository: 'defaultRepo',
@@ -49,6 +48,9 @@ const basicFleets: Fleet[] = [
       conditions: [],
       devicesSummary: {
         total: 0,
+        applicationStatus: {},
+        summaryStatus: {},
+        updateStatus: {},
       }
     },
   },
@@ -75,7 +77,6 @@ const basicFleets: Fleet[] = [
         spec: {
           config: [
             {
-              configType: 'GitConfigProviderSpec',
               gitRef: {
                 path: '/etc/microshift/manifests',
                 targetRevision: 'main',
@@ -85,7 +86,6 @@ const basicFleets: Fleet[] = [
             },
             {
               name: 'pull-secret',
-              configType: 'KubernetesSecretProviderSpec',
               secretRef: {
                 mountPath: '/etc/crio/pull-secret',
                 name: 'device-pull-secret',
@@ -109,6 +109,9 @@ const basicFleets: Fleet[] = [
       conditions: [],
       devicesSummary: {
         total: 0,
+        applicationStatus: {},
+        summaryStatus: {},
+        updateStatus: {},
       }
     },
   },

--- a/libs/types/index.ts
+++ b/libs/types/index.ts
@@ -17,6 +17,7 @@ export type { CertificateSigningRequestStatus } from './models/CertificateSignin
 export type { Condition } from './models/Condition';
 export { ConditionStatus } from './models/ConditionStatus';
 export { ConditionType } from './models/ConditionType';
+export type { ConfigProviderSpec } from './models/ConfigProviderSpec';
 export type { CPUResourceMonitorSpec } from './models/CPUResourceMonitorSpec';
 export type { CustomResourceMonitorSpec } from './models/CustomResourceMonitorSpec';
 export type { Device } from './models/Device';
@@ -63,7 +64,6 @@ export type { FleetList } from './models/FleetList';
 export type { FleetRolloutStatus } from './models/FleetRolloutStatus';
 export type { FleetSpec } from './models/FleetSpec';
 export type { FleetStatus } from './models/FleetStatus';
-export type { GenericConfigSpec } from './models/GenericConfigSpec';
 export type { GenericRepoSpec } from './models/GenericRepoSpec';
 export type { GitConfigProviderSpec } from './models/GitConfigProviderSpec';
 export type { HookAction } from './models/HookAction';

--- a/libs/types/models/ConfigProviderSpec.ts
+++ b/libs/types/models/ConfigProviderSpec.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { GitConfigProviderSpec } from './GitConfigProviderSpec';
+import type { HttpConfigProviderSpec } from './HttpConfigProviderSpec';
+import type { InlineConfigProviderSpec } from './InlineConfigProviderSpec';
+import type { KubernetesSecretProviderSpec } from './KubernetesSecretProviderSpec';
+export type ConfigProviderSpec = (GitConfigProviderSpec | KubernetesSecretProviderSpec | InlineConfigProviderSpec | HttpConfigProviderSpec);
+

--- a/libs/types/models/DeviceSpec.ts
+++ b/libs/types/models/DeviceSpec.ts
@@ -3,19 +3,16 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { ApplicationSpec } from './ApplicationSpec';
+import type { ConfigProviderSpec } from './ConfigProviderSpec';
 import type { DeviceHooksSpec } from './DeviceHooksSpec';
 import type { DeviceOSSpec } from './DeviceOSSpec';
-import type { GitConfigProviderSpec } from './GitConfigProviderSpec';
-import type { HttpConfigProviderSpec } from './HttpConfigProviderSpec';
-import type { InlineConfigProviderSpec } from './InlineConfigProviderSpec';
-import type { KubernetesSecretProviderSpec } from './KubernetesSecretProviderSpec';
 import type { ResourceMonitor } from './ResourceMonitor';
 export type DeviceSpec = {
   os?: DeviceOSSpec;
   /**
-   * List of config resources.
+   * List of config providers.
    */
-  config?: Array<(GitConfigProviderSpec | KubernetesSecretProviderSpec | InlineConfigProviderSpec | HttpConfigProviderSpec)>;
+  config?: Array<ConfigProviderSpec>;
   hooks?: DeviceHooksSpec;
   /**
    * List of applications.

--- a/libs/types/models/GenericConfigSpec.ts
+++ b/libs/types/models/GenericConfigSpec.ts
@@ -1,9 +1,0 @@
-/* generated using openapi-typescript-codegen -- do no edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
-export type GenericConfigSpec = {
-  configType: string;
-  name: string;
-};
-

--- a/libs/types/models/GitConfigProviderSpec.ts
+++ b/libs/types/models/GitConfigProviderSpec.ts
@@ -2,8 +2,11 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { GenericConfigSpec } from './GenericConfigSpec';
-export type GitConfigProviderSpec = (GenericConfigSpec & {
+export type GitConfigProviderSpec = {
+  /**
+   * The name of the config provider
+   */
+  name: string;
   gitRef: {
     /**
      * The name of the repository resource to use as the sync source
@@ -17,5 +20,5 @@ export type GitConfigProviderSpec = (GenericConfigSpec & {
      */
     mountPath?: string;
   };
-});
+};
 

--- a/libs/types/models/HttpConfigProviderSpec.ts
+++ b/libs/types/models/HttpConfigProviderSpec.ts
@@ -2,8 +2,11 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { GenericConfigSpec } from './GenericConfigSpec';
-export type HttpConfigProviderSpec = (GenericConfigSpec & {
+export type HttpConfigProviderSpec = {
+  /**
+   * The name of the config provider
+   */
+  name: string;
   httpRef: {
     /**
      * The name of the repository resource to use as the sync source
@@ -22,5 +25,5 @@ export type HttpConfigProviderSpec = (GenericConfigSpec & {
      */
     filePath: string;
   };
-});
+};
 

--- a/libs/types/models/InlineConfigProviderSpec.ts
+++ b/libs/types/models/InlineConfigProviderSpec.ts
@@ -3,8 +3,11 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { FileSpec } from './FileSpec';
-import type { GenericConfigSpec } from './GenericConfigSpec';
-export type InlineConfigProviderSpec = (GenericConfigSpec & {
+export type InlineConfigProviderSpec = {
+  /**
+   * The name of the config provider
+   */
+  name: string;
   inline: Array<FileSpec>;
-});
+};
 

--- a/libs/types/models/KubernetesSecretProviderSpec.ts
+++ b/libs/types/models/KubernetesSecretProviderSpec.ts
@@ -2,12 +2,15 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { GenericConfigSpec } from './GenericConfigSpec';
-export type KubernetesSecretProviderSpec = (GenericConfigSpec & {
+export type KubernetesSecretProviderSpec = {
+  /**
+   * The name of the config provider
+   */
+  name: string;
   secretRef: {
     name: string;
     namespace: string;
     mountPath: string;
   };
-});
+};
 

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ConfigTemplateForm.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ConfigTemplateForm.tsx
@@ -16,7 +16,7 @@ import { MinusCircleIcon } from '@patternfly/react-icons/dist/js/icons/minus-cir
 import { PlusCircleIcon } from '@patternfly/react-icons/dist/js/icons/plus-circle-icon';
 
 import { RepoSpecType, Repository, RepositoryList } from '@flightctl/types';
-import { SpecConfigTemplate } from '../../../../types/deviceSpec';
+import { ConfigType, SpecConfigTemplate } from '../../../../types/deviceSpec';
 import { DeviceSpecConfigFormValues } from '../types';
 import { useTranslation } from '../../../../hooks/useTranslation';
 import { useFetchPeriodically } from '../../../../hooks/useFetchPeriodically';
@@ -80,11 +80,12 @@ const ConfigSection = ({ index, repositories, repoRefetch }: ConfigSectionProps)
             placeholderText={t('Select a source type')}
           />
         </FormGroup>
-        {type === 'secret' && <ConfigK8sSecretTemplateForm index={index} />}
-        {type === 'inline' && <ConfigInlineTemplateForm index={index} />}
-        {(type === 'http' || type === 'git') && (
+
+        {type === ConfigType.K8S_SECRET && <ConfigK8sSecretTemplateForm index={index} />}
+        {type === ConfigType.INLINE && <ConfigInlineTemplateForm index={index} />}
+        {(type === ConfigType.GIT || type === ConfigType.HTTP) && (
           <ConfigWithRepositoryTemplateForm
-            repoType={type as RepoSpecType}
+            repoType={type === ConfigType.HTTP ? RepoSpecType.HTTP : RepoSpecType.GIT}
             index={index}
             repositories={repositories}
             repoRefetch={repoRefetch}

--- a/libs/ui-components/src/components/Repository/RepositoryDetails/RepositorySource.tsx
+++ b/libs/ui-components/src/components/Repository/RepositoryDetails/RepositorySource.tsx
@@ -9,8 +9,15 @@ import {
   InlineConfigProviderSpec,
   KubernetesSecretProviderSpec,
 } from '@flightctl/types';
-import { ConfigSourceProvider, RepoConfig, getConfigFullRepoUrl, getRepoName } from '../../../types/deviceSpec';
+import {
+  ConfigSourceProvider,
+  ConfigType,
+  RepoConfig,
+  getConfigFullRepoUrl,
+  getRepoName,
+} from '../../../types/deviceSpec';
 import { useTranslation } from '../../../hooks/useTranslation';
+import { getConfigType } from '../../Device/EditDeviceWizard/deviceSpecUtils';
 
 type ExtraArgs = Record<string, string>;
 
@@ -58,9 +65,9 @@ export const RepositoryConfigDetails = ({ config, extraArgs }: { config: RepoCon
 };
 
 export const getConfigDetails = (config: ConfigSourceProvider, extraArgs: ExtraArgs) => {
-  switch (config.configType) {
-    case 'GitConfigProviderSpec':
-    case 'HttpConfigProviderSpec':
+  switch (getConfigType(config)) {
+    case ConfigType.GIT:
+    case ConfigType.HTTP:
       return (
         <RepositoryConfigDetails
           config={config as GitConfigProviderSpec | HttpConfigProviderSpec}


### PR DESCRIPTION
The "configType" discriminator has been dropped. The config types are implicit defined by the config properties.

Depends on https://github.com/flightctl/flightctl/pull/594