### PR TITLE
EDM-1345: Enrollment requests filter text done via API

### DIFF
--- a/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestList.tsx
+++ b/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestList.tsx
@@ -50,7 +50,6 @@ const EnrollmentRequestList = ({ refetchDevices, isStandalone }: EnrollmentReque
   const [canDelete] = useAccessReview(RESOURCE.ENROLLMENT_REQUEST, VERB.DELETE);
   const { remove } = useFetch();
   const [search, setSearch] = React.useState<string>('');
-  const [isLastUnfilteredListEmpty, setIsLastUnfilteredListEmpty] = React.useState<boolean>(false);
 
   const enrollmentColumns = React.useMemo(() => getEnrollmentColumns(t), [t]);
 
@@ -76,11 +75,7 @@ const EnrollmentRequestList = ({ refetchDevices, isStandalone }: EnrollmentReque
     },
   });
 
-  React.useEffect(() => {
-    if (!search && !isLoading) {
-      setIsLastUnfilteredListEmpty(itemCount === 0);
-    }
-  }, [itemCount, search, isLoading]);
+  const isLastUnfilteredListEmpty = !search && !isLoading && itemCount === 0;
 
   // In non-standalone mode, hide the entire component when the search result is empty (and not due to filtering)
   if (!isStandalone && isLastUnfilteredListEmpty) {
@@ -136,7 +131,7 @@ const EnrollmentRequestList = ({ refetchDevices, isStandalone }: EnrollmentReque
           </Tbody>
         </Table>
         <TablePagination pagination={pagination} isUpdating={isLoading} />
-        {isStandalone && pendingEnrollments.length === 0 && !isLoading && <EnrollmentRequestEmptyState />}
+        {isStandalone && itemCount === 0 && !isLoading && <EnrollmentRequestEmptyState />}
         {deleteModal}
         {currentEnrollmentRequest && (
           <ApproveDeviceModal

--- a/libs/ui-components/src/components/EnrollmentRequest/useEnrollmentRequests.ts
+++ b/libs/ui-components/src/components/EnrollmentRequest/useEnrollmentRequests.ts
@@ -10,12 +10,18 @@ import { PaginationDetails, useTablePagination } from '../../hooks/useTablePagin
 import { PAGE_SIZE } from '../../constants';
 
 type EnrollmentRequestsEndpointArgs = {
+  search?: string;
   nextContinue?: string;
 };
 
-const getPendingEnrollmentsEndpoint = ({ nextContinue }: EnrollmentRequestsEndpointArgs) => {
+const getPendingEnrollmentsEndpoint = ({ search, nextContinue }: EnrollmentRequestsEndpointArgs) => {
+  const fieldSelector = ['!status.approval.approved'];
+  if (search) {
+    fieldSelector.push(`metadata.name contains ${search}`);
+  }
+
   const params = new URLSearchParams({
-    fieldSelector: '!status.approval.approved',
+    fieldSelector: fieldSelector.join(','),
   });
 
   if (nextContinue !== undefined) {
@@ -33,7 +39,9 @@ export const useEnrollmentRequestsEndpoint = (args: EnrollmentRequestsEndpointAr
   return [pendingErEndpointDebounced, endpoint !== pendingErEndpointDebounced];
 };
 
-export const usePendingEnrollments = (): [
+export const usePendingEnrollments = (
+  search?: string,
+): [
   EnrollmentRequest[],
   boolean,
   unknown,
@@ -42,7 +50,7 @@ export const usePendingEnrollments = (): [
 ] => {
   const { currentPage, setCurrentPage, itemCount, nextContinue, onPageFetched } =
     useTablePagination<EnrollmentRequestList>();
-  const [pendingErEndpoint, isDebouncing] = useEnrollmentRequestsEndpoint({ nextContinue });
+  const [pendingErEndpoint, isDebouncing] = useEnrollmentRequestsEndpoint({ search, nextContinue });
 
   const [erList, isLoading, error, refetch] = useFetchPeriodically<EnrollmentRequestList>(
     {


### PR DESCRIPTION
The filtering of Enrollment Requests by search text was done client-side, so it could only find ERs if they happened to be in the first page of results. Now the filtering is done via the API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined enrollment request handling to directly reflect current pending enrollments.
	- Enhanced search functionality to filter enrollment requests based on user input.
	- Updated bulk action modals to consistently operate on the most recent enrollment data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->