### PR TITLE
Make the Add label button inline to avoid extra space

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,9 +96,3 @@ jobs:
           start: npm run integration-tests:ci
           wait-on: 'http://localhost:9000'
           wait-on-timeout: 60
-      - name: Store test execution screenshots on failure
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: cypress-screenshots
-          path: cypress/screenshots

--- a/libs/ui-components/src/components/common/EditableLabelControl.tsx
+++ b/libs/ui-components/src/components/common/EditableLabelControl.tsx
@@ -55,6 +55,8 @@ const EditableLabelControl = ({
   ) : (
     <Button
       variant="link"
+      className="pf-v5-u-ml-xs"
+      isInline
       isDisabled={!isEditable}
       onClick={() => {
         setIsEditing(true);


### PR DESCRIPTION
The button for "Add label" / "Add system service" has an extra padding which is more noticeable when the list is empty.
Making the button inline removes the extra padding.
![add-label-button](https://github.com/user-attachments/assets/4076574e-b97c-4d96-963b-a90d9b16b9fd)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added an inline display option for the editable label control button, providing more flexible layout configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->