### PR TITLE
EDM-615: Add PF4 CSS class to descripion list

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,12 +71,17 @@ module.exports = {
           {
             name: '@patternfly/react-core',
             importNames: ['ActionGroup'],
-            message: 'Use FlightCtlActionGroup to wrap the footer actions',
+            message: 'Use FlightCtlActionGroup wrapper',
+          },
+          {
+            name: '@patternfly/react-core',
+            importNames: ['DescriptionList'],
+            message: 'Use FlightCtlDescriptionList wrapper',
           },
           {
             name: '@patternfly/react-core',
             importNames: ['Form'],
-            message: 'Use FlightCtlForm to wrap forms',
+            message: 'Use FlightCtlForm wrapper',
           },
           {
             name: 'react-i18next',

--- a/libs/ui-components/src/components/DetailsPage/Tables/IntegrityDetails.tsx
+++ b/libs/ui-components/src/components/DetailsPage/Tables/IntegrityDetails.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   Bullseye,
-  DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
@@ -10,6 +9,7 @@ import {
 import { DeviceIntegrityStatus } from '@flightctl/types';
 import { useTranslation } from '../../../hooks/useTranslation';
 import IntegrityStatus from '../../Status/IntegrityStatus';
+import FlightControlDescriptionList from '../../common/FlightCtlDescriptionList';
 
 type IntegrityDetailsProps = {
   integrity?: DeviceIntegrityStatus;
@@ -20,7 +20,7 @@ const IntegrityDetails = ({ integrity }: IntegrityDetailsProps) => {
   const info = integrity?.summary.info;
   const status = integrity?.summary.status;
   return info || status ? (
-    <DescriptionList columnModifier={{ lg: '3Col' }}>
+    <FlightControlDescriptionList columnModifier={{ lg: '3Col' }}>
       {status && (
         <DescriptionListGroup>
           <DescriptionListTerm>{t('Status')}</DescriptionListTerm>
@@ -35,7 +35,7 @@ const IntegrityDetails = ({ integrity }: IntegrityDetailsProps) => {
           <DescriptionListDescription>{info}</DescriptionListDescription>
         </DescriptionListGroup>
       )}
-    </DescriptionList>
+    </FlightControlDescriptionList>
   ) : (
     <Bullseye>{t('No system integrity details found.')}</Bullseye>
   );

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsTab.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsTab.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
   Alert,
   CardTitle,
-  DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
@@ -25,6 +24,7 @@ import DeviceFleet from './DeviceFleet';
 import DeviceOs from './DeviceOs';
 import DetailsPageCard, { DetailsPageCardBody } from '../../DetailsPage/DetailsPageCard';
 import SystemdTable from './SystemdTable';
+import FlightControlDescriptionList from '../../common/FlightCtlDescriptionList';
 import RepositorySourceList from '../../Repository/RepositoryDetails/RepositorySourceList';
 import { getErrorMessage } from '../../../utils/error';
 import ApplicationSummaryStatus from '../../Status/ApplicationSummaryStatus';
@@ -96,7 +96,7 @@ const DeviceDetailsTab = ({
         <DetailsPageCard>
           <CardTitle>{t('System status')}</CardTitle>
           <DetailsPageCardBody>
-            <DescriptionList columnModifier={{ default: '3Col' }}>
+            <FlightControlDescriptionList columnModifier={{ default: '3Col' }}>
               <DescriptionListGroup>
                 <DescriptionListTerm>
                   <WithHelperText
@@ -139,7 +139,7 @@ const DeviceDetailsTab = ({
                 <DescriptionListTerm>{t('Last seen')}</DescriptionListTerm>
                 <DescriptionListDescription>{timeSinceText(t, device.status.lastSeen)}</DescriptionListDescription>
               </DescriptionListGroup>
-            </DescriptionList>
+            </FlightControlDescriptionList>
           </DetailsPageCardBody>
         </DetailsPageCard>
       </GridItem>
@@ -147,7 +147,7 @@ const DeviceDetailsTab = ({
         <DetailsPageCard>
           <CardTitle>{t('Resource status')}</CardTitle>
           <DetailsPageCardBody>
-            <DescriptionList columnModifier={{ default: '3Col' }}>
+            <FlightControlDescriptionList columnModifier={{ default: '3Col' }}>
               <DescriptionListGroup>
                 <DescriptionListTerm>{t('CPU pressure')}</DescriptionListTerm>
                 <DescriptionListDescription>
@@ -166,7 +166,7 @@ const DeviceDetailsTab = ({
                   <DeviceResourceStatus device={device} monitorType="memory" />
                 </DescriptionListDescription>
               </DescriptionListGroup>
-            </DescriptionList>
+            </FlightControlDescriptionList>
           </DetailsPageCardBody>
         </DetailsPageCard>
       </GridItem>
@@ -174,7 +174,7 @@ const DeviceDetailsTab = ({
         <DetailsPageCard>
           <CardTitle>{t('Configurations')}</CardTitle>
           <DetailsPageCardBody>
-            <DescriptionList columnModifier={{ default: '2Col' }}>
+            <FlightControlDescriptionList columnModifier={{ default: '2Col' }}>
               <DescriptionListGroup>
                 <DescriptionListTerm>{t('System image (running)')}</DescriptionListTerm>
                 <DescriptionListDescription>
@@ -189,7 +189,7 @@ const DeviceDetailsTab = ({
                   <RepositorySourceList configs={device.spec.config || []} />
                 </DescriptionListDescription>
               </DescriptionListGroup>
-            </DescriptionList>
+            </FlightControlDescriptionList>
           </DetailsPageCardBody>
         </DetailsPageCard>
       </GridItem>

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ReviewDeviceStep.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ReviewDeviceStep.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useFormikContext } from 'formik';
 import {
   Alert,
-  DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
@@ -15,6 +14,7 @@ import { useTranslation } from '../../../../hooks/useTranslation';
 import LabelsView from '../../../common/LabelsView';
 import { toAPILabel } from '../../../../utils/labels';
 import { getErrorMessage } from '../../../../utils/error';
+import FlightControlDescriptionList from '../../../common/FlightCtlDescriptionList';
 import RepositorySourceList from '../../../Repository/RepositoryDetails/RepositorySourceList';
 import { getAPIConfig } from '../deviceSpecUtils';
 import ReviewApplications from './ReviewApplications';
@@ -27,7 +27,7 @@ const ReviewStep = ({ error }: { error?: string }) => {
   return (
     <Stack hasGutter>
       <StackItem isFilled>
-        <DescriptionList
+        <FlightControlDescriptionList
           isHorizontal
           horizontalTermWidthModifier={{
             default: '25ch',
@@ -67,7 +67,7 @@ const ReviewStep = ({ error }: { error?: string }) => {
               <ReviewApplications apps={values.applications} />
             </DescriptionListDescription>
           </DescriptionListGroup>
-        </DescriptionList>
+        </FlightControlDescriptionList>
       </StackItem>
       {!!error && (
         <StackItem>

--- a/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestDetails/EnrollmentRequestDetails.tsx
+++ b/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestDetails/EnrollmentRequestDetails.tsx
@@ -13,7 +13,6 @@ import {
   Card,
   CardBody,
   CardTitle,
-  DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
@@ -32,6 +31,7 @@ import DetailsPageCard, { DetailsPageCardBody } from '../../DetailsPage/DetailsP
 import DetailsPageActions, { useDeleteAction } from '../../DetailsPage/DetailsPageActions';
 import EnrollmentRequestStatus from '../../Status/EnrollmentRequestStatus';
 import WithHelperText from '../../common/WithHelperText';
+import FlightControlDescriptionList from '../../common/FlightCtlDescriptionList';
 import { useTranslation } from '../../../hooks/useTranslation';
 import { ROUTE, useNavigate } from '../../../hooks/useNavigate';
 import { useAppContext } from '../../../hooks/useAppContext';
@@ -87,7 +87,7 @@ const EnrollmentRequestDetails = () => {
           <Card>
             <CardTitle>{t('Details')}</CardTitle>
             <CardBody>
-              <DescriptionList columnModifier={{ lg: '3Col' }}>
+              <FlightControlDescriptionList columnModifier={{ lg: '3Col' }}>
                 <DescriptionListGroup>
                   <DescriptionListTerm>{t('Name')}</DescriptionListTerm>
                   <DescriptionListDescription>{er?.metadata.name || '-'}</DescriptionListDescription>
@@ -122,7 +122,7 @@ const EnrollmentRequestDetails = () => {
                     <EnrollmentRequestStatus er={er} />
                   </DescriptionListDescription>
                 </DescriptionListGroup>
-              </DescriptionList>
+              </FlightControlDescriptionList>
             </CardBody>
           </Card>
         </GridItem>

--- a/libs/ui-components/src/components/Fleet/CreateFleet/steps/ReviewStep.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/steps/ReviewStep.tsx
@@ -1,17 +1,18 @@
+import * as React from 'react';
 import {
   Alert,
-  DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
-import * as React from 'react';
-import { useTranslation } from '../../../../hooks/useTranslation';
 import { useFormikContext } from 'formik';
+
+import { useTranslation } from '../../../../hooks/useTranslation';
 import { FleetFormValues } from '../types';
 import LabelsView from '../../../common/LabelsView';
+import FlightControlDescriptionList from '../../../common/FlightCtlDescriptionList';
 import { toAPILabel } from '../../../../utils/labels';
 import RepositorySourceList from '../../../Repository/RepositoryDetails/RepositorySourceList';
 import { getErrorMessage } from '../../../../utils/error';
@@ -26,7 +27,7 @@ const ReviewStep = ({ error }: { error?: unknown }) => {
   return (
     <Stack hasGutter>
       <StackItem isFilled>
-        <DescriptionList
+        <FlightControlDescriptionList
           isHorizontal
           horizontalTermWidthModifier={{
             default: '25ch',
@@ -66,7 +67,7 @@ const ReviewStep = ({ error }: { error?: unknown }) => {
               <ReviewApplications apps={values.applications} />
             </DescriptionListDescription>
           </DescriptionListGroup>
-        </DescriptionList>
+        </FlightControlDescriptionList>
       </StackItem>
       {!!error && (
         <StackItem>

--- a/libs/ui-components/src/components/Fleet/FleetDetails/FleetDetailsContent.tsx
+++ b/libs/ui-components/src/components/Fleet/FleetDetails/FleetDetailsContent.tsx
@@ -1,25 +1,26 @@
-import LabelsView from '../../common/LabelsView';
-import { getDateDisplay } from '../../../utils/dates';
+import * as React from 'react';
+
 import {
   Card,
   CardBody,
   CardTitle,
-  DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
   Grid,
   GridItem,
 } from '@patternfly/react-core';
-import * as React from 'react';
 
 import { Fleet } from '@flightctl/types';
 import FleetOwnerLink from './FleetOwnerLink';
 import FleetDevices from './FleetDevices';
 import FleetStatus from '../FleetStatus';
+import FleetDevicesLink from './FleetDevicesLink';
+import FlightControlDescriptionList from '../../common/FlightCtlDescriptionList';
+import LabelsView from '../../common/LabelsView';
+import { getDateDisplay } from '../../../utils/dates';
 import { useTranslation } from '../../../hooks/useTranslation';
 import RepositorySourceList from '../../Repository/RepositoryDetails/RepositorySourceList';
-import FleetDevicesLink from './FleetDevicesLink';
 
 const FleetDetailsContent = ({ fleet }: { fleet: Fleet }) => {
   const { t } = useTranslation();
@@ -31,7 +32,7 @@ const FleetDetailsContent = ({ fleet }: { fleet: Fleet }) => {
         <Card>
           <CardTitle>{t('Details')}</CardTitle>
           <CardBody>
-            <DescriptionList columnModifier={{ lg: '3Col' }}>
+            <FlightControlDescriptionList columnModifier={{ lg: '3Col' }}>
               <DescriptionListGroup>
                 <DescriptionListTerm>{t('Created')}</DescriptionListTerm>
                 <DescriptionListDescription>
@@ -74,7 +75,7 @@ const FleetDetailsContent = ({ fleet }: { fleet: Fleet }) => {
                   <RepositorySourceList configs={fleet.spec.template.spec.config || []} />
                 </DescriptionListDescription>
               </DescriptionListGroup>
-            </DescriptionList>
+            </FlightControlDescriptionList>
           </CardBody>
         </Card>
       </GridItem>

--- a/libs/ui-components/src/components/Repository/RepositoryDetails/RepositoryGeneralDetailsCard.tsx
+++ b/libs/ui-components/src/components/Repository/RepositoryDetails/RepositoryGeneralDetailsCard.tsx
@@ -3,7 +3,6 @@ import {
   Card,
   CardBody,
   CardTitle,
-  DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
@@ -12,9 +11,11 @@ import {
 import { LockIcon } from '@patternfly/react-icons/dist/js/icons/lock-icon';
 import { LockOpenIcon } from '@patternfly/react-icons/dist/js/icons/lock-open-icon';
 
-import { getLastTransitionTimeText, getRepositorySyncStatus } from '../../../utils/status/repository';
 import { RepoSpecType, Repository } from '@flightctl/types';
+
+import { getLastTransitionTimeText, getRepositorySyncStatus } from '../../../utils/status/repository';
 import { useTranslation } from '../../../hooks/useTranslation';
+import FlightControlDescriptionList from '../../common/FlightCtlDescriptionList';
 import RepositoryStatus from '../../Status/RepositoryStatus';
 import { isHttpRepoSpec, isSshRepoSpec } from '../CreateRepository/utils';
 import { RepositoryLink } from './RepositorySource';
@@ -55,7 +56,7 @@ const DetailsTab = ({ repoDetails }: { repoDetails: Repository }) => {
     <Card>
       <CardTitle>{t('Details')}</CardTitle>
       <CardBody>
-        <DescriptionList columnModifier={{ lg: '3Col' }}>
+        <FlightControlDescriptionList columnModifier={{ lg: '3Col' }}>
           <DescriptionListGroup>
             <DescriptionListTerm>{t('Url')}</DescriptionListTerm>
             <DescriptionListDescription>
@@ -88,7 +89,7 @@ const DetailsTab = ({ repoDetails }: { repoDetails: Repository }) => {
               {repoDetails ? getLastTransitionTimeText(repoDetails, t).text : '-'}
             </DescriptionListDescription>
           </DescriptionListGroup>
-        </DescriptionList>
+        </FlightControlDescriptionList>
       </CardBody>
     </Card>
   );

--- a/libs/ui-components/src/components/common/FlightCtlDescriptionList.tsx
+++ b/libs/ui-components/src/components/common/FlightCtlDescriptionList.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+// eslint-disable-next-line no-restricted-imports
+import { DescriptionList, DescriptionListProps } from '@patternfly/react-core';
+
+// Wrapper that adds the PF4 class for description lists as their styles are not loaded in the Console
+const FlightCtlDescriptionList = ({ children, ...rest }: DescriptionListProps) => (
+  <DescriptionList {...rest} className="pf-c-description-list">
+    {children}
+  </DescriptionList>
+);
+
+export default FlightCtlDescriptionList;


### PR DESCRIPTION
As a workaround to fix the styling issue of Description Lists in the OCP console, UI has a wrapper for DescriptionList which adds the PF4 className.

Will try to fix the issue in a better way, this PR is just in case we don't have it in time for v0.3.