### PR TITLE
Change Release branch name to "release-number"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Check workflow runs in a release branch
         run: |
-          if [[ "${{ github.event.release.target_commitish }}" != *releases* ]]; then
+          if [[ "${{ github.event.release.target_commitish }}" != *release-* ]]; then
             echo "Expecting to be in a release branch, but we are in: ${{ github.event.release.target_commitish }}"
             exit 1
           fi
@@ -84,7 +84,7 @@ jobs:
           for LIB in $(echo ${LIBS}); do
             git add libs/"${LIB}"/package.json
           done
-          git commit -m "Version ${GITHUB_REF_NAME}"
-          git tag -f -a ${GITHUB_REF_NAME} -m "${GITHUB_REF_NAME}"
+          git commit -m "Release ${GITHUB_REF_NAME}"
+          git tag -f -a ${GITHUB_REF_NAME} -m "Release ${GITHUB_REF_NAME}"
           git push origin ${GITHUB_REF_NAME} --force
           git push origin ${{ github.event.release.target_commitish }} --force


### PR DESCRIPTION
We want to align how we do our releases to how the Backend team does them:

- Release branch should be called `release-vA.B.C`
- Tag commit message is in the form "Release vA.B.C"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the release automation by refining criteria for identifying the correct branches for release operations.
  - Standardized commit and tag messages to clearly denote release updates, ensuring consistency and improved clarity in our release management workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->