### PR TITLE
EDM-473 Fleets table includes pagination

### DIFF
--- a/apps/standalone/src/app/constants.ts
+++ b/apps/standalone/src/app/constants.ts
@@ -1,4 +1,0 @@
-const APP_TITLE = 'Flight Control';
-const API_VERSION = 'v1alpha1';
-
-export { APP_TITLE, API_VERSION };

--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -495,7 +495,7 @@
   "Updates blocked": "Updates blocked",
   "Invalid configuration": "Invalid configuration",
   "No resources are matching the current filters.": "No resources are matching the current filters.",
-  "{currentPage} of <2>{totalPages}</2>": "{currentPage} of <2>{totalPages}</2>",
+  "{pageNum} of <2>{totalPages}</2>": "{pageNum} of <2>{totalPages}</2>",
   "{{ numberOfItems }} items": "{{ numberOfItems }} items",
   "Waiting for terminal session to open...": "Waiting for terminal session to open...",
   "System default": "System default",

--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -495,6 +495,8 @@
   "Updates blocked": "Updates blocked",
   "Invalid configuration": "Invalid configuration",
   "No resources are matching the current filters.": "No resources are matching the current filters.",
+  "{currentPage} of <2>{totalPages}</2>": "{currentPage} of <2>{totalPages}</2>",
+  "{{ numberOfItems }} items": "{{ numberOfItems }} items",
   "Waiting for terminal session to open...": "Waiting for terminal session to open...",
   "System default": "System default",
   "Light": "Light",

--- a/libs/ui-components/src/components/Table/TablePagination.tsx
+++ b/libs/ui-components/src/components/Table/TablePagination.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Trans } from 'react-i18next';
+import { Pagination, PaginationToggleTemplateProps, PaginationVariant, Spinner } from '@patternfly/react-core';
+
+import { PAGE_SIZE } from '../../constants';
+import { useTranslation } from '../../hooks/useTranslation';
+
+type TablePaginationProps = {
+  isUpdating: boolean;
+  itemCount?: number;
+  currentPage: number;
+  setCurrentPage: (page: number) => void;
+};
+
+const PaginationTemplate = ({
+  isUpdating,
+  firstIndex,
+  itemCount,
+}: PaginationToggleTemplateProps & { isUpdating: boolean }) => {
+  const { t } = useTranslation();
+
+  if (isUpdating) {
+    return <Spinner size="sm" />;
+  }
+
+  const totalPages = String(Math.ceil((itemCount || 0) / PAGE_SIZE));
+  const currentPage = String(Math.ceil((firstIndex || 0) / PAGE_SIZE));
+  return (
+    <Trans t={t}>
+      {currentPage} of <strong>{totalPages}</strong>
+    </Trans>
+  );
+};
+
+const TablePagination = ({ isUpdating, itemCount, currentPage, setCurrentPage }: TablePaginationProps) => {
+  const { t } = useTranslation();
+
+  const onSetPage = (_event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPage: number) => {
+    setCurrentPage(newPage);
+  };
+
+  return (
+    <Pagination
+      widgetId="table-pagination"
+      isCompact
+      variant={PaginationVariant.top}
+      toggleTemplate={(props) => <PaginationTemplate isUpdating={isUpdating} {...props} />}
+      itemCount={itemCount || 0}
+      perPage={PAGE_SIZE}
+      page={currentPage}
+      perPageOptions={[{ title: t(`{{ numberOfItems }} items`, { numberOfItems: PAGE_SIZE }), value: PAGE_SIZE }]}
+      onSetPage={onSetPage}
+    />
+  );
+};
+
+export default TablePagination;

--- a/libs/ui-components/src/constants.ts
+++ b/libs/ui-components/src/constants.ts
@@ -1,4 +1,5 @@
 const APP_TITLE = 'Device management service';
 const API_VERSION = 'v1alpha1';
+const PAGE_SIZE = 15;
 
-export { APP_TITLE, API_VERSION };
+export { APP_TITLE, API_VERSION, PAGE_SIZE };

--- a/libs/ui-components/src/hooks/useFetchPeriodically.ts
+++ b/libs/ui-components/src/hooks/useFetchPeriodically.ts
@@ -8,6 +8,7 @@ const TIMEOUT = 10000;
 
 export const useFetchPeriodically = <R>(
   query: FlightControlQuery,
+  onFetchComplete?: (data: R) => void,
 ): [R | undefined, boolean, unknown, VoidFunction, boolean] => {
   const [isLoading, setIsLoading] = React.useState(true);
   const [isUpdating, setIsUpdating] = React.useState(false);
@@ -48,6 +49,9 @@ export const useFetchPeriodically = <R>(
             // eslint-disable-next-line
             setData(isAPI ? data : (data as any).data.result);
             setError(undefined);
+            if (isAPI && onFetchComplete) {
+              onFetchComplete(data as R);
+            }
           } catch (err) {
             // aborting fetch trows 'AbortError', we can ignore it
             if (abortController.signal.aborted) {

--- a/libs/ui-components/src/hooks/useTablePagination.ts
+++ b/libs/ui-components/src/hooks/useTablePagination.ts
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { ApiList } from '../utils/api';
+import { PAGE_SIZE } from '../constants';
+
+export const useTablePagination = () => {
+  const [currentPage, setCurrentPage] = React.useState<number>(1);
+  const [continueTokens, setContinueTokens] = React.useState<string[]>([]);
+  const [itemCount, setItemCount] = React.useState<number>(0);
+
+  const nextContinue = currentPage <= 1 ? '' : continueTokens[currentPage - 2];
+
+  const onPageFetched = React.useCallback(
+    (apiList: ApiList<unknown>) => {
+      const prevItems = (currentPage - 1) * PAGE_SIZE;
+      setItemCount(prevItems + (apiList?.items.length || 0) + (apiList.metadata.remainingItemCount || 0));
+
+      const nextToken = apiList.metadata?.continue || '';
+      if (currentPage === 1) {
+        // Always reset the list when at first page
+        setContinueTokens([nextToken]);
+      } else if (continueTokens.length < currentPage) {
+        // Visiting current page for the first time
+        setContinueTokens((prevList: string[]) => prevList.concat(nextToken));
+      } else {
+        // Re-visiting current page, token is updated in case the list of items changed
+        setContinueTokens((prevList: string[]) =>
+          prevList.map((token, index) => (index === currentPage - 1 ? nextToken : token)),
+        );
+      }
+    },
+    [setContinueTokens, continueTokens, setItemCount, currentPage],
+  );
+
+  return { onPageFetched, currentPage, setCurrentPage, nextContinue, itemCount };
+};

--- a/libs/ui-components/src/utils/api.ts
+++ b/libs/ui-components/src/utils/api.ts
@@ -42,12 +42,12 @@ const getRequestQueryString = (queryObj: FlightControlQuery) => {
   return getMetricsQueryString(queryObj);
 };
 
-interface ApiList {
-  items: Array<unknown>;
+export interface ApiList<R> {
+  items: Array<R>;
   metadata: ListMeta;
 }
 
-const getApiListCount = (listResponse: ApiList | undefined): number | undefined => {
+const getApiListCount = <T>(listResponse: ApiList<T> | undefined): number | undefined => {
   if (listResponse === undefined) {
     return undefined;
   }


### PR DESCRIPTION
Adds pagination to Fleets table. If the approach is approved, we can extend this pattern to the rest of the tables.

Also, it changes the logic on how we show the resource syncs, so it doesn't depend in fetching the entire list of fleets.

![fleets-paginated](https://github.com/user-attachments/assets/8d164799-cf8c-4261-94c2-3b0a61d3c405)
