### PR TITLE
EDM-665: Show URL of Http configs without a link

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -449,6 +449,7 @@
   "Git repository": "Git repository",
   "Privacy": "Privacy",
   "Device management service will monitor the specified paths, import the defined fleets and synchronise devices": "Device management service will monitor the specified paths, import the defined fleets and synchronise devices",
+  "Copy Url": "Copy Url",
   "The repository \"{{name}}\" defined for this source failed to load.": "The repository \"{{name}}\" defined for this source failed to load.",
   "Create a repository": "Create a repository",
   "No repositories here!": "No repositories here!",

--- a/libs/ui-components/src/components/Repository/RepositoryDetails/RepositoryGeneralDetailsCard.tsx
+++ b/libs/ui-components/src/components/Repository/RepositoryDetails/RepositoryGeneralDetailsCard.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from '../../../hooks/useTranslation';
 import FlightControlDescriptionList from '../../common/FlightCtlDescriptionList';
 import RepositoryStatus from '../../Status/RepositoryStatus';
 import { isHttpRepoSpec, isSshRepoSpec } from '../CreateRepository/utils';
-import { RepositoryLink } from './RepositorySource';
+import { GitRepositoryLink, HttpRepositoryUrl } from './RepositorySource';
 
 const RepoPrivacy = ({ repo }: { repo: Repository }) => {
   const { t } = useTranslation();
@@ -60,7 +60,11 @@ const DetailsTab = ({ repoDetails }: { repoDetails: Repository }) => {
           <DescriptionListGroup>
             <DescriptionListTerm>{t('Url')}</DescriptionListTerm>
             <DescriptionListDescription>
-              <RepositoryLink url={repoDetails.spec.url} />
+              {repoDetails?.spec.type === RepoSpecType.HTTP ? (
+                <HttpRepositoryUrl url={repoDetails.spec.url} />
+              ) : (
+                <GitRepositoryLink url={repoDetails.spec.url} />
+              )}
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>

--- a/libs/ui-components/src/components/Repository/RepositoryDetails/RepositorySource.tsx
+++ b/libs/ui-components/src/components/Repository/RepositoryDetails/RepositorySource.tsx
@@ -15,7 +15,9 @@ import {
   RepoConfig,
   getConfigFullRepoUrl,
   getRepoName,
+  isHttpProviderSpec,
 } from '../../../types/deviceSpec';
+import CopyButton from '../../common/CopyButton';
 import { useTranslation } from '../../../hooks/useTranslation';
 import { getConfigType } from '../../Device/EditDeviceWizard/deviceSpecUtils';
 
@@ -29,7 +31,17 @@ export const DefaultConfigDetails = ({
   return <>{config.name}</>;
 };
 
-export const RepositoryLink = ({ name, url }: { name?: string; url: string }) => (
+export const HttpRepositoryUrl = ({ name, url }: { name?: string; url: string }) => {
+  const { t } = useTranslation();
+  return (
+    <>
+      {name || url}
+      <CopyButton text={url} ariaLabel={t('Copy Url')} />
+    </>
+  );
+};
+
+export const GitRepositoryLink = ({ name, url }: { name?: string; url: string }) => (
   <Button
     component="a"
     variant="link"
@@ -61,7 +73,11 @@ export const RepositoryConfigDetails = ({ config, extraArgs }: { config: RepoCon
     );
   }
 
-  return <RepositoryLink name={config.name} url={getConfigFullRepoUrl(config, extraArgs.url)} />;
+  const url = getConfigFullRepoUrl(config, extraArgs.url);
+  if (isHttpProviderSpec(config)) {
+    return <HttpRepositoryUrl name={config.name} url={url} />;
+  }
+  return <GitRepositoryLink name={config.name} url={url} />;
 };
 
 export const getConfigDetails = (config: ConfigSourceProvider, extraArgs: ExtraArgs) => {

--- a/libs/ui-components/src/components/common/CopyButton.tsx
+++ b/libs/ui-components/src/components/common/CopyButton.tsx
@@ -4,7 +4,13 @@ import { Button, ButtonProps, Icon, Tooltip } from '@patternfly/react-core';
 
 import { useTranslation } from '../../hooks/useTranslation';
 
-const CopyButton = ({ text, variant }: { text: string; variant?: ButtonProps['variant'] }) => {
+interface CopyButtonProps {
+  text: string;
+  variant?: ButtonProps['variant'];
+  ariaLabel?: string;
+}
+
+const CopyButton = ({ ariaLabel, text, variant }: CopyButtonProps) => {
   const { t } = useTranslation();
 
   const onCopy = () => {
@@ -12,7 +18,7 @@ const CopyButton = ({ text, variant }: { text: string; variant?: ButtonProps['va
   };
 
   return (
-    <Tooltip content={t('Copy text')}>
+    <Tooltip content={ariaLabel || t('Copy text')}>
       <Button
         variant={variant || 'plain'}
         isInline={variant === 'link'}
@@ -21,7 +27,7 @@ const CopyButton = ({ text, variant }: { text: string; variant?: ButtonProps['va
             <CopyIcon onClick={onCopy} />
           </Icon>
         }
-        aria-label={t('Copy text')}
+        aria-label={ariaLabel || t('Copy text')}
       />
     </Tooltip>
   );


### PR DESCRIPTION
Http config URLs should not be opened as browser links, since they most likely cannot be used as a GET request without authentication, etc.

Only the config name will be shown, then the url (+suffix) can be copied.
![http-config](https://github.com/user-attachments/assets/b3330aa3-c97e-4fda-8cec-2f7e08eaa5e1)
