### PR TITLE
EDM-1028: Improve security for API queries accepting user input

### DIFF
--- a/libs/ui-components/src/components/Fleet/CreateFleet/steps/DeviceLabelSelector.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/steps/DeviceLabelSelector.tsx
@@ -12,7 +12,7 @@ import { useFetch } from '../../../../hooks/useFetch';
 import { FlightCtlLabel } from '../../../../types/extraTypes';
 import { getApiListCount } from '../../../../utils/api';
 import { getErrorMessage } from '../../../../utils/error';
-import { labelToExactApiMatchString } from '../../../../utils/labels';
+import { commonQueries } from '../../../../utils/query';
 
 const validateLabels = (labels: FlightCtlLabel[]) =>
   hasUniqueLabelKeys(labels) && getInvalidKubernetesLabels(labels).length === 0;
@@ -27,10 +27,10 @@ const DeviceLabelSelector = () => {
   const [deviceCount, setDeviceCount] = React.useState<number>(0);
 
   const updateDeviceCount = async (matchLabels: FlightCtlLabel[]) => {
-    const labelSelector = matchLabels.map(labelToExactApiMatchString);
-
     try {
-      const deviceListResp = await get<DeviceList>(`devices?labelSelector=${labelSelector.join(',')}&limit=1`);
+      const deviceListResp = await get<DeviceList>(
+        commonQueries.getDevicesWithExactLabelMatching(matchLabels, { limit: 1 }),
+      );
       const num = getApiListCount(deviceListResp);
       setDeviceCount(num || 0);
     } catch (e) {

--- a/libs/ui-components/src/components/Repository/RepositoryDetails/DeleteRepositoryModal.tsx
+++ b/libs/ui-components/src/components/Repository/RepositoryDetails/DeleteRepositoryModal.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import { useEffect } from 'react';
 import { Alert, Button, Modal, Spinner, Stack, StackItem, Text, TextContent } from '@patternfly/react-core';
+import { Trans } from 'react-i18next';
+
+import { ResourceSyncList } from '@flightctl/types';
 
 import { getErrorMessage } from '../../../utils/error';
+import { commonQueries } from '../../../utils/query';
 import { useFetch } from '../../../hooks/useFetch';
-import { ResourceSyncList } from '@flightctl/types';
-import { Trans } from 'react-i18next';
 import { useTranslation } from '../../../hooks/useTranslation';
 
 type DeleteRepositoryModalProps = {
@@ -46,7 +48,7 @@ const DeleteRepositoryModal = ({ repositoryId, onClose, onDeleteSuccess }: Delet
 
   const loadRS = React.useCallback(async () => {
     try {
-      const resourceSyncs = await get<ResourceSyncList>(`resourcesyncs?fieldSelector=spec.repository=${repositoryId}`);
+      const resourceSyncs = await get<ResourceSyncList>(commonQueries.getResourceSyncsByRepo(repositoryId));
       setResourceSyncIds(resourceSyncs.items.map((rs) => rs.metadata.name || ''));
       setRsError(undefined);
     } catch (e) {

--- a/libs/ui-components/src/components/Repository/useRepositories.ts
+++ b/libs/ui-components/src/components/Repository/useRepositories.ts
@@ -13,8 +13,7 @@ type RepositoriesEndpointArgs = {
 };
 
 const getRepositoriesEndpoint = ({ nextContinue }: RepositoriesEndpointArgs) => {
-  const params = new URLSearchParams({});
-
+  const params = new URLSearchParams();
   if (nextContinue !== undefined) {
     params.set('limit', `${PAGE_SIZE}`);
   }

--- a/libs/ui-components/src/components/ResourceSync/RepositoryResourceSyncList.tsx
+++ b/libs/ui-components/src/components/ResourceSync/RepositoryResourceSyncList.tsx
@@ -35,6 +35,7 @@ import ResourceSyncStatus from './ResourceSyncStatus';
 import { useTranslation } from '../../hooks/useTranslation';
 import { useAppContext } from '../../hooks/useAppContext';
 import { getErrorMessage } from '../../utils/error';
+import { commonQueries } from '../../utils/query';
 
 import {
   SingleResourceSyncValues,
@@ -168,7 +169,7 @@ const CreateResourceSyncModal = ({
 
 const RepositoryResourceSyncList = ({ repositoryId }: { repositoryId: string }) => {
   const [rsList, isLoading, error, refetch] = useFetchPeriodically<ResourceSyncList>({
-    endpoint: `resourcesyncs?fieldSelector=spec.repository=${repositoryId}`,
+    endpoint: commonQueries.getResourceSyncsByRepo(repositoryId),
   });
 
   const resourceSyncs = rsList?.items || [];

--- a/libs/ui-components/src/components/modals/massModals/MassDeleteRepositoryModal/MassDeleteRepositoryModal.tsx
+++ b/libs/ui-components/src/components/modals/massModals/MassDeleteRepositoryModal/MassDeleteRepositoryModal.tsx
@@ -1,12 +1,15 @@
-import { useFetch } from '../../../../hooks/useFetch';
-import { getErrorMessage } from '../../../../utils/error';
+import * as React from 'react';
 import { Alert, Button, Modal, Progress, ProgressMeasureLocation, Stack, StackItem } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+
 import { Repository, ResourceSyncList } from '@flightctl/types';
-import * as React from 'react';
+
+import { useFetch } from '../../../../hooks/useFetch';
+import { getErrorMessage } from '../../../../utils/error';
 import { useTranslation } from '../../../../hooks/useTranslation';
 import { isPromiseRejected } from '../../../../types/typeUtils';
 import { getApiListCount } from '../../../../utils/api';
+import { commonQueries } from '../../../../utils/query';
 
 type MassDeleteRepositoryModalProps = {
   onClose: VoidFunction;
@@ -38,7 +41,7 @@ const MassDeleteRepositoryModal: React.FC<MassDeleteRepositoryModalProps> = ({
     const promises = repositories.map(async (r) => {
       const repositoryId = r.metadata.name || '';
       const resourceSyncs = await get<ResourceSyncList>(
-        `resourcesyncs?fieldSelector=spec.repository=${repositoryId}&limit=1`,
+        commonQueries.getResourceSyncsByRepo(repositoryId, { limit: 1 }),
       );
       rsCount[repositoryId] = getApiListCount(resourceSyncs);
     });
@@ -53,7 +56,7 @@ const MassDeleteRepositoryModal: React.FC<MassDeleteRepositoryModalProps> = ({
     setProgress(0);
     const promises = repositories.map(async (r) => {
       const repositoryId = r.metadata.name || '';
-      const resourceSyncs = await get<ResourceSyncList>(`resourcesyncs?fieldSelector=spec.repository=${repositoryId}`);
+      const resourceSyncs = await get<ResourceSyncList>(commonQueries.getResourceSyncsByRepo(repositoryId));
       const rsyncPromises = resourceSyncs.items.map((rsync) => remove(`resourcesyncs/${rsync.metadata.name}`));
       const rsyncResults = await Promise.allSettled(rsyncPromises);
       const rejectedResults = rsyncResults.filter(isPromiseRejected);

--- a/libs/ui-components/src/utils/query.ts
+++ b/libs/ui-components/src/utils/query.ts
@@ -1,4 +1,5 @@
 import { FlightCtlLabel } from '../types/extraTypes';
+import { labelToExactApiMatchString } from './labels';
 
 const addQueryConditions = (fieldSelectors: string[], fieldSelector: string, values?: string[]) => {
   if (values?.length === 1) {
@@ -24,6 +25,46 @@ const setLabelParams = (params: URLSearchParams, labels?: FlightCtlLabel[]) => {
     }, '');
     params.append('labelSelector', labelSelector);
   }
+};
+
+type CommonQueryOptions = {
+  limit: number | undefined;
+};
+
+export const commonQueries = {
+  // We can't specify a sorting, as every entity has a default sorting which is always applied implicitly.
+  getDevicesWithExactLabelMatching: (labels: FlightCtlLabel[], options?: CommonQueryOptions) => {
+    const searchParams = new URLSearchParams();
+
+    // By default (without the "equal" sign), the API returns a partial match, but only on the label keys
+    // To prevent this confusing behaviour, we query for exact matches in all cases (for both keys and values)
+    const exactLabelsMatch = labels.map(labelToExactApiMatchString).join(',');
+    searchParams.set('labelSelector', exactLabelsMatch);
+
+    if (options?.limit) {
+      searchParams.set('limit', `${options.limit}`);
+    }
+    return `devices?${searchParams.toString()}`;
+  },
+  getFleetsWithNameMatching: (matchName: string, options?: CommonQueryOptions) => {
+    const searchParams = new URLSearchParams();
+    searchParams.set('fieldSelector', `metadata.name contains ${matchName}`);
+
+    if (options?.limit) {
+      searchParams.set('limit', `${options.limit}`);
+    }
+    return `fleets?${searchParams.toString()}`;
+  },
+  getResourceSyncsByRepo: (repositoryId: string, options?: CommonQueryOptions) => {
+    const searchParams = new URLSearchParams();
+    searchParams.set('fieldSelector', `spec.repository=${repositoryId}`);
+
+    if (options?.limit) {
+      searchParams.set('limit', `${options.limit}`);
+    }
+    return `resourcesyncs?${searchParams.toString()}`;
+  },
+  getRepositoryById: (repositoryId: string) => `repositories/${repositoryId}`,
 };
 
 export { addQueryConditions, addTextContainsCondition, setLabelParams };

--- a/libs/ui-components/src/utils/search.ts
+++ b/libs/ui-components/src/utils/search.ts
@@ -1,7 +1,7 @@
 import fuzzy from 'fuzzysearch';
 
 // Must be an even number for "getSearchResultsCount" to work
-const MAX_TOTAL_SEARCH_RESULTS = 10;
+export const MAX_TOTAL_SEARCH_RESULTS = 10;
 
 export const fuzzySeach = (filter: string | undefined, value?: string): boolean => {
   if (!filter) {


### PR DESCRIPTION
Whenever there's some user input which we use to build an API query, we will use `URLSearchParams`.

Also, this PR unifies the calls for the same request in a single function, so that we don't DRY and that's easier to maintain when the API calls need to change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced centralized query methods for more efficient data fetching across various components
	- Enhanced search and filtering capabilities for devices, fleets, and repositories

- **Improvements**
	- Streamlined API endpoint construction
	- Improved modularity of query-related utilities
	- Added more flexible search result limit options

- **Technical Updates**
	- Refactored import statements and query logic in multiple UI components
	- Exported additional utility constants for search functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->