### PR TITLE
Prevent continuous refresh in flow with disabled auth

### DIFF
--- a/apps/standalone/src/app/context/AuthContext.ts
+++ b/apps/standalone/src/app/context/AuthContext.ts
@@ -96,13 +96,18 @@ export const useAuthContext = () => {
   React.useEffect(() => {
     if (!loading) {
       const scheduleRefresh = () => {
+        if (!authEnabled) {
+          return;
+        }
         const expiresAt = parseInt(localStorage.getItem(EXPIRATION) || '0', 10);
         if (expiresAt > 0) {
           const now = nowInSeconds();
           // refresh 15s before expiration
           const expiresIn = expiresAt - now - 15;
           const timeout = Math.min(maxTimeout, expiresIn * 1000);
-          refreshRef.current = setTimeout(refreshToken, timeout);
+          if (timeout > 0) {
+            refreshRef.current = setTimeout(refreshToken, timeout);
+          }
         }
       };
 
@@ -131,7 +136,7 @@ export const useAuthContext = () => {
       scheduleRefresh();
     }
     return () => clearTimeout(refreshRef.current);
-  }, [loading]);
+  }, [loading, authEnabled]);
 
   return { username, loading, authEnabled, error };
 };


### PR DESCRIPTION
We shouldn't attempt to refresh the token when in disabled-auth mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced authentication handling to ensure token refresh processes execute only under the proper conditions.
	- Refined timing logic to prevent issues with scheduling, ensuring a more reliable and consistent session management experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->