### PR TITLE
Add back libs/ansible name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -241,6 +241,7 @@
       }
     },
     "libs/ansible": {
+      "name": "@flightctl/ansible",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
For some reason, previously the "name" for the libs/ansible dependency had been deleted.

I'm checking the dependencies again, and its being populated if installing everything from a clean repo.