### PR TITLE
EDM-1006 Force API to produce only exact label matches

### DIFF
--- a/libs/ui-components/src/components/Fleet/CreateFleet/steps/DeviceLabelSelector.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/steps/DeviceLabelSelector.tsx
@@ -12,7 +12,7 @@ import { useFetch } from '../../../../hooks/useFetch';
 import { FlightCtlLabel } from '../../../../types/extraTypes';
 import { getApiListCount } from '../../../../utils/api';
 import { getErrorMessage } from '../../../../utils/error';
-import { labelToString } from '../../../../utils/labels';
+import { labelToExactApiMatchString } from '../../../../utils/labels';
 
 const validateLabels = (labels: FlightCtlLabel[]) =>
   hasUniqueLabelKeys(labels) && getInvalidKubernetesLabels(labels).length === 0;
@@ -27,7 +27,7 @@ const DeviceLabelSelector = () => {
   const [deviceCount, setDeviceCount] = React.useState<number>(0);
 
   const updateDeviceCount = async (matchLabels: FlightCtlLabel[]) => {
-    const labelSelector = matchLabels.map(labelToString);
+    const labelSelector = matchLabels.map(labelToExactApiMatchString);
 
     try {
       const deviceListResp = await get<DeviceList>(`devices?labelSelector=${labelSelector.join(',')}&limit=1`);

--- a/libs/ui-components/src/utils/labels.ts
+++ b/libs/ui-components/src/utils/labels.ts
@@ -22,6 +22,9 @@ export const toAPILabel = (labels: FlightCtlLabel[]): Record<string, string> =>
     {} as Record<string, string>,
   );
 
+// Used to force the API to perform an exact match check for labels
+export const labelToExactApiMatchString = (label: FlightCtlLabel) => `${label.key}=${label.value || ''}`;
+
 export const labelToString = (label: FlightCtlLabel) => `${label.key}${label.value ? `=${label.value}` : ''}`;
 
 export const stringToLabel = (labelStr: string): FlightCtlLabel => {
@@ -30,11 +33,4 @@ export const stringToLabel = (labelStr: string): FlightCtlLabel => {
     key: labelParts[0],
     value: labelParts.length > 1 ? labelParts[1] : undefined,
   };
-};
-
-export const filterDevicesLabels = (allLabels: FlightCtlLabel[], selectedLabels: FlightCtlLabel[], filter: string) => {
-  const filteredLabels = [...new Set(allLabels.concat(selectedLabels).map(labelToString))]
-    .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })) // ignore case
-    .filter((label) => label.includes(filter));
-  return filteredLabels;
 };


### PR DESCRIPTION
With the latest changes in the API for filtering, the Typeahead for searching for labels was not behaving correctly.

When typing "test" (without the equal sign), the API falls back to partial matching on label keys. To prevent the inconsistencies with having only exact match for values and partial match for keys, we change the query to only do exact matching of labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced label matching logic to support more precise API queries
	- Improved label processing for device and fleet label selections

- **Refactor**
	- Updated label utility functions to provide more exact matching capabilities
	- Removed previous label filtering method

- **Bug Fixes**
	- Improved handling of label matches to extract more accurate results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->