### PR TITLE
EDM-1047 Template variables validation fixed

### DIFF
--- a/libs/ui-components/src/components/form/validations.ts
+++ b/libs/ui-components/src/components/form/validations.ts
@@ -36,8 +36,9 @@ const K8S_DNS_SUBDOMAIN_VALUE_MAX_LENGTH = 253;
 const BASIC_DEVICE_OS_IMAGE_REGEXP = /^[a-zA-Z0-9.\-\/:@_+]*$/;
 const APPLICATION_IMAGE_REGEXP = BASIC_DEVICE_OS_IMAGE_REGEXP;
 
-const TEMPLATE_VARIABLES_REGEXP = /{{[\s.a-zA-Z0-9-_\/]+}}/g;
-const TEMPLATE_VARIABLES_CONTENT_REGEXP = /^\s*(lower|upper|replace|getOrDefault)?\s*\.metadata\.(labels|name)/;
+const TEMPLATE_VARIABLES_REGEXP = /{{.+?}}/g;
+// Special characters allowed: "dot", "pipe", "spaces" "quote", "backward slash", "underscore", "forward slash", "dash"
+const TEMPLATE_VARIABLES_CONTENT_REGEXP = /^([.a-zA-Z0-9|\s"\\_\/-])+$/;
 
 const absolutePathRegex = /^\/.*$/;
 export const MAX_TARGET_REVISION_LENGTH = 244;
@@ -67,20 +68,6 @@ export const getDnsSubdomainValidations = (t: TFunction) => [
     message: t('1-{{ maxCharacters }} characters', { maxCharacters: K8S_DNS_SUBDOMAIN_VALUE_MAX_LENGTH }),
   },
 ];
-
-export const getKubernetesLabelValueErrors = (labelValue: string) => {
-  const errorKeys: Record<string, string> = {};
-  if (!K8S_LABEL_VALUE_START_END.test(labelValue)) {
-    errorKeys.labelValueStartAndEnd = 'failed';
-  }
-  if (!K8S_LABEL_VALUE_ALLOWED_CHARACTERS.test(labelValue)) {
-    errorKeys.labelValueAllowedChars = 'failed';
-  }
-  if (labelValue?.length > K8S_LABEL_VALUE_MAX_LENGTH) {
-    errorKeys.labelValueMaxLength = 'failed';
-  }
-  return errorKeys;
-};
 
 export const getKubernetesDnsSubdomainErrors = (value: string) => {
   const errorKeys: Record<string, string> = {};


### PR DESCRIPTION
Validations of template variables was not correct.
Now we won't test for the content to be formally correct, as there can be many variations (for example, `quay.io/redhat/rhde:9.2-{{ getOrDefault .metadata.labels \"key\" \"default\" | upper | replace \" \" \"-\" }}`), so we just validate the expression only includes supported characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced form input validation, allowing a broader range of characters in template fields and label entries.
	- Streamlined error handling for user input, improving the overall flexibility and experience.
	- Removed the function for validating Kubernetes label values, centralizing validation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->