### PR TITLE
Workaround to have correct number of devices selected by a fleet

### DIFF
--- a/libs/ui-components/src/components/Fleet/CreateFleet/steps/DeviceLabelSelector.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/steps/DeviceLabelSelector.tsx
@@ -30,7 +30,10 @@ const DeviceLabelSelector = () => {
     const labelSelector = matchLabels.map(labelToString);
 
     try {
-      const deviceListResp = await get<DeviceList>(`devices?labelSelector=${labelSelector.join(',')}&limit=1`);
+      // TODO remove sortBy when https://issues.redhat.com/browse/EDM-624 is fixed. Otherwise the device count can be wrong.
+      const deviceListResp = await get<DeviceList>(
+        `devices?labelSelector=${labelSelector.join(',')}&limit=1&sortBy=metadata.name`,
+      );
       const num = getApiListCount(deviceListResp);
       setDeviceCount(num || 0);
     } catch (e) {


### PR DESCRIPTION
Until EDM-624 is fixed, the API may return an incorrect number of devices selected by a fleet.

Adding `sortBy=metadata.name` to the query prevents the bug from happening.