### PR TITLE
EDM-1009: Hide terminal tab if user does not have permissions

### DIFF
--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsPage.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsPage.tsx
@@ -33,6 +33,7 @@ const DeviceDetailsPage = ({ children, hideTerminal }: React.PropsWithChildren<{
 
   const [canDelete] = useAccessReview(RESOURCE.DEVICE, VERB.DELETE);
   const [canEdit] = useAccessReview(RESOURCE.DEVICE, VERB.PATCH);
+  const [canOpenTerminal] = useAccessReview(RESOURCE.DEVICE_CONSOLE, VERB.GET);
 
   const { deleteAction, deleteModal } = useDeleteAction({
     onDelete: async () => {
@@ -64,7 +65,7 @@ const DeviceDetailsPage = ({ children, hideTerminal }: React.PropsWithChildren<{
         <Nav variant="tertiary">
           <NavList>
             <NavItem to="details">{t('Details')}</NavItem>
-            <NavItem to="terminal">{t('Terminal')}</NavItem>
+            {!hideTerminal && canOpenTerminal && <NavItem to="terminal">{t('Terminal')}</NavItem>}
           </NavList>
         </Nav>
       }
@@ -102,7 +103,7 @@ const DeviceDetailsPage = ({ children, hideTerminal }: React.PropsWithChildren<{
               </DeviceDetailsTab>
             }
           />
-          {!hideTerminal && <Route path="terminal" element={<TerminalTab device={device} />} />}
+          {!hideTerminal && canOpenTerminal && <Route path="terminal" element={<TerminalTab device={device} />} />}
         </Routes>
       )}
       {deleteModal}

--- a/libs/ui-components/src/components/Device/DeviceDetails/TerminalTab.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/TerminalTab.tsx
@@ -6,8 +6,15 @@ import { useWebSocket } from '../../../hooks/useWebSocket';
 import ErrorAlert from '../../ErrorAlert/ErrorAlert';
 import { useTranslation } from '../../../hooks/useTranslation';
 import Terminal, { ImperativeTerminalType } from '../../Terminal/Terminal';
+import PageWithPermissions from '../../common/PageWithPermissions';
+import { useAccessReview } from '../../../hooks/useAccessReview';
+import { RESOURCE, VERB } from '../../../types/rbac';
 
-const TerminalTab = ({ device }: { device: Device }) => {
+type TerminalTabProps = {
+  device: Device;
+};
+
+const TerminalTab = ({ device }: TerminalTabProps) => {
   const { t } = useTranslation();
   const terminal = React.useRef<ImperativeTerminalType>(null);
 
@@ -51,4 +58,13 @@ const TerminalTab = ({ device }: { device: Device }) => {
   );
 };
 
-export default TerminalTab;
+const TerminalTabWithPermissions = (props: TerminalTabProps) => {
+  const [allowed, loading] = useAccessReview(RESOURCE.DEVICE_CONSOLE, VERB.GET);
+  return (
+    <PageWithPermissions allowed={allowed} loading={loading}>
+      <TerminalTab {...props} />
+    </PageWithPermissions>
+  );
+};
+
+export default TerminalTabWithPermissions;

--- a/libs/ui-components/src/types/rbac.ts
+++ b/libs/ui-components/src/types/rbac.ts
@@ -10,6 +10,7 @@ export enum VERB {
 export enum RESOURCE {
   FLEET = 'fleets',
   DEVICE = 'devices',
+  DEVICE_CONSOLE = 'devices/console',
   REPOSITORY = 'repositories',
   RESOURCE_SYNC = 'resourcesyncs',
   ENROLLMENT_REQUEST = 'enrollmentrequests',


### PR DESCRIPTION
requires https://github.com/flightctl/flightctl/pull/763

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added permission-based access control for device terminal functionality
	- Implemented access review checks before displaying terminal options
	- Enhanced security by restricting terminal access based on user permissions

- **Improvements**
	- Improved type safety for terminal-related components
	- Added more granular control over terminal navigation and routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->