### PR TITLE
NO-ISSUE: Improve tech preview badge positioning

### DIFF
--- a/libs/ui-components/src/components/ListPage/ListPage.tsx
+++ b/libs/ui-components/src/components/ListPage/ListPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { PageSection, PageSectionVariants, Title, TitleProps } from '@patternfly/react-core';
+import { Flex, FlexItem, PageSection, PageSectionVariants, Title, TitleProps } from '@patternfly/react-core';
 import TechPreviewBadge from '../common/TechPreviewBadge';
 
 type ListPageProps = {
@@ -12,9 +12,16 @@ type ListPageProps = {
 const ListPage: React.FC<ListPageProps> = ({ title, headingLevel = 'h1', children }) => {
   return (
     <PageSection variant={PageSectionVariants.light}>
-      <Title headingLevel={headingLevel} size="3xl">
-        {title} <TechPreviewBadge />
-      </Title>
+      <Flex gap={{ default: 'gapMd' }} alignItems={{ default: 'alignItemsCenter' }}>
+        <FlexItem>
+          <Title headingLevel={headingLevel} size="3xl">
+            {title}
+          </Title>
+        </FlexItem>
+        <FlexItem>
+          <TechPreviewBadge />
+        </FlexItem>
+      </Flex>
       {children}
     </PageSection>
   );

--- a/libs/ui-components/src/components/OverviewPage/OverviewPage.tsx
+++ b/libs/ui-components/src/components/OverviewPage/OverviewPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Overview from './Overview';
 import { useTranslation } from '../../hooks/useTranslation';
-import { PageSection, PageSectionVariants, Title } from '@patternfly/react-core';
+import { Flex, FlexItem, PageSection, PageSectionVariants, Title } from '@patternfly/react-core';
 import TechPreviewBadge from '../common/TechPreviewBadge';
 
 const OverviewPage = () => {
@@ -9,10 +9,16 @@ const OverviewPage = () => {
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
-        <Title headingLevel="h1" size="3xl" role="heading">
-          {t('Overview')}
-          <TechPreviewBadge />
-        </Title>
+        <Flex gap={{ default: 'gapMd' }} alignItems={{ default: 'alignItemsCenter' }}>
+          <FlexItem>
+            <Title headingLevel="h1" size="3xl" role="heading">
+              {t('Overview')}
+            </Title>
+          </FlexItem>
+          <FlexItem>
+            <TechPreviewBadge />
+          </FlexItem>
+        </Flex>
       </PageSection>
       <PageSection variant={PageSectionVariants.light} isFilled>
         <Overview />

--- a/libs/ui-components/src/components/common/TechPreviewBadge.tsx
+++ b/libs/ui-components/src/components/common/TechPreviewBadge.tsx
@@ -27,18 +27,16 @@ const TechPreviewBadge = () => {
   const { t } = useTranslation();
 
   return (
-    <Label color="orange" className="pf-v5-u-ml-md">
-      <Popover
-        aria-label={t('Technology preview description')}
-        bodyContent={<TechPreviewPopoverContent />}
-        withFocusTrap
-        triggerAction="click"
-      >
-        <span>
-          <InfoCircleIcon /> {t('Technology preview')}
-        </span>
-      </Popover>
-    </Label>
+    <Popover
+      aria-label={t('Technology preview description')}
+      bodyContent={<TechPreviewPopoverContent />}
+      withFocusTrap
+      triggerAction="click"
+    >
+      <Label color="orange" icon={<InfoCircleIcon />}>
+        {t('Technology preview')}
+      </Label>
+    </Popover>
   );
 };
 


### PR DESCRIPTION
Before

![Screenshot From 2025-02-11 14-11-15](https://github.com/user-attachments/assets/2e6bb6e0-76b2-4a33-975b-70186e6c4c81)

After

![Screenshot From 2025-02-11 14-10-56](https://github.com/user-attachments/assets/a2a85694-6045-4cd7-8b74-e94dd21a7c5d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Redesigned header layouts on key pages to enhance the alignment and spacing of titles and badges.
  - Streamlined the display of informational badges for a more consistent and visually appealing interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->