### PR TITLE
EDM-615: Loading DescriptionList CSS from PF5 explicitly

### DIFF
--- a/apps/ocp-plugin/src/components/AppContext/AppContext.tsx
+++ b/apps/ocp-plugin/src/components/AppContext/AppContext.tsx
@@ -18,6 +18,8 @@ import { useSelector } from 'react-redux';
 import { useFetch } from '../../hooks/useFetch';
 import { useMetrics } from '../../hooks/useMetrics';
 import { DeviceImages, fetchImages } from '../../utils/apiCalls';
+// CSS for DescriptionList not included in the PF5 CSS bundle
+import '@patternfly/react-styles/css/components/DescriptionList/description-list.css';
 
 export const OCPPluginAppContext = AppContext.Provider;
 


### PR DESCRIPTION
Alternative workaround to load the PF5 styles for DescriptionList in the OCP plugin.