### PR TITLE
EDM- 1311 Technology Preview badge is shown only once

### DIFF
--- a/libs/ui-components/src/components/Device/DevicesPage/DevicesPage.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/DevicesPage.tsx
@@ -36,6 +36,15 @@ const DevicesPage = ({ canListER }: { canListER: boolean }) => {
     setSelectedLabels,
   } = useDeviceBackendFilters();
   const [onlyDecommissioned, setOnlyDecommissioned] = React.useState<boolean>(false);
+  const [showDeviceListBadge, setShowDeviceListBadge] = React.useState<boolean>(true);
+
+  const onEmptyErChanged = React.useCallback((isEmpty: boolean) => {
+    if (isEmpty) {
+      setShowDeviceListBadge(true);
+    } else {
+      setShowDeviceListBadge(false);
+    }
+  }, []);
 
   const { currentPage, setCurrentPage, onPageFetched, nextContinue, itemCount } = useTablePagination<DeviceList>(
     onlyDecommissioned ? undefined : removeDecommissionedDevices,
@@ -62,9 +71,9 @@ const DevicesPage = ({ canListER }: { canListER: boolean }) => {
 
   return (
     <>
-      {canListER && <EnrollmentRequestList refetchDevices={refetch} />}
+      {canListER && <EnrollmentRequestList onEmptyListChanged={onEmptyErChanged} refetchDevices={refetch} />}
 
-      <ListPage title={t('Devices')}>
+      <ListPage title={t('Devices')} withBadge={showDeviceListBadge}>
         {/* When searching for decommissioned devices we want to avoid showing the enrolled devices */}
         <ListPageBody error={error} loading={loading || (onlyDecommissioned && updating && !hasFiltersEnabled)}>
           {onlyDecommissioned ? (

--- a/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestList.tsx
+++ b/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestList.tsx
@@ -42,9 +42,13 @@ const getEnrollmentColumns = (t: TFunction): ApiSortTableColumn[] => [
   },
 ];
 
-type EnrollmentRequestListProps = { refetchDevices?: VoidFunction; isStandalone?: boolean };
+type EnrollmentRequestListProps = {
+  refetchDevices?: VoidFunction;
+  onEmptyListChanged?: (isEmpty: boolean) => void;
+  isStandalone?: boolean;
+};
 
-const EnrollmentRequestList = ({ refetchDevices, isStandalone }: EnrollmentRequestListProps) => {
+const EnrollmentRequestList = ({ onEmptyListChanged, refetchDevices, isStandalone }: EnrollmentRequestListProps) => {
   const { t } = useTranslation();
   const [canApprove] = useAccessReview(RESOURCE.ENROLLMENT_REQUEST_APPROVAL, VERB.POST);
   const [canDelete] = useAccessReview(RESOURCE.ENROLLMENT_REQUEST, VERB.DELETE);
@@ -74,9 +78,14 @@ const EnrollmentRequestList = ({ refetchDevices, isStandalone }: EnrollmentReque
     },
   });
 
-  const isLastUnfilteredListEmpty = !search && !isLoading && itemCount === 0;
+  React.useEffect(() => {
+    if (onEmptyListChanged && !search && !isLoading) {
+      onEmptyListChanged?.(itemCount === 0);
+    }
+  }, [search, itemCount, isLoading, onEmptyListChanged]);
 
   // In non-standalone mode, hide the entire component when the search result is empty (and not due to filtering)
+  const isLastUnfilteredListEmpty = !search && itemCount === 0;
   if (!isStandalone && isLastUnfilteredListEmpty) {
     return null;
   }
@@ -106,7 +115,7 @@ const EnrollmentRequestList = ({ refetchDevices, isStandalone }: EnrollmentReque
           aria-label={t('Table for devices pending approval')}
           loading={!!isStandalone && isLoading && isLastUnfilteredListEmpty}
           columns={enrollmentColumns}
-          emptyData={pendingEnrollments.length === 0}
+          emptyData={itemCount === 0}
           clearFilters={() => setSearch('')}
           hasFilters={!!search}
           isAllSelected={isAllSelected}

--- a/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestList.tsx
+++ b/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestList.tsx
@@ -52,7 +52,6 @@ const EnrollmentRequestList = ({ refetchDevices, isStandalone }: EnrollmentReque
   const [search, setSearch] = React.useState<string>('');
 
   const enrollmentColumns = React.useMemo(() => getEnrollmentColumns(t), [t]);
-
   const [pendingEnrollments, isLoading, error, refetch, pagination] = usePendingEnrollments(search);
   const itemCount = pendingEnrollments.length;
 

--- a/libs/ui-components/src/components/ListPage/ListPage.tsx
+++ b/libs/ui-components/src/components/ListPage/ListPage.tsx
@@ -7,9 +7,10 @@ type ListPageProps = {
   title: string;
   headingLevel?: TitleProps['headingLevel'];
   children: React.ReactNode;
+  withBadge?: boolean;
 };
 
-const ListPage: React.FC<ListPageProps> = ({ title, headingLevel = 'h1', children }) => {
+const ListPage: React.FC<ListPageProps> = ({ title, headingLevel = 'h1', withBadge = true, children }) => {
   return (
     <PageSection variant={PageSectionVariants.light}>
       <Flex gap={{ default: 'gapMd' }} alignItems={{ default: 'alignItemsCenter' }}>
@@ -18,9 +19,11 @@ const ListPage: React.FC<ListPageProps> = ({ title, headingLevel = 'h1', childre
             {title}
           </Title>
         </FlexItem>
-        <FlexItem>
-          <TechPreviewBadge />
-        </FlexItem>
+        {withBadge && (
+          <FlexItem>
+            <TechPreviewBadge />
+          </FlexItem>
+        )}
       </Flex>
       {children}
     </PageSection>


### PR DESCRIPTION
Controls whether the Technology Preview badge should appear next to the Enrollment request list, or next to the Devices list.
It should not appear next to both at the same time.
![tp-badge-only-once](https://github.com/user-attachments/assets/d8288e3c-0164-492f-bcec-8045a10d20e9)

Built on top of https://github.com/flightctl/flightctl-ui/pull/267 as they relate to the same area of the application.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The device list page now dynamically updates a badge’s visibility based on the current list status.
  - An optional configuration on the list page allows users to control the display of a preview badge for enhanced user feedback.
  - The enrollment request list component now notifies when the list becomes empty, enhancing state communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->