### PR TITLE
EDM-1033: Do not set username when approving ER

### DIFF
--- a/libs/types/index.ts
+++ b/libs/types/index.ts
@@ -54,6 +54,7 @@ export type { Duration } from './models/Duration';
 export type { EnrollmentConfig } from './models/EnrollmentConfig';
 export type { EnrollmentRequest } from './models/EnrollmentRequest';
 export type { EnrollmentRequestApproval } from './models/EnrollmentRequestApproval';
+export type { EnrollmentRequestApprovalStatus } from './models/EnrollmentRequestApprovalStatus';
 export type { EnrollmentRequestList } from './models/EnrollmentRequestList';
 export type { EnrollmentRequestSpec } from './models/EnrollmentRequestSpec';
 export type { EnrollmentRequestStatus } from './models/EnrollmentRequestStatus';

--- a/libs/types/models/EnrollmentRequestApproval.ts
+++ b/libs/types/models/EnrollmentRequestApproval.ts
@@ -14,13 +14,5 @@ export type EnrollmentRequestApproval = {
    * Indicates whether the request has been approved.
    */
   approved: boolean;
-  /**
-   * The name of the approver.
-   */
-  approvedBy?: string;
-  /**
-   * The time at which the request was approved.
-   */
-  approvedAt?: string;
 };
 

--- a/libs/types/models/EnrollmentRequestApprovalStatus.ts
+++ b/libs/types/models/EnrollmentRequestApprovalStatus.ts
@@ -1,0 +1,16 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { EnrollmentRequestApproval } from './EnrollmentRequestApproval';
+export type EnrollmentRequestApprovalStatus = (EnrollmentRequestApproval & {
+  /**
+   * The name of the approver.
+   */
+  approvedBy: string;
+  /**
+   * The time at which the request was approved.
+   */
+  approvedAt: string;
+});
+

--- a/libs/types/models/EnrollmentRequestStatus.ts
+++ b/libs/types/models/EnrollmentRequestStatus.ts
@@ -3,7 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { Condition } from './Condition';
-import type { EnrollmentRequestApproval } from './EnrollmentRequestApproval';
+import type { EnrollmentRequestApprovalStatus } from './EnrollmentRequestApprovalStatus';
 /**
  * EnrollmentRequestStatus represents information about the status of a EnrollmentRequest.
  */
@@ -16,6 +16,6 @@ export type EnrollmentRequestStatus = {
    * Current state of the EnrollmentRequest.
    */
   conditions: Array<Condition>;
-  approval?: EnrollmentRequestApproval;
+  approval?: EnrollmentRequestApprovalStatus;
 };
 

--- a/libs/ui-components/src/components/modals/ApproveDeviceModal/ApproveDeviceModal.tsx
+++ b/libs/ui-components/src/components/modals/ApproveDeviceModal/ApproveDeviceModal.tsx
@@ -14,7 +14,6 @@ import { useTranslation } from '../../../hooks/useTranslation';
 import { deviceApprovalValidationSchema } from '../../form/validations';
 
 import { fromAPILabel, toAPILabel } from '../../../utils/labels';
-import { useAppContext } from '../../../hooks/useAppContext';
 
 type DeviceEnrollmentModalProps = Omit<ApproveDeviceFormProps, 'error'>;
 
@@ -22,7 +21,6 @@ const DeviceEnrollmentModal: React.FC<DeviceEnrollmentModalProps> = ({ enrollmen
   const { t } = useTranslation();
   const { put } = useFetch();
   const [error, setError] = React.useState<string>();
-  const { user } = useAppContext();
   return (
     <Formik<ApproveDeviceFormValues>
       initialValues={{
@@ -41,7 +39,6 @@ const DeviceEnrollmentModal: React.FC<DeviceEnrollmentModalProps> = ({ enrollmen
           await put<EnrollmentRequestApproval>(`enrollmentrequests/${enrollmentRequest.metadata.name}/approval`, {
             approved: true,
             labels: deviceLabels,
-            approvedBy: user,
           });
           onClose(true);
         } catch (e) {

--- a/libs/ui-components/src/components/modals/massModals/MassApproveDeviceModal/MassApproveDeviceModal.tsx
+++ b/libs/ui-components/src/components/modals/massModals/MassApproveDeviceModal/MassApproveDeviceModal.tsx
@@ -49,7 +49,6 @@ const MassApproveDeviceModal: React.FC<MassApproveDeviceModalProps> = ({
   const [totalProgress, setTotalProgress] = React.useState(0);
   const [errors, setErrors] = React.useState<string[]>();
   const {
-    user,
     fetch: { put },
   } = useAppContext();
 
@@ -66,7 +65,6 @@ const MassApproveDeviceModal: React.FC<MassApproveDeviceModalProps> = ({
       await put<EnrollmentRequestApproval>(`enrollmentrequests/${r.metadata.name}/approval`, {
         approved: true,
         labels,
-        approvedBy: user,
       });
       setProgress((p) => p + 1);
     });


### PR DESCRIPTION
Based on https://github.com/flightctl/flightctl/pull/788

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Type Changes**
	- Updated `EnrollmentRequestStatus` to use a new `EnrollmentRequestApprovalStatus` type
	- Removed `approvedBy` and `approvedAt` properties from `EnrollmentRequestApproval`

- **Approval Process Modification**
	- Removed user-specific approval tracking from device enrollment modals
	- Simplified approval request payload

These changes appear to refactor the enrollment request approval type and remove explicit user tracking from the approval process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->