### PR TITLE
EDM-944: Inline config content is optional

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -346,7 +346,6 @@
   "Secret namespace is required.": "Secret namespace is required.",
   "File path must be absolute.": "File path must be absolute.",
   "File path must be unique.": "File path must be unique.",
-  "File content is required.": "File content is required.",
   "The maximum number of systemd units is {{maxSystemUnits}}.": "The maximum number of systemd units is {{maxSystemUnits}}.",
   "Invalid systemd service names: {{invalidPatterns}}": "Invalid systemd service names: {{invalidPatterns}}",
   "Systemd service names must be unique": "Systemd service names must be unique",

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ConfigInlineTemplateForm.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ConfigInlineTemplateForm.tsx
@@ -49,12 +49,7 @@ const FileForm = ({ fieldName, index }: { fieldName: string; index: number }) =>
         <FormGroup label={t('File path on the device')} isRequired>
           <TextField name={`${fieldName}.path`} />
         </FormGroup>
-        <UploadField
-          label={t('Content')}
-          name={`${fieldName}.content`}
-          maxFileBytes={MAX_INLINE_FILE_SIZE_BYTES}
-          isRequired
-        />
+        <UploadField label={t('Content')} name={`${fieldName}.content`} maxFileBytes={MAX_INLINE_FILE_SIZE_BYTES} />
         <FormGroup>
           <CheckboxField name={`${fieldName}.base64`} label={t('Content is base64 encoded')} />
         </FormGroup>

--- a/libs/ui-components/src/components/form/validations.ts
+++ b/libs/ui-components/src/components/form/validations.ts
@@ -346,7 +346,7 @@ export const validConfigTemplatesSchema = (t: TFunction) =>
                     t('File path must be unique.'),
                     (path) => !path || value.files.filter((file) => file.path === path).length == 1,
                   ),
-                content: Yup.string().required(t('File content is required.')),
+                content: Yup.string(),
               }),
             ),
           });


### PR DESCRIPTION
Content of inline config files is optional, make it so in the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Removed mandatory file content requirement in file upload and configuration forms

- **Bug Fixes**
	- Updated validation logic to allow optional file content

- **Documentation**
	- Removed translation for "File content is required" message

The changes make file uploads more flexible by allowing submissions without mandatory content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->