### PR TITLE
EDM-971: Accept forward slash in the OS image regexp

### DIFF
--- a/libs/ui-components/src/components/form/validations.ts
+++ b/libs/ui-components/src/components/form/validations.ts
@@ -34,8 +34,8 @@ const K8S_DNS_SUBDOMAIN_ALLOWED_CHARACTERS = /^[a-z0-9.-]*$/;
 const K8S_DNS_SUBDOMAIN_VALUE_MAX_LENGTH = 253;
 
 // https://issues.redhat.com/browse/MGMT-18349 to make the validation more robust
-const BASIC_DEVICE_OS_IMAGE_REGEXP = /^[a-zA-Z0-9.\-:@_+]*$/;
-const BASIC_FLEET_OS_IMAGE_REGEXP = /^[a-zA-Z0-9.\-:@_+{}\s]*$/;
+const BASIC_DEVICE_OS_IMAGE_REGEXP = /^[a-zA-Z0-9.\-\/:@_+]*$/;
+const BASIC_FLEET_OS_IMAGE_REGEXP = /^[a-zA-Z0-9.\-\/:@_+{}\s]*$/;
 
 const absolutePathRegex = /^\/.*$/;
 export const MAX_TARGET_REVISION_LENGTH = 244;


### PR DESCRIPTION
Forward slashes should be accepted for OS images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated OS image validation to allow forward slashes in image names, improving compatibility with various naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->