### PR TITLE
EDM-975: Adjust mass delete table column widths

### DIFF
--- a/libs/ui-components/src/components/modals/massModals/MassDecommissionDeviceModal/MassDecommissionDeviceModal.tsx
+++ b/libs/ui-components/src/components/modals/massModals/MassDecommissionDeviceModal/MassDecommissionDeviceModal.tsx
@@ -80,18 +80,18 @@ const MassDecommissionDeviceModal = ({ onClose, devices, onSuccess }: MassDecomm
           <Table>
             <Thead>
               <Tr>
-                <Th>{t('Name')}</Th>
                 <Th>{t('Alias')}</Th>
+                <Th>{t('Name')}</Th>
               </Tr>
             </Thead>
             <Tbody>
               {devices.map((device) => {
                 return (
                   <Tr key={device.metadata.name}>
+                    <Td dataLabel={t('Alias')}>{device.metadata.labels?.alias || '-'}</Td>
                     <Td dataLabel={t('Name')}>
                       <ResourceLink id={device.metadata.name as string} />
                     </Td>
-                    <Td dataLabel={t('Alias')}>{device.metadata.labels?.alias || '-'}</Td>
                   </Tr>
                 );
               })}

--- a/libs/ui-components/src/components/modals/massModals/MassDeleteDeviceModal/MassDeleteDeviceModal.tsx
+++ b/libs/ui-components/src/components/modals/massModals/MassDeleteDeviceModal/MassDeleteDeviceModal.tsx
@@ -67,18 +67,18 @@ const MassDeleteDeviceModal: React.FC<MassDeleteDeviceModalProps> = ({ onClose, 
           <Table>
             <Thead>
               <Tr>
-                <Th>{t('Name')}</Th>
                 <Th>{t('Alias')}</Th>
+                <Th>{t('Name')}</Th>
               </Tr>
             </Thead>
             <Tbody>
               {resources.map((resource) => {
                 return (
                   <Tr key={resource.metadata.name}>
+                    <Td dataLabel={t('Alias')}>{resource.metadata.labels?.alias || '-'}</Td>
                     <Td dataLabel={t('Name')}>
                       <ResourceLink id={resource.metadata.name as string} />
                     </Td>
-                    <Td dataLabel={t('Alias')}>{resource.metadata.labels?.alias || '-'}</Td>
                   </Tr>
                 );
               })}

--- a/libs/ui-components/src/components/modals/massModals/MassDeleteFleetModal/MassDeleteFleetModal.tsx
+++ b/libs/ui-components/src/components/modals/massModals/MassDeleteFleetModal/MassDeleteFleetModal.tsx
@@ -30,8 +30,8 @@ const MassDeleteFleetTable = ({ fleets }: { fleets: Array<Fleet> }) => {
     <Table>
       <Thead>
         <Tr>
-          <Th>{t('Name')}</Th>
-          <Th>{t('Managed by')}</Th>
+          <Th modifier="fitContent">{t('Name')}</Th>
+          <Th modifier="fitContent">{t('Managed by')}</Th>
         </Tr>
       </Thead>
       <Tbody>

--- a/libs/ui-components/src/components/modals/massModals/MassDeleteRepositoryModal/MassDeleteRepositoryModal.tsx
+++ b/libs/ui-components/src/components/modals/massModals/MassDeleteRepositoryModal/MassDeleteRepositoryModal.tsx
@@ -126,8 +126,8 @@ const MassDeleteRepositoryModal: React.FC<MassDeleteRepositoryModalProps> = ({
               <Table>
                 <Thead>
                   <Tr>
-                    <Th>{t('Repository name')}</Th>
-                    <Th>{t('# Resource syncs')}</Th>
+                    <Th modifier="fitContent">{t('Repository name')}</Th>
+                    <Th modifier="fitContent">{t('# Resource syncs')}</Th>
                   </Tr>
                 </Thead>
                 <Tbody>


### PR DESCRIPTION
Adds `fitContent` for better displaying long names in the mass-delete modals for Fleets and Repositories.

![mass-delete-repos](https://github.com/user-attachments/assets/017b6a2d-1edb-42fb-8bdd-59cd91ef9bef)
![mass-delete-fleets](https://github.com/user-attachments/assets/05f1511d-4d44-4139-9d42-6130170fae46)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Adjusted the display of table headers in modal dialogs for fleet and repository deletions, ensuring header cells now better handle content width for improved visual consistency.
  - Reordered table headers and their corresponding data cells in the device decommission and delete modals, enhancing data alignment and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->