### PR TITLE
EDM-624: Sorting parameters have been removed from the API

### DIFF
--- a/libs/ui-components/src/components/Device/DevicesPage/DevicesPage.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/DevicesPage.tsx
@@ -227,7 +227,7 @@ const DevicesPage = () => {
   });
 
   const [fleetsList, flLoading, flError] = useFetchPeriodically<FleetList>({
-    endpoint: 'fleets?sortBy=metadata.name&sortOrder=Asc',
+    endpoint: 'fleets',
   });
 
   return (

--- a/libs/ui-components/src/components/Device/DevicesPage/EnrollmentRequestList.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/EnrollmentRequestList.tsx
@@ -39,7 +39,7 @@ const EnrollmentRequestList = ({ refetchDevices }: { refetchDevices: VoidFunctio
   const enrollmentColumns = React.useMemo(() => getEnrollmentColumns(t), [t]);
 
   const [erList, isLoading, error, refetch] = useFetchPeriodically<EnrollmentRequestListType>({
-    endpoint: 'enrollmentrequests?fieldSelector=!status.approval.approved&sortBy=metadata.name&sortOrderAsc',
+    endpoint: 'enrollmentrequests?fieldSelector=!status.approval.approved',
   });
   const pendingEnrollments = erList?.items || [];
 

--- a/libs/ui-components/src/components/Device/DevicesPage/useDevices.ts
+++ b/libs/ui-components/src/components/Device/DevicesPage/useDevices.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useDebounce } from 'use-debounce';
 
-import { Device, DeviceList, DevicesSummary, SortOrder } from '@flightctl/types';
+import { Device, DeviceList, DevicesSummary } from '@flightctl/types';
 import { FilterSearchParams } from '../../../utils/status/devices';
 import * as queryUtils from '../../../utils/query';
 import { fromAPILabel } from '../../../utils/labels';
@@ -38,10 +38,7 @@ const getDevicesEndpoint = ({ nameOrAlias, ownerFleets, activeStatuses, labels, 
     );
   }
 
-  const params = new URLSearchParams({
-    sortBy: 'metadata.name',
-    sortOrder: SortOrder.ASC,
-  });
+  const params = new URLSearchParams();
   if (fieldSelectors.length > 0) {
     params.set('fieldSelector', fieldSelectors.join(','));
   }
@@ -49,7 +46,7 @@ const getDevicesEndpoint = ({ nameOrAlias, ownerFleets, activeStatuses, labels, 
   if (summaryOnly) {
     params.set('summaryOnly', 'true');
   }
-  return `devices?${params.toString()}`;
+  return params.size ? `devices?${params.toString()}` : 'devices';
 };
 
 export const useDevicesEndpoint = (args: DevicesEndpointArgs): [string, boolean] => {
@@ -80,7 +77,7 @@ export const useDevices = (args: {
   labels?: FlightCtlLabel[];
 }): [Device[], boolean, unknown, boolean, VoidFunction, FlightCtlLabel[]] => {
   const [deviceLabelList] = useFetchPeriodically<DeviceList>({
-    endpoint: 'devices?sortBy=metadata.name&sortOrder=Asc',
+    endpoint: 'devices',
   });
   const [devicesEndpoint, devicesDebouncing] = useDevicesEndpoint(args);
   const [devicesList, devicesLoading, devicesError, devicesRefetch, updating] = useFetchPeriodically<DeviceList>({

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ConfigurationTemplates.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ConfigurationTemplates.tsx
@@ -157,7 +157,7 @@ const ConfigurationTemplatesForm = ({ repositories, repoRefetch }: ConfigSection
 
 const ConfigurationTemplates = () => {
   const [repositoryList, isLoading, error, refetch] = useFetchPeriodically<RepositoryList>({
-    endpoint: 'repositories?sortBy=metadata.name&sortOrder=Asc',
+    endpoint: 'repositories',
   });
 
   const repositories = repositoryList?.items || [];

--- a/libs/ui-components/src/components/Fleet/CreateFleet/steps/DeviceLabelSelector.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/steps/DeviceLabelSelector.tsx
@@ -30,10 +30,7 @@ const DeviceLabelSelector = () => {
     const labelSelector = matchLabels.map(labelToString);
 
     try {
-      // TODO remove sortBy when https://issues.redhat.com/browse/EDM-624 is fixed. Otherwise the device count can be wrong.
-      const deviceListResp = await get<DeviceList>(
-        `devices?labelSelector=${labelSelector.join(',')}&limit=1&sortBy=metadata.name`,
-      );
+      const deviceListResp = await get<DeviceList>(`devices?labelSelector=${labelSelector.join(',')}&limit=1`);
       const num = getApiListCount(deviceListResp);
       setDeviceCount(num || 0);
     } catch (e) {

--- a/libs/ui-components/src/components/Fleet/FleetResourceSyncs.tsx
+++ b/libs/ui-components/src/components/Fleet/FleetResourceSyncs.tsx
@@ -112,7 +112,7 @@ const FleetResourceSyncs = ({ fleets }: { fleets: Fleet[] }) => {
   const { t } = useTranslation();
 
   const [rsList, , , rsRefetch] = useFetchPeriodically<ResourceSyncList>({
-    endpoint: 'resourcesyncs?sortBy=metadata.name&sortOrder=Asc',
+    endpoint: 'resourcesyncs',
   });
 
   // TODO Remove the client-side filtering once the API filter is available

--- a/libs/ui-components/src/components/Fleet/ImportFleetWizard/ImportFleetWizard.tsx
+++ b/libs/ui-components/src/components/Fleet/ImportFleetWizard/ImportFleetWizard.tsx
@@ -98,7 +98,7 @@ const ImportFleetWizard = () => {
   const navigate = useNavigate();
   const [currentStep, setCurrentStep] = React.useState<WizardStepType>();
   const [repoList, isLoading, error] = useFetchPeriodically<RepositoryList>({
-    endpoint: 'repositories?sortBy=metadata.name&sortOrder=Asc',
+    endpoint: 'repositories',
   });
 
   const gitRepositories = (repoList?.items || []).filter((repo) => repo.spec.type === RepoSpecType.GIT);

--- a/libs/ui-components/src/components/Fleet/useFleets.ts
+++ b/libs/ui-components/src/components/Fleet/useFleets.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { useAppContext } from '../../hooks/useAppContext';
 import { useFetchPeriodically } from '../../hooks/useFetchPeriodically';
-import { Fleet, FleetList, SortOrder } from '@flightctl/types';
+import { Fleet, FleetList } from '@flightctl/types';
 import { useDebounce } from 'use-debounce';
 
 export enum FleetSearchParams {
@@ -43,17 +43,14 @@ export const useFleetBackendFilters = () => {
 };
 
 const getFleetsEndpoint = ({ addDevicesCount, name }: { addDevicesCount?: boolean; name?: string }) => {
-  const params = new URLSearchParams({
-    sortBy: 'metadata.name',
-    sortOrder: SortOrder.ASC,
-  });
+  const params = new URLSearchParams();
   if (name) {
     params.set('fieldSelector', `metadata.name contains ${name}`);
   }
   if (addDevicesCount) {
     params.set('addDevicesCount', 'true');
   }
-  return `fleets?${params.toString()}`;
+  return params.size ? `fleets?${params.toString()}` : 'fleets';
 };
 
 const useFleetsEndpoint = (args: FleetsEndpointArgs): [string, boolean] => {

--- a/libs/ui-components/src/components/OverviewPage/Cards/Status/StatusCard.tsx
+++ b/libs/ui-components/src/components/OverviewPage/Cards/Status/StatusCard.tsx
@@ -43,7 +43,7 @@ const StatusCard = () => {
 
   // TODO https://issues.redhat.com/browse/EDM-683 Use the new API endpoint to retrieve fleet names
   const [fleetsList, flLoading, flError] = useFetchPeriodically<FleetList>({
-    endpoint: 'fleets?sortBy=metadata.name&sortOrder=Asc',
+    endpoint: 'fleets',
   });
 
   let content: React.ReactNode;

--- a/libs/ui-components/src/components/Repository/RepositoryList.tsx
+++ b/libs/ui-components/src/components/Repository/RepositoryList.tsx
@@ -88,7 +88,7 @@ const getSearchText = (repo: Repository) => [repo.metadata.name];
 const RepositoryTable = () => {
   const { t } = useTranslation();
   const [repositoryList, loading, error, refetch] = useFetchPeriodically<RepositoryList>({
-    endpoint: 'repositories?sortBy=metadata.name&sortOrder=Asc',
+    endpoint: 'repositories',
   });
   const [deleteModalRepoId, setDeleteModalRepoId] = React.useState<string>();
   const [isMassDeleteModalOpen, setIsMassDeleteModalOpen] = React.useState(false);

--- a/libs/ui-components/src/components/ResourceSync/RepositoryResourceSyncList.tsx
+++ b/libs/ui-components/src/components/ResourceSync/RepositoryResourceSyncList.tsx
@@ -164,7 +164,7 @@ const CreateResourceSyncModal = ({
 
 const RepositoryResourceSyncList = ({ repositoryId }: { repositoryId: string }) => {
   const [rsList, isLoading, error, refetch] = useFetchPeriodically<ResourceSyncList>({
-    endpoint: `resourcesyncs?fieldSelector=spec.repository=${repositoryId}&sortBy=metadata.name&sortOrder=Asc`,
+    endpoint: `resourcesyncs?fieldSelector=spec.repository=${repositoryId}`,
   });
 
   const resourceSyncs = rsList?.items || [];

--- a/libs/ui-components/src/hooks/usePendingEnrollmentRequestsCount.ts
+++ b/libs/ui-components/src/hooks/usePendingEnrollmentRequestsCount.ts
@@ -5,7 +5,7 @@ import { getApiListCount } from '../utils/api';
 
 export const usePendingEnrollmentRequestsCount = (): [number, boolean, unknown] => {
   const [erList, loading, error] = useFetchPeriodically<EnrollmentRequestList>({
-    endpoint: 'enrollmentrequests?fieldSelector=!status.approval.approved&limit=1&sortBy=metadata.name&sortOrder=Asc',
+    endpoint: 'enrollmentrequests?fieldSelector=!status.approval.approved&limit=1',
   });
 
   return [getApiListCount(erList) || 0, loading, error];


### PR DESCRIPTION
Due to bug EDM-624, the API parameters `sortBy` and `sortOrder` have been removed for now.

We'll have a proper sorting implementation in the future, but for now the default sorting is for `metadata.name` in Ascending order, and it will be done implicitly in the API.