### PR TITLE
EDM-681 filter using field selector

### DIFF
--- a/libs/ui-components/src/components/Device/DevicesPage/useDevices.ts
+++ b/libs/ui-components/src/components/Device/DevicesPage/useDevices.ts
@@ -40,20 +40,15 @@ const getDevicesEndpoint = ({
   if (nameOrAlias) {
     queryUtils.addTextContainsCondition(fieldSelectors, 'metadata.nameoralias', nameOrAlias);
   }
+  if (ownerFleets?.length) {
+    queryUtils.addQueryConditions(
+      fieldSelectors,
+      'metadata.owner',
+      ownerFleets.map((fleet) => `Fleet/${fleet}`),
+    );
+  }
 
   const params = new URLSearchParams();
-  if (ownerFleets?.length) {
-    if (summaryOnly) {
-      // TODO https://issues.redhat.com/browse/EDM-681 filtering not implemented for summaryOnly+field-selector
-      params.set('owner', ownerFleets.map((fleet) => `Fleet/${fleet}`).join(','));
-    } else {
-      queryUtils.addQueryConditions(
-        fieldSelectors,
-        'metadata.owner',
-        ownerFleets.map((fleet) => `Fleet/${fleet}`),
-      );
-    }
-  }
   if (fieldSelectors.length > 0) {
     params.set('fieldSelector', fieldSelectors.join(','));
   }


### PR DESCRIPTION
This PR removes a TODO related to not being able to filter using "fieldSelector" in the "summaryOnly" requests.

The Backend change has already been merged.