### PR TITLE
EDM-997: Ensure Http config repository is filled

### DIFF
--- a/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ConfigWithRepositoryTemplateForm.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ConfigWithRepositoryTemplateForm.tsx
@@ -190,6 +190,7 @@ const ConfigWithRepositoryTemplateForm = ({
         <FormSelect
           name={`configTemplates[${index}].repository`}
           items={repositoryItems}
+          withStatusIcon
           placeholderText={t('Select a repository')}
         >
           {canCreateRepo && (

--- a/libs/ui-components/src/components/form/FormSelect.tsx
+++ b/libs/ui-components/src/components/form/FormSelect.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { FormGroup, MenuToggle, Select, SelectList, SelectOption } from '@patternfly/react-core';
+import { FormGroup, MenuToggle, MenuToggleStatus, Select, SelectList, SelectOption } from '@patternfly/react-core';
 import { useField } from 'formik';
 import ErrorHelperText, { DefaultHelperText } from './FieldHelperText';
 
@@ -14,13 +14,21 @@ type FormSelectProps = {
   helperText?: React.ReactNode;
   children?: React.ReactNode;
   placeholderText?: string;
+  withStatusIcon?: boolean;
 };
 
 const isItemObject = (item: string | SelectItem): item is SelectItem => typeof item === 'object';
 
 const getItemLabel = (item: string | SelectItem) => (isItemObject(item) ? item.label : item);
 
-const FormSelect: React.FC<FormSelectProps> = ({ name, items, helperText, placeholderText, children }) => {
+const FormSelect: React.FC<FormSelectProps> = ({
+  name,
+  items,
+  withStatusIcon,
+  helperText,
+  placeholderText,
+  children,
+}) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const [field, meta, { setValue, setTouched }] = useField<string>({
     name: name,
@@ -38,6 +46,17 @@ const FormSelect: React.FC<FormSelectProps> = ({ name, items, helperText, placeh
 
   const selectedText = field.value ? getItemLabel(items[field.value]) : placeholderText;
 
+  let statusToggle: MenuToggleStatus;
+  if (withStatusIcon) {
+    if (field.value) {
+      statusToggle = MenuToggleStatus.success;
+    } else if (meta.touched) {
+      statusToggle = MenuToggleStatus.danger;
+    } else {
+      statusToggle = MenuToggleStatus.warning;
+    }
+  }
+
   return (
     <FormGroup id={`form-control__${fieldId}`} fieldId={fieldId}>
       <Select
@@ -49,6 +68,7 @@ const FormSelect: React.FC<FormSelectProps> = ({ name, items, helperText, placeh
         }}
         toggle={(toggleRef) => (
           <MenuToggle
+            status={statusToggle}
             ref={toggleRef}
             onClick={() => {
               if (isOpen && !meta.touched) {

--- a/libs/ui-components/src/components/form/validations.ts
+++ b/libs/ui-components/src/components/form/validations.ts
@@ -315,6 +315,7 @@ export const validConfigTemplatesSchema = (t: TFunction) =>
         } else if (isHttpConfigTemplate(value)) {
           return Yup.object<HttpConfigTemplate>().shape({
             type: Yup.string().required(t('Source type is required.')),
+            repository: Yup.string().required(t('Repository is required.')),
             name: validKubernetesDnsSubdomain(t, { isRequired: true }),
             filePath: Yup.string()
               .required(t('File path is required.'))


### PR DESCRIPTION
The repository of a http config was not being handled correctly as a required parameter.

I added  a status icon given that otherwise it's easy to miss that the repository is missing if the field hasn't been touched by the user. (Requires PF update which is done in a separate PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added status icon option to repository selection form.
  - Enhanced form validation for repository configuration.

- **Bug Fixes**
  - Ensured repository field is required for HTTP configuration templates.

- **User Interface**
  - Improved visual feedback for repository selection state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->