### PR TITLE
EDM-1223: Change filter position in Overview page

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -536,7 +536,7 @@
   "Review pending devices_one": "Review pending device",
   "Review pending devices_other": "Review pending devices",
   "All good!": "All good!",
-  "To do": "To do",
+  "Tasks": "Tasks",
   "Failed to retrieve repository details": "Failed to retrieve repository details",
   "Failed to retrieve the resource syncs": "Failed to retrieve the resource syncs",
   "The repository cannot be modified at the moment because some of its details could not be obtained.": "The repository cannot be modified at the moment because some of its details could not be obtained.",

--- a/libs/ui-components/src/components/OverviewPage/Cards/Status/StatusCard.tsx
+++ b/libs/ui-components/src/components/OverviewPage/Cards/Status/StatusCard.tsx
@@ -80,19 +80,19 @@ const StatusCard = () => {
   return (
     <Card>
       <CardHeader>
-        <Flex alignItems={{ default: 'alignItemsCenter' }}>
-          <FlexItem>
+        <Stack hasGutter>
+          <StackItem>
             <CardTitle>{t('Status')}</CardTitle>
-          </FlexItem>
-          <FlexItem>
+          </StackItem>
+          <StackItem>
             <StatusCardFilters
               selectedFleets={fleets}
               setSelectedFleets={setFleets}
               selectedLabels={labels}
               setSelectedLabels={setLabels}
             />
-          </FlexItem>
-        </Flex>
+          </StackItem>
+        </Stack>
       </CardHeader>
 
       <CardBody>{content}</CardBody>

--- a/libs/ui-components/src/components/OverviewPage/Cards/Tasks/TasksCard.tsx
+++ b/libs/ui-components/src/components/OverviewPage/Cards/Tasks/TasksCard.tsx
@@ -18,7 +18,7 @@ import { usePendingEnrollmentRequestsCount } from '../../../../hooks/usePendingE
 import { Link, ROUTE } from '../../../../hooks/useNavigate';
 import ErrorAlert from '../../../ErrorAlert/ErrorAlert';
 
-const ToDoCard = () => {
+const TasksCard = () => {
   const { t } = useTranslation();
 
   const [pendingErCount, loading, error] = usePendingEnrollmentRequestsCount();
@@ -59,10 +59,10 @@ const ToDoCard = () => {
 
   return (
     <Card>
-      <CardTitle>{t('To do')}</CardTitle>
+      <CardTitle>{t('Tasks')}</CardTitle>
       <CardBody>{content}</CardBody>
     </Card>
   );
 };
 
-export default ToDoCard;
+export default TasksCard;

--- a/libs/ui-components/src/components/OverviewPage/Overview.tsx
+++ b/libs/ui-components/src/components/OverviewPage/Overview.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Grid, GridItem } from '@patternfly/react-core';
 import StatusCard from './Cards/Status/StatusCard';
-import ToDoCard from './Cards/ToDo/ToDoCard';
+import TasksCard from './Cards/Tasks/TasksCard';
 import { useAccessReview } from '../../hooks/useAccessReview';
 import { RESOURCE, VERB } from '../../types/rbac';
 import PageWithPermissions from '../common/PageWithPermissions';
@@ -20,7 +20,7 @@ const Overview = () => {
         )}
         {canListErs && (
           <GridItem md={6} lg={4}>
-            <ToDoCard />
+            <TasksCard />
           </GridItem>
         )}
       </Grid>


### PR DESCRIPTION
Changed the layout so that the filters appear below the title
![status-filter-layout](https://github.com/user-attachments/assets/652dbe41-e8a7-4ec0-9560-61241e3cd585)

Also includes https://issues.redhat.com/browse/EDM-1225: renaming "ToDo" card to "Tasks"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated terminology in the user interface by changing "To do" to "Tasks".
	- Replaced the `ToDoCard` component with the newly named `TasksCard` in the overview section.

- **Refactor**
	- Improved the visual layout of a card header, resulting in a cleaner and more streamlined appearance without impacting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->