### PR TITLE
EDM-733: Force lose focus onMouseOut

### DIFF
--- a/libs/ui-components/src/components/Device/EditDeviceWizard/EditDeviceWizardFooter.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/EditDeviceWizardFooter.tsx
@@ -15,6 +15,7 @@ const EditDeviceWizardFooter = () => {
   const { goToNextStep, goToPrevStep, activeStep } = useWizardContext();
   const { submitForm, isSubmitting, errors } = useFormikContext<EditDeviceFormValues>();
   const navigate = useNavigate();
+  const buttonRef = React.useRef<HTMLButtonElement>();
 
   const isSubmitStep = activeStep.id === reviewDeviceStepId;
 
@@ -33,12 +34,18 @@ const EditDeviceWizardFooter = () => {
       break;
   }
 
+  const onMoveNext = () => {
+    goToNextStep();
+    // Blur the button, otherwise it keeps the focus from the previous click
+    buttonRef.current?.blur();
+  };
+
   const primaryBtn = isSubmitStep ? (
     <Button variant="primary" onClick={submitForm} isDisabled={isSubmitting} isLoading={isSubmitting}>
       {t('Save')}
     </Button>
   ) : (
-    <Button variant="primary" onClick={goToNextStep} isDisabled={!isStepValid}>
+    <Button variant="primary" onClick={onMoveNext} isDisabled={!isStepValid} ref={buttonRef}>
       {t('Next')}
     </Button>
   );

--- a/libs/ui-components/src/components/Fleet/CreateFleet/CreateFleetWizardFooter.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/CreateFleetWizardFooter.tsx
@@ -21,6 +21,7 @@ const CreateFleetWizardFooter = ({ isEdit }: CreateFleetWizardFooterProps) => {
   const { goToNextStep, goToPrevStep, activeStep } = useWizardContext();
   const { submitForm, isSubmitting, errors } = useFormikContext<FleetFormValues>();
   const navigate = useNavigate();
+  const buttonRef = React.useRef<HTMLButtonElement>();
 
   const isReviewStep = activeStep.id === reviewStepId;
   let isStepValid = true;
@@ -32,12 +33,18 @@ const CreateFleetWizardFooter = ({ isEdit }: CreateFleetWizardFooterProps) => {
     isStepValid = isUpdatePolicyStepValid(errors);
   }
 
+  const onMoveNext = () => {
+    goToNextStep();
+    // Blur the button, otherwise it keeps the focus from the previous click
+    buttonRef.current?.blur();
+  };
+
   const primaryBtn = isReviewStep ? (
     <Button variant="primary" onClick={submitForm} isDisabled={isSubmitting} isLoading={isSubmitting}>
       {isEdit ? t('Save') : t('Create fleet')}
     </Button>
   ) : (
-    <Button variant="primary" onClick={goToNextStep} isDisabled={!isStepValid}>
+    <Button variant="primary" onClick={onMoveNext} isDisabled={!isStepValid} ref={buttonRef}>
       {t('Next')}
     </Button>
   );


### PR DESCRIPTION
In the EditDevice / EditFleet wizards, the footer buttons were keeping the focus even after moving the mouse outside the buttons. We now force `blur` on the "Next" button when it is clicked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved wizard navigation by updating the "Next" button behavior. Now, after clicking, the button automatically clears focus, ensuring a smoother and more responsive step transition experience in both device and fleet wizards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->