### PR TITLE
Fix intercept for enrollment requests

### DIFF
--- a/libs/cypress/support/interceptors/enrollmentRequests.ts
+++ b/libs/cypress/support/interceptors/enrollmentRequests.ts
@@ -15,7 +15,7 @@ const loadInterceptors = () => {
     });
   }).as('all-enrollment-requests');
 
-  cy.intercept('GET', '/api/flightctl/api/v1/enrollmentrequests?fieldSelector=!status.approval.approved*', (req) => {
+  cy.intercept('GET', '/api/flightctl/api/v1/enrollmentrequests?fieldSelector=*', (req) => {
     req.reply({
       body: buildErResponse(getErList(true)),
     });

--- a/libs/types/models/ApplicationEnvVars.ts
+++ b/libs/types/models/ApplicationEnvVars.ts
@@ -4,7 +4,7 @@
 /* eslint-disable */
 export type ApplicationEnvVars = {
   /**
-   * Environment variable key-value pairs, injected during runtime.
+   * Environment variable key-value pairs, injected during runtime. The key and value each must be between 1 and 253 characters.
    */
   envVars?: Record<string, string>;
 };

--- a/libs/types/models/ApplicationSpec.ts
+++ b/libs/types/models/ApplicationSpec.ts
@@ -6,7 +6,7 @@ import type { ApplicationEnvVars } from './ApplicationEnvVars';
 import type { ImageApplicationProvider } from './ImageApplicationProvider';
 export type ApplicationSpec = (ApplicationEnvVars & {
   /**
-   * The name of the application.
+   * The name of the application must be between 1 and 253 characters and start with a letter or number.
    */
   name?: string;
 } & ImageApplicationProvider);

--- a/libs/types/models/DeviceSpec.ts
+++ b/libs/types/models/DeviceSpec.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 import type { ApplicationSpec } from './ApplicationSpec';
 import type { ConfigProviderSpec } from './ConfigProviderSpec';
+import type { DeviceDecommission } from './DeviceDecommission';
 import type { DeviceOsSpec } from './DeviceOsSpec';
 import type { DeviceUpdatePolicySpec } from './DeviceUpdatePolicySpec';
 import type { ResourceMonitor } from './ResourceMonitor';
@@ -34,5 +35,6 @@ export type DeviceSpec = {
    * Array of resource monitor configurations.
    */
   resources?: Array<ResourceMonitor>;
+  decommissioning?: DeviceDecommission;
 };
 


### PR DESCRIPTION
The request is sometimes created using URLSearchParams and others not, which changes the request due to encoding.

Might be best to soon build all requests using URLSearchParams as discussed previously.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated request interceptor to improve handling of enrollment request data during testing.
	- Expanded request matching criteria to capture a broader range of enrollment request scenarios.

- **Documentation**
	- Enhanced comments for `envVars` property in `ApplicationEnvVars` to specify key and value length constraints.
	- Updated documentation for `name` property in `ApplicationSpec` to clarify naming requirements.

- **New Features**
	- Introduced a new optional `decommissioning` property in `DeviceSpec` to specify device decommissioning details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->