### PR TITLE
EDM-1103 Fix validation sync issue when resetting basic configuration

### DIFF
--- a/libs/ui-components/src/components/Fleet/CreateFleet/fleetSpecUtils.ts
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/fleetSpecUtils.ts
@@ -3,7 +3,7 @@ import { Duration, FleetSpec, Percentage } from '@flightctl/types';
 import { BatchLimitType } from './types';
 import { fromAPILabel } from '../../../utils/labels';
 
-const DEFAULT_BACKEND_UPDATE_TIMEOUT = '1140m'; // 24h, expressed in minutes
+export const DEFAULT_BACKEND_UPDATE_TIMEOUT_MINUTES = 1140; // 24h, expressed in minutes
 const DEFAULT_BACKEND_SUCCESS_THRESHOLD_PERCENTAGE = '90%';
 
 const numberValue = (value: Percentage | number | undefined) => {
@@ -46,7 +46,7 @@ export const getRolloutPolicyValues = (fleetSpec?: FleetSpec) => {
   }));
 
   // If the policy does not specify the timeout, we set the backend's default as the field is required in the UI
-  const updateTimeout = fleetSpec?.rolloutPolicy?.defaultUpdateTimeout || DEFAULT_BACKEND_UPDATE_TIMEOUT;
+  const updateTimeout = fleetSpec?.rolloutPolicy?.defaultUpdateTimeout || `${DEFAULT_BACKEND_UPDATE_TIMEOUT_MINUTES}m`;
   return { isAdvanced: batches.length > 0, batches, updateTimeout: durationToMinutes(updateTimeout) };
 };
 

--- a/libs/ui-components/src/components/Fleet/CreateFleet/steps/UpdatePolicyStep.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/steps/UpdatePolicyStep.tsx
@@ -3,7 +3,7 @@ import { Alert, Checkbox, FormGroup, FormSection, Grid } from '@patternfly/react
 import { FormikErrors, useFormikContext } from 'formik';
 
 import { FleetFormValues } from '../types';
-import { getEmptyInitializedBatch } from '../fleetSpecUtils';
+import { DEFAULT_BACKEND_UPDATE_TIMEOUT_MINUTES, getEmptyInitializedBatch } from '../fleetSpecUtils';
 import { useTranslation } from '../../../../hooks/useTranslation';
 import WithHelperText from '../../../common/WithHelperText';
 
@@ -49,13 +49,17 @@ const UpdatePolicyStep = () => {
     }
   };
 
-  const onChangePolicyType = (toAdvanced: boolean) => {
-    setFieldValue('rolloutPolicy.batches', toAdvanced ? [getEmptyInitializedBatch()] : []);
+  const onChangePolicyType = async (toAdvanced: boolean) => {
+    await setFieldValue('rolloutPolicy', {
+      isAdvanced: toAdvanced,
+      batches: toAdvanced ? [getEmptyInitializedBatch()] : [],
+      updateTimeout: DEFAULT_BACKEND_UPDATE_TIMEOUT_MINUTES,
+    });
   };
 
-  const onChangeDisruptionBudget = (toAdvanced: boolean) => {
+  const onChangeDisruptionBudget = async (toAdvanced: boolean) => {
     if (!toAdvanced) {
-      setFieldValue('disruptionBudget', {
+      await setFieldValue('disruptionBudget', {
         isAdvanced: false,
         groupBy: [],
         minAvailable: '',
@@ -64,7 +68,7 @@ const UpdatePolicyStep = () => {
     }
   };
 
-  const onModalClose = (doSwitch: boolean) => {
+  const onModalClose = async (doSwitch: boolean) => {
     setAlertSwitchToBasic(undefined);
     if (!doSwitch) {
       return;
@@ -73,16 +77,14 @@ const UpdatePolicyStep = () => {
     // When the user confirms switching a setting to its basic mode
     switch (alertSwitchToBasic) {
       case 'all-settings':
-        setFieldValue('rolloutPolicy.isAdvanced', false);
-        setFieldValue('disruptionBudget.isAdvanced', false);
+        await onChangePolicyType(false);
+        await onChangeDisruptionBudget(false);
         break;
       case 'rollout-policies':
-        setFieldValue('rolloutPolicy.isAdvanced', false);
-        onChangePolicyType(false);
+        void onChangePolicyType(false);
         break;
       case 'disruption-budget':
-        setFieldValue('disruptionBudget.isAdvanced', false);
-        onChangeDisruptionBudget(false);
+        void onChangeDisruptionBudget(false);
         break;
     }
     setForceShowAdvancedMode(false);


### PR DESCRIPTION
There seemed to be a synchronization issue when we switched the Updates form to use basic configuration and there was an error in the form prior to the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the handling of update timeout values for fleet policies to ensure consistent and reliable display.
	- Improved the state update process during policy modifications, resulting in smoother and more predictable user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->