### PR TITLE
EDM-1139: Always set a default successThreshold for a new batch

### DIFF
--- a/libs/ui-components/src/components/Fleet/CreateFleet/fleetSpecUtils.ts
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/fleetSpecUtils.ts
@@ -4,7 +4,21 @@ import { BatchLimitType } from './types';
 import { fromAPILabel } from '../../../utils/labels';
 
 const DEFAULT_BACKEND_UPDATE_TIMEOUT = '1140m'; // 24h, expressed in minutes
-const DEFAULT_BACKEND_SUCCESS_THRESHOLD = '90%';
+const DEFAULT_BACKEND_SUCCESS_THRESHOLD_PERCENTAGE = '90%';
+
+const numberValue = (value: Percentage | number | undefined) => {
+  if (value === undefined || typeof value === 'number') {
+    return value;
+  }
+  return Number(value.replace(/[%]/, ''));
+};
+
+export const getEmptyInitializedBatch = () => ({
+  limit: '',
+  limitType: BatchLimitType.BatchLimitPercent,
+  successThreshold: numberValue(DEFAULT_BACKEND_SUCCESS_THRESHOLD_PERCENTAGE),
+  selector: [],
+});
 
 const durationToMinutes = (duration: Duration) => {
   const timeoutVal = Number(duration.replace(/[shm]/, ''));
@@ -22,20 +36,13 @@ const durationToMinutes = (duration: Duration) => {
 };
 
 export const getRolloutPolicyValues = (fleetSpec?: FleetSpec) => {
-  const numberValue = (value: Percentage | number | undefined) => {
-    if (value === undefined || typeof value === 'number') {
-      return value;
-    }
-    return Number(value.replace(/[%]/, ''));
-  };
-
   const batches = (fleetSpec?.rolloutPolicy?.deviceSelection?.sequence || []).map((batch) => ({
     selector: fromAPILabel(batch.selector?.matchLabels || {}),
     limit: numberValue(batch.limit),
     limitType:
       typeof batch.limit === 'number' ? BatchLimitType.BatchLimitAbsoluteNumber : BatchLimitType.BatchLimitPercent,
     // If the policy does not specify the threshold, we set the backend's default as the field is required in the UI
-    successThreshold: numberValue(batch.successThreshold || DEFAULT_BACKEND_SUCCESS_THRESHOLD),
+    successThreshold: numberValue(batch.successThreshold || DEFAULT_BACKEND_SUCCESS_THRESHOLD_PERCENTAGE),
   }));
 
   // If the policy does not specify the timeout, we set the backend's default as the field is required in the UI

--- a/libs/ui-components/src/components/Fleet/CreateFleet/steps/UpdatePolicyStep.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/steps/UpdatePolicyStep.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { Alert, Checkbox, FormGroup, FormSection, Grid } from '@patternfly/react-core';
 import { FormikErrors, useFormikContext } from 'formik';
 
-import { BatchLimitType, FleetFormValues } from '../types';
+import { FleetFormValues } from '../types';
+import { getEmptyInitializedBatch } from '../fleetSpecUtils';
 import { useTranslation } from '../../../../hooks/useTranslation';
 import WithHelperText from '../../../common/WithHelperText';
 
@@ -49,19 +50,7 @@ const UpdatePolicyStep = () => {
   };
 
   const onChangePolicyType = (toAdvanced: boolean) => {
-    setFieldValue(
-      'rolloutPolicy.batches',
-      toAdvanced
-        ? [
-            {
-              limit: '',
-              limitType: BatchLimitType.BatchLimitPercent,
-              successThreshold: '',
-              selector: [],
-            },
-          ]
-        : [],
-    );
+    setFieldValue('rolloutPolicy.batches', toAdvanced ? [getEmptyInitializedBatch()] : []);
   };
 
   const onChangeDisruptionBudget = (toAdvanced: boolean) => {

--- a/libs/ui-components/src/components/Fleet/CreateFleet/steps/UpdateStepRolloutPolicy.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/steps/UpdateStepRolloutPolicy.tsx
@@ -22,6 +22,7 @@ import FormSelect from '../../../form/FormSelect';
 import NumberField from '../../../form/NumberField';
 import WithHelperText from '../../../common/WithHelperText';
 import { useTranslation } from '../../../../hooks/useTranslation';
+import { getEmptyInitializedBatch } from '../fleetSpecUtils';
 
 const RolloutPolicyBatch = ({ index }: { index: number }) => {
   const { t } = useTranslation();
@@ -171,12 +172,7 @@ const UpdateStepRolloutPolicy = () => {
                     icon={<PlusCircleIcon />}
                     iconPosition="start"
                     onClick={() => {
-                      push({
-                        limit: '',
-                        limitType: BatchLimitType.BatchLimitPercent,
-                        selector: [],
-                        successThreshold: '',
-                      });
+                      push(getEmptyInitializedBatch());
                     }}
                   >
                     {t('Add batch')}


### PR DESCRIPTION
The API definition for `successThreshold` is optional, but in reality when no value is specified, the system will use a hardcoded value of 90%. In the UI the decision was to make the field mandatory so that users are aware that there's always a successThreshold, and they can see what the default value is.

So whenever a new batch is added, the default successThreshold value is set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a consistent default configuration for rollout batches, ensuring that new or updated rollout policies are initialized with clear and predictable settings.

- **Refactor**
  - Streamlined the batch setup process by replacing manual configuration with the new default mechanism for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->