### PR TITLE
EDM-1299: Shown enrollment requests default-labels (including alias)

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -256,6 +256,7 @@
   "Approve": "Approve",
   "OS": "OS",
   "Architecture": "Architecture",
+  "Default labels": "Default labels",
   "Certificate signing request": "Certificate signing request",
   "A PEM-encoded PKCS#10 certificate signing request.": "A PEM-encoded PKCS#10 certificate signing request.",
   "Certificate Signing Request": "Certificate Signing Request",

--- a/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestDetails/EnrollmentRequestDetails.tsx
+++ b/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestDetails/EnrollmentRequestDetails.tsx
@@ -67,7 +67,6 @@ const EnrollmentRequestDetails = () => {
 
   const approvalStatus = er ? getApprovalStatus(er) : '-';
   const isPendingApproval = approvalStatus === EnrollmentRequestStatusType.Pending;
-
   return (
     <DetailsPage
       loading={loading}
@@ -77,7 +76,7 @@ const EnrollmentRequestDetails = () => {
       resourceType="Devices"
       resourceTypeLabel={t('Devices')}
       actions={
-        (canApprove || canApprove) && (
+        (canApprove || canDelete) && (
           <DetailsPageActions>
             <DropdownList>
               {canApprove && (
@@ -120,9 +119,9 @@ const EnrollmentRequestDetails = () => {
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
-                  <DescriptionListTerm>{t('Labels')}</DescriptionListTerm>
+                  <DescriptionListTerm>{t('Default labels')}</DescriptionListTerm>
                   <DescriptionListDescription>
-                    <LabelsView prefix="er" labels={er?.metadata.labels} />
+                    <LabelsView prefix="er" labels={er?.spec.labels} />
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>

--- a/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestList.tsx
+++ b/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestList.tsx
@@ -33,6 +33,9 @@ const EnrollmentRequestEmptyState = () => {
 
 const getEnrollmentColumns = (t: TFunction): ApiSortTableColumn[] => [
   {
+    name: t('Alias'),
+  },
+  {
     name: t('Name'),
   },
   {
@@ -40,7 +43,10 @@ const getEnrollmentColumns = (t: TFunction): ApiSortTableColumn[] => [
   },
 ];
 
-const getSearchText = (er: EnrollmentRequest) => [er.metadata.name];
+const getSearchText = (er: EnrollmentRequest) => {
+  const alias = er.spec.labels?.alias;
+  return alias ? [er.metadata.name, alias] : [er.metadata.name];
+};
 
 type EnrollmentRequestListProps = { refetchDevices?: VoidFunction; isStandalone?: boolean };
 
@@ -109,7 +115,7 @@ const EnrollmentRequestList = ({ refetchDevices, isStandalone }: EnrollmentReque
           onSelectAll={setAllSelected}
         >
           <Tbody>
-            {pendingEnrollments.map((er, index) => (
+            {filteredData.map((er, index) => (
               <EnrollmentRequestTableRow
                 key={er.metadata.name || ''}
                 er={er}

--- a/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestTableRow.tsx
+++ b/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestTableRow.tsx
@@ -32,6 +32,7 @@ const EnrollmentRequestTableRow: React.FC<EnrollmentRequestTableRow> = ({
 }) => {
   const { t } = useTranslation();
   const erName = er.metadata.name as string;
+  const erAlias = er.spec.labels?.alias;
 
   const approveEnrollment = () => {
     onApprove(erName);
@@ -57,8 +58,11 @@ const EnrollmentRequestTableRow: React.FC<EnrollmentRequestTableRow> = ({
           isSelected: isRowSelected(er),
         }}
       />
+      <Td dataLabel={t('Alias')}>
+        <ResourceLink id={erName} name={erAlias || t('Untitled')} routeLink={ROUTE.ENROLLMENT_REQUEST_DETAILS} />
+      </Td>
       <Td dataLabel={t('Name')}>
-        <ResourceLink id={erName} routeLink={ROUTE.ENROLLMENT_REQUEST_DETAILS} />
+        <ResourceLink id={erName} />
       </Td>
       <Td dataLabel={t('Created')}>{timeSinceText(t, er.metadata.creationTimestamp)}</Td>
       {canApprove && (

--- a/libs/ui-components/src/components/modals/ApproveDeviceModal/ApproveDeviceForm.tsx
+++ b/libs/ui-components/src/components/modals/ApproveDeviceModal/ApproveDeviceForm.tsx
@@ -32,6 +32,7 @@ const ApproveDeviceForm: React.FC<ApproveDeviceFormProps> = ({ enrollmentRequest
 
   const disableSubmit = Object.keys(formErrors).length > 0;
   const [matchLabelsOnChange, matchStatus] = useDeviceLabelMatch();
+  const defaultAlias = enrollmentRequest.spec.labels?.alias;
 
   return (
     <FlightCtlForm>
@@ -39,12 +40,11 @@ const ApproveDeviceForm: React.FC<ApproveDeviceFormProps> = ({ enrollmentRequest
         fieldName="deviceAlias"
         aria-label={t('Alias')}
         validations={getLabelValueValidations(t)}
+        isDisabled={!!defaultAlias}
       />
-      {enrollmentRequest && (
-        <FormGroup label={t('Name')} aria-label={t('Name')}>
-          <ResourceLink id={enrollmentRequest.metadata.name as string} variant="full" />
-        </FormGroup>
-      )}
+      <FormGroup label={t('Name')} aria-label={t('Name')}>
+        <ResourceLink id={enrollmentRequest.metadata.name as string} variant="full" />
+      </FormGroup>
       <FormGroup label={t('Labels')}>
         <LabelsField name="labels" onChangeCallback={matchLabelsOnChange} />
       </FormGroup>

--- a/libs/ui-components/src/components/modals/ApproveDeviceModal/ApproveDeviceModal.tsx
+++ b/libs/ui-components/src/components/modals/ApproveDeviceModal/ApproveDeviceModal.tsx
@@ -21,11 +21,12 @@ const DeviceEnrollmentModal: React.FC<DeviceEnrollmentModalProps> = ({ enrollmen
   const { t } = useTranslation();
   const { put } = useFetch();
   const [error, setError] = React.useState<string>();
+  const labels = enrollmentRequest.spec.labels || {};
   return (
     <Formik<ApproveDeviceFormValues>
       initialValues={{
-        labels: fromAPILabel(enrollmentRequest.spec.labels || {}, { isDefault: true }),
-        deviceAlias: '',
+        labels: fromAPILabel(labels, { isDefault: true }).filter((label) => label.key !== 'alias'),
+        deviceAlias: labels.alias || '',
       }}
       validationSchema={deviceApprovalValidationSchema(t, { isSingleDevice: true })}
       onSubmit={async ({ labels, deviceAlias }) => {


### PR DESCRIPTION
The table for pending devices now has two columns, one for alias and one for name (fingerprint).
Alias is defined via the "default-labels".

Labels are now also shown in the Enrollment Request details page, and the alias is shown and pre-populated in the modal for approving the enrollment request.

![er-list](https://github.com/user-attachments/assets/ee0b8882-7255-4b03-9703-a2ad0a722cc6)
![er-approve-modal](https://github.com/user-attachments/assets/904d2147-8357-429b-813f-16d228b28d82)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded localization support with an additional translation entry for "Default labels".
	- Updated enrollment request actions to reflect refined permission checks and clearer labeling of "Default labels".
	- Introduced an "Alias" column to provide more detailed information in the enrollment list and enhanced search functionality.
	- Improved device enrollment handling by ensuring consistent alias display in user forms and managing default alias settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->