### PR TITLE
EDM-1020 OS image help text

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -226,7 +226,7 @@
   "System image": "System image",
   "The target system image for this fleet's devices.": "The target system image for this fleet's devices.",
   "The target system image for this device.": "The target system image for this device.",
-  "Must be either an OCI image ref (e.g. \"quay.io/redhat/rhde:9.3\") or ostree ref (e.g. \"https://ostree.fedoraproject.org/iot?ref=fedora/stable/x86_64/iot\"). Keep this empty if you do not want to manage your OS from Flight Control.": "Must be either an OCI image ref (e.g. \"quay.io/redhat/rhde:9.3\") or ostree ref (e.g. \"https://ostree.fedoraproject.org/iot?ref=fedora/stable/x86_64/iot\"). Keep this empty if you do not want to manage your OS from Flight Control.",
+  "Must be a reference to a bootable container image (e.g. \"quay.io/<my-org>/my-rhel-with-fc-agent:<version>\"). When left empty, the device's existing OS will be kept unchanged.": "Must be a reference to a bootable container image (e.g. \"quay.io/<my-org>/my-rhel-with-fc-agent:<version>\"). When left empty, the device's existing OS will be kept unchanged.",
   "Tracked systemd services": "Tracked systemd services",
   "Device labels": "Device labels",
   "Unnamed": "Unnamed",

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/steps/DeviceTemplateStep.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/steps/DeviceTemplateStep.tsx
@@ -148,7 +148,7 @@ const DeviceTemplateStep = ({ isFleet }: { isFleet: boolean }) => {
             aria-label={t('System image')}
             value={values.osImage}
             helperText={t(
-              'Must be either an OCI image ref (e.g. "quay.io/redhat/rhde:9.3") or ostree ref (e.g. "https://ostree.fedoraproject.org/iot?ref=fedora/stable/x86_64/iot"). Keep this empty if you do not want to manage your OS from Flight Control.',
+              'Must be a reference to a bootable container image (e.g. "quay.io/<my-org>/my-rhel-with-fc-agent:<version>"). When left empty, the device\'s existing OS will be kept unchanged.',
             )}
           />
         </FormGroup>


### PR DESCRIPTION
- Remove the reference to Flight Control
- Remove the invalid ostree example, it's not even supported yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Documentation**
  - Updated translation strings to clarify OS image reference requirements
  - Improved guidance for device template OS image input

- **Refactor**
  - Simplified enrollment request approval type definitions
  - Removed redundant `EnrollmentRequestApprovalStatus` type

- **New Features**
  - Added optional `approvedBy` and `approvedAt` properties to enrollment request approval tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->