### PR TITLE
Use go 1.21 also in the OCP plugin

### DIFF
--- a/Containerfile.ocp
+++ b/Containerfile.ocp
@@ -12,7 +12,7 @@ ENV NODE_OPTIONS='--max-old-space-size=8192'
 RUN npm ci
 RUN npm run build:ocp
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20 as proxy-build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21 as proxy-build
 WORKDIR /app
 COPY proxy /app
 USER 0


### PR DESCRIPTION
The image for the OCP plugin was using go 1.20 instead of 1.21 as we have in the base Containerfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the build environment to the latest available toolchain version, enhancing overall stability and performance in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->