### PR TITLE
EDM-1391: Fix validation for file permissions which are optional

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -479,7 +479,6 @@
   "Secret namespace is required.": "Secret namespace is required.",
   "File path must be absolute.": "File path must be absolute.",
   "File path must be unique.": "File path must be unique.",
-  "Permissions are required": "Permissions are required",
   "Permissions must use octal notation": "Permissions must use octal notation",
   "The maximum number of systemd units is {{maxSystemUnits}}.": "The maximum number of systemd units is {{maxSystemUnits}}.",
   "Invalid systemd service names: {{invalidPatterns}}": "Invalid systemd service names: {{invalidPatterns}}",

--- a/libs/ui-components/src/components/form/validations.ts
+++ b/libs/ui-components/src/components/form/validations.ts
@@ -620,12 +620,17 @@ export const validConfigTemplatesSchema = (t: TFunction) =>
                     (path) => !path || value.files.filter((file) => file.path === path).length == 1,
                   ),
                 content: Yup.string(),
-                permissions: Yup.string()
-                  .required(t('Permissions are required'))
-                  .test('permissions', t('Permissions must use octal notation'), (perm: string) => {
-                    const valNum = Number(`0o${perm || ''}`);
+                permissions: Yup.string().test(
+                  'permissions',
+                  t('Permissions must use octal notation'),
+                  (perm: string | undefined) => {
+                    if (!perm) {
+                      return true;
+                    }
+                    const valNum = Number(`0o${perm}`);
                     return Number.isFinite(valNum) && valNum >= 0 && valNum <= 0o7777;
-                  }),
+                  },
+                ),
               }),
             ),
           });


### PR DESCRIPTION
Permissions can be unset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the permissions field validation to allow it to be optional, ensuring that leaving the field blank does not trigger an error while still validating any provided value in octal notation. 
- **Documentation**
  - Removed the translation entry for the message indicating that permissions are required, which may affect user communication regarding permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->