### PR TITLE
EDM-1181 FieldSelector "nameOrAlias" casing changed

### DIFF
--- a/libs/ui-components/src/components/Device/DevicesPage/useDevices.ts
+++ b/libs/ui-components/src/components/Device/DevicesPage/useDevices.ts
@@ -47,7 +47,7 @@ const getDevicesEndpoint = ({
   queryUtils.addQueryConditions(fieldSelectors, 'status.updated.status', filterByUpdateStatus);
 
   if (nameOrAlias) {
-    queryUtils.addTextContainsCondition(fieldSelectors, 'metadata.nameoralias', nameOrAlias);
+    queryUtils.addTextContainsCondition(fieldSelectors, 'metadata.nameOrAlias', nameOrAlias);
   }
   if (ownerFleets?.length) {
     queryUtils.addQueryConditions(


### PR DESCRIPTION
Needs the equivalent API PR to be merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced device filtering by correcting the handling of device name or alias criteria. This update improves the accuracy of device searches, ensuring results reflect the correct metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->