### PR TITLE
EDM-1221: Rename Edge tab in ACM to 'Edge devices'

### DIFF
--- a/apps/ocp-plugin/console-extensions.json
+++ b/apps/ocp-plugin/console-extensions.json
@@ -144,7 +144,7 @@
   {
     "type": "acm.overview/tab",
     "properties": {
-      "tabTitle": "Edge",
+      "tabTitle": "Edge devices",
       "component": { "$codeRef": "OverviewTab" }
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the overview tab label from "Edge" to "Edge devices" for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->