### PR TITLE
EDM-843: Searching devices by labels now with partial matching

### DIFF
--- a/libs/ui-components/src/components/Device/DevicesPage/DeviceToolbarFilters.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/DeviceToolbarFilters.tsx
@@ -52,14 +52,16 @@ const LabelFleetResults = ({
   allLabels: FlightCtlLabel[];
 }) => {
   const { t } = useTranslation();
+  const regexp = React.useMemo(() => new RegExp(`(${filterText})`, 'g'), [filterText]);
+
   const searchHighlighter = React.useCallback(
     (text: string) => {
       return text
-        .split(new RegExp(`(${filterText})`, 'g'))
+        .split(regexp)
         .filter(Boolean)
         .map((part, index) => (part.trim() === filterText ? <strong key={`part-${index}`}>{part}</strong> : part));
     },
-    [filterText],
+    [filterText, regexp],
   );
 
   if (isUpdating) {

--- a/libs/ui-components/src/utils/labels.ts
+++ b/libs/ui-components/src/utils/labels.ts
@@ -22,8 +22,14 @@ export const toAPILabel = (labels: FlightCtlLabel[]): Record<string, string> =>
     {} as Record<string, string>,
   );
 
-// Used to force the API to perform an exact match check for labels
 export const labelToExactApiMatchString = (label: FlightCtlLabel) => `${label.key}=${label.value || ''}`;
+export const textToPartialApiMatchString = (text: string) => {
+  if (text.includes('=')) {
+    const [key, value] = text.split('=');
+    return value ? `metadata.labels.key=${key},metadata.labels.value contains ${value}` : `metadata.label.key=${key}`;
+  }
+  return `metadata.labels.keyOrValue contains ${text}`;
+};
 
 export const labelToString = (label: FlightCtlLabel) => `${label.key}${label.value ? `=${label.value}` : ''}`;
 

--- a/libs/ui-components/src/utils/query.ts
+++ b/libs/ui-components/src/utils/query.ts
@@ -1,5 +1,5 @@
 import { FlightCtlLabel } from '../types/extraTypes';
-import { labelToExactApiMatchString } from './labels';
+import { labelToExactApiMatchString, textToPartialApiMatchString } from './labels';
 
 const addQueryConditions = (fieldSelectors: string[], fieldSelector: string, values?: string[]) => {
   if (values?.length === 1) {
@@ -32,12 +32,9 @@ type CommonQueryOptions = {
 };
 
 export const commonQueries = {
-  // We can't specify a sorting, as every entity has a default sorting which is always applied implicitly.
   getDevicesWithExactLabelMatching: (labels: FlightCtlLabel[], options?: CommonQueryOptions) => {
     const searchParams = new URLSearchParams();
 
-    // By default (without the "equal" sign), the API returns a partial match, but only on the label keys
-    // To prevent this confusing behaviour, we query for exact matches in all cases (for both keys and values)
     const exactLabelsMatch = labels.map(labelToExactApiMatchString).join(',');
     searchParams.set('labelSelector', exactLabelsMatch);
 
@@ -45,6 +42,18 @@ export const commonQueries = {
       searchParams.set('limit', `${options.limit}`);
     }
     return `devices?${searchParams.toString()}`;
+  },
+  getDevicesWithPartialLabelMatching: (text: string, options?: CommonQueryOptions) => {
+    const searchParams = new URLSearchParams({
+      kind: 'Device',
+    });
+
+    searchParams.set('fieldSelector', textToPartialApiMatchString(text));
+
+    if (options?.limit) {
+      searchParams.set('limit', `${options.limit}`);
+    }
+    return `labels?${searchParams.toString()}`;
   },
   getFleetsWithNameMatching: (matchName: string, options?: CommonQueryOptions) => {
     const searchParams = new URLSearchParams();

--- a/libs/ui-components/src/utils/search.ts
+++ b/libs/ui-components/src/utils/search.ts
@@ -1,4 +1,5 @@
 import fuzzy from 'fuzzysearch';
+import { API_VERSION } from '../constants';
 
 // Must be an even number for "getSearchResultsCount" to work
 export const MAX_TOTAL_SEARCH_RESULTS = 10;
@@ -23,3 +24,10 @@ export const getSearchResultsCount = (labelCount: number, fleetCount: number) =>
   const rest = MAX_TOTAL_SEARCH_RESULTS - min;
   return labelCount === min ? [labelCount, rest] : [rest, fleetCount];
 };
+
+export const getEmptyFleetSearch = () => ({
+  apiVersion: API_VERSION,
+  kind: 'Fleet',
+  metadata: {},
+  items: [],
+});


### PR DESCRIPTION
Uses the new endpoint `GET /labels` that allows us to search for device labels including using partial matching.
(Requires https://github.com/flightctl/flightctl/pull/939)

Additionally, the search results now highlight the part of the label / fleet name which match the search text (solves EDM-533)
![label-partial-matching](https://github.com/user-attachments/assets/3116d089-a04d-42e5-a496-db38aaed8b8f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced device filtering experience by highlighting matching text in labels and fleet names.
  - Improved search functionality with support for partial label matching, offering more flexible and intuitive search results.
  - Introduced a new option for empty fleet searches to provide clearer, more predictable outcomes.
  - Added a method for constructing API-compatible strings for partial label matches.
  - Introduced a new querying function for devices based on partial label matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->