### PR TITLE
EDM-883: Clear error after moving away from submit step

### DIFF
--- a/libs/ui-components/src/components/Device/EditDeviceWizard/EditDeviceWizard.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/EditDeviceWizard.tsx
@@ -69,7 +69,7 @@ const EditDeviceWizard = () => {
       <Formik<EditDeviceFormValues>
         initialValues={{
           deviceAlias,
-          osImage: device.spec?.os?.image,
+          osImage: device.spec?.os?.image || '',
           labels: fromAPILabel(device.metadata.labels || {}).filter((label) => label.key !== 'alias'),
           configTemplates: getConfigTemplatesValues(device.spec, registerMicroShift),
           fleetMatch: '', // Initially this is always a fleetless device
@@ -105,6 +105,11 @@ const EditDeviceWizard = () => {
                 className="fctl-edit-device__wizard"
                 footer={<EditDeviceWizardFooter />}
                 nav={<EditDeviceWizardNav />}
+                onStepChange={() => {
+                  if (submitError) {
+                    setSubmitError(undefined);
+                  }
+                }}
               >
                 <WizardStep name={t('General info')} id={generalInfoStepId}>
                   <GeneralInfoStep />

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/utils.ts
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/utils.ts
@@ -35,7 +35,8 @@ export const getDevicePatches = (currentDevice: Device, updatedDevice: EditDevic
 
   // Device labels
   const currentLabels = currentDevice.metadata.labels || {};
-  const updatedLabels = updatedDevice.labels || [];
+  const updatedLabels = [...updatedDevice.labels];
+
   if (updatedDevice.deviceAlias) {
     updatedLabels.push({ key: 'alias', value: updatedDevice.deviceAlias });
   }

--- a/libs/ui-components/src/components/Fleet/CreateFleet/CreateFleetWizard.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/CreateFleetWizard.tsx
@@ -92,7 +92,12 @@ const CreateFleetWizard = () => {
               <LeaveFormConfirmation />
               <Wizard
                 footer={<CreateFleetWizardFooter isEdit={isEdit} />}
-                onStepChange={(_, step) => setCurrentStep(step)}
+                onStepChange={(_, step) => {
+                  if (error) {
+                    setError(undefined);
+                  }
+                  setCurrentStep(step);
+                }}
                 className="fctl-create-fleet"
               >
                 <WizardStep name={t('General info')} id={generalInfoStepId}>


### PR DESCRIPTION
If the user attempts to make some changes in the Device/Fleet wizard, but it fails due to an API error, the error stayed visible even after the user moves to the previous steps and even if they fix the issue.

When the user moves to another step, the error should be cleared.