### PR TITLE
EDM-1150: Clear filters when switching device view

### DIFF
--- a/libs/ui-components/src/components/Device/DevicesPage/EnrolledDevicesTable.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/EnrolledDevicesTable.tsx
@@ -27,6 +27,7 @@ import AddDeviceModal from '../AddDeviceModal/AddDeviceModal';
 import { EnrolledDevicesEmptyState } from './DevicesEmptyStates';
 import DeviceTableToolbar from './DeviceTableToolbar';
 import EnrolledDeviceTableRow from './EnrolledDeviceTableRow';
+import { FilterSearchParams } from '../../../utils/status/devices';
 
 interface EnrolledDeviceTableProps {
   devices: Array<Device>;
@@ -144,6 +145,16 @@ const EnrolledDevicesTable = ({
             label={t('Show only decommissioned devices')}
             isChecked={false}
             onChange={() => {
+              if (hasFiltersEnabled) {
+                setActiveStatuses({
+                  [FilterSearchParams.AppStatus]: [],
+                  [FilterSearchParams.DeviceStatus]: [],
+                  [FilterSearchParams.UpdatedStatus]: [],
+                });
+                setOwnerFleets([]);
+                setNameOrAlias('');
+                setSelectedLabels([]);
+              }
               setOnlyDecommissioned(true);
             }}
             ouiaId={t('Show only decommissioned devices')}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Modified the decommissioned device view toggle so that when enabled, any active filters are automatically cleared. This ensures a more consistent and predictable display of device information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->