### PR TITLE
Delete forever button was nested inside another button

### DIFF
--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsPage.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsPage.tsx
@@ -34,7 +34,7 @@ const DeviceDetailsPage = ({ children, hideTerminal }: DeviceDetailsPageProps) =
   const [showDebugInfo, setShowDebugInfo] = React.useState<boolean>(false);
 
   const deviceAlias = device?.metadata.labels?.alias || deviceId;
-  const isEnrolled = device && isDeviceEnrolled(device);
+  const isEnrolled = !device || isDeviceEnrolled(device);
 
   const [hasTerminalAccess] = useAccessReview(RESOURCE.DEVICE_CONSOLE, VERB.GET);
   const [canDelete] = useAccessReview(RESOURCE.DEVICE, VERB.DELETE);
@@ -106,7 +106,7 @@ const DeviceDetailsPage = ({ children, hideTerminal }: DeviceDetailsPageProps) =
           </DetailsPageActions>
         ) : (
           canDelete && (
-            <Button aria-label={t('Delete device forever')} variant="danger">
+            <Button component="a" aria-label={t('Delete device forever')} variant="danger" tabIndex={0}>
               {deleteAction}
             </Button>
           )


### PR DESCRIPTION
Fixes a DOM/accessibility issue in the "Delete forever" button for decommissioned devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the device status display to ensure a more consistent and accurate presentation.
  - Enhanced the delete action with improved accessibility and navigation, making it easier for users to interact with the option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->