### PR TITLE
Containers are removed from device spec

### DIFF
--- a/libs/cypress/fixtures/fleets/initialFleets.ts
+++ b/libs/cypress/fixtures/fleets/initialFleets.ts
@@ -33,9 +33,6 @@ const basicFleets: Fleet[] = [
               name: 'example-server',
             },
           ],
-          containers: {
-            matchPatterns: ['*ai-optimizer-model-server*', '*web-interface*', '*control-loop*'],
-          },
           os: {
             image: 'quay.io/solar-farms/ai-inverter:1.5.0',
           },
@@ -93,9 +90,6 @@ const basicFleets: Fleet[] = [
               },
             },
           ],
-          containers: {
-            matchPatterns: ['*ai-optimizer-model-server*', '*web-interface*', '*control-loop*'],
-          },
           os: {
             image: 'quay.io/solar-farms/ai-inverter:1.5.0',
           },

--- a/libs/types/models/DeviceSpec.ts
+++ b/libs/types/models/DeviceSpec.ts
@@ -21,9 +21,6 @@ export type DeviceSpec = {
    * List of applications.
    */
   applications?: Array<ApplicationSpec>;
-  containers?: {
-    matchPatterns?: Array<string>;
-  };
   systemd?: {
     matchPatterns?: Array<string>;
   };

--- a/libs/types/models/RenderedDeviceSpec.ts
+++ b/libs/types/models/RenderedDeviceSpec.ts
@@ -10,9 +10,6 @@ import type { ResourceMonitor } from './ResourceMonitor';
 export type RenderedDeviceSpec = {
   renderedVersion: string;
   os?: DeviceOSSpec;
-  containers?: {
-    matchPatterns?: Array<string>;
-  };
   config?: string;
   applications?: Array<RenderedApplicationSpec>;
   hooks?: DeviceHooksSpec;


### PR DESCRIPTION
`containers` are being dropped from the device spec.

The UI was not using this property, so the only changes are for cleaning-up code and fixtures.

Depends on https://github.com/flightctl/flightctl/pull/596