### PR TITLE
EDM-629 Show label for MicroShift cluster only once

### DIFF
--- a/apps/ocp-plugin/src/components/Devices/DeviceDetailsPage.tsx
+++ b/apps/ocp-plugin/src/components/Devices/DeviceDetailsPage.tsx
@@ -50,14 +50,9 @@ const DeviceDetailsPage = () => {
     );
   } else if (loaded && mc) {
     mcContent = isMicroShiftCluster(mc) ? (
-      <Stack>
-        <StackItem className="fctl-device-details-tab__label">{t('MicroShift cluster')}</StackItem>
-        <StackItem>
-          <WithTooltip content={clusterName} showTooltip>
-            <Link to={`/multicloud/infrastructure/clusters/details/${clusterName}/${clusterName}`}>{t('View')}</Link>
-          </WithTooltip>
-        </StackItem>
-      </Stack>
+      <WithTooltip content={clusterName} showTooltip>
+        <Link to={`/multicloud/infrastructure/clusters/details/${clusterName}/${clusterName}`}>{t('View')}</Link>
+      </WithTooltip>
     ) : (
       '-'
     );

--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -1,8 +1,8 @@
 {
   "The cluster details failed to load": "The cluster details failed to load",
   "Failed to load": "Failed to load",
-  "MicroShift cluster": "MicroShift cluster",
   "View": "View",
+  "MicroShift cluster": "MicroShift cluster",
   "Global navigation": "Global navigation",
   "Skip to Content": "Skip to Content",
   "User preferences": "User preferences",


### PR DESCRIPTION
Remove the duplicate label for a MicroShift cluster in the device details page.