### PR TITLE
EDM-831: Fix changing inline configs user/group to default value

### DIFF
--- a/libs/cypress/support/interceptors/repositories.ts
+++ b/libs/cypress/support/interceptors/repositories.ts
@@ -9,7 +9,7 @@ const buildRepositoriesResponse = (repositories: Repository[]) => ({
 });
 
 const loadInterceptors = () => {
-  cy.intercept('GET', '/api/flightctl/api/v1/repositories', (req) => {
+  cy.intercept('GET', '/api/flightctl/api/v1/repositories?*', (req) => {
     req.reply({
       body: buildRepositoriesResponse(repoList),
     });

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/deviceSpecUtils.ts
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/deviceSpecUtils.ts
@@ -201,14 +201,20 @@ export const getAPIConfig = (ct: SpecConfigTemplate): ConfigSourceProvider => {
   return {
     name: ct.name,
     inline: ct.files.map((file) => {
-      return {
+      const baseProps: FileSpec = {
         path: file.path,
         content: file.content,
-        group: file.group,
-        user: file.user,
         mode: file.permissions ? parseInt(file.permissions, 8) : undefined,
         contentEncoding: file.base64 ? FileSpec.contentEncoding.BASE64 : undefined,
       };
+      // user / group fields cannot be sent as empty in PATCH operations
+      if (file.user) {
+        baseProps.user = file.user;
+      }
+      if (file.group) {
+        baseProps.group = file.group;
+      }
+      return baseProps;
     }),
   };
 };


### PR DESCRIPTION
There was a bug when modifying an inline config, and changing the user/group fields from any value to unset.
The API would reject such modification with error 400.