### PR TITLE
EDM-1004: Restore create fleet test and fix flakyness

### DIFF
--- a/libs/cypress/support/interceptors/repositories.ts
+++ b/libs/cypress/support/interceptors/repositories.ts
@@ -9,7 +9,7 @@ const buildRepositoriesResponse = (repositories: Repository[]) => ({
 });
 
 const loadInterceptors = () => {
-  cy.intercept('GET', '/api/flightctl/api/v1/repositories?*', (req) => {
+  cy.intercept('GET', '/api/flightctl/api/v1/repositories', (req) => {
     req.reply({
       body: buildRepositoriesResponse(repoList),
     });


### PR DESCRIPTION
Restore the integration test that creates a fleet - flakyness should be fixed by defining the interceptors better.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced fleet creation tests with dynamic naming for improved consistency.
  - Re-enabled a previously inactive test scenario, ensuring the creation flow is thoroughly verified.
  - Refined the API interception logic for both fleet and repository requests to ensure more accurate validation of network interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->