### PR TITLE
EDM-1374: monitorType casing changed

### DIFF
--- a/libs/types/models/DeviceResourceStatus.ts
+++ b/libs/types/models/DeviceResourceStatus.ts
@@ -7,8 +7,7 @@ import type { DeviceResourceStatusType } from './DeviceResourceStatusType';
  * Current status of the resources of the device.
  */
 export type DeviceResourceStatus = {
-  cpu: DeviceResourceStatusType;
-  memory: DeviceResourceStatusType;
-  disk: DeviceResourceStatusType;
+  CPU: DeviceResourceStatusType;
+  Memory: DeviceResourceStatusType;
+  Disk: DeviceResourceStatusType;
 };
-

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsTabContent/SystemResourcesContent.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsTabContent/SystemResourcesContent.tsx
@@ -23,19 +23,19 @@ const SystemResourcesContent = ({ device }: { device: Required<Device> }) => {
           <DescriptionListGroup>
             <DescriptionListTerm>{t('CPU pressure')}</DescriptionListTerm>
             <DescriptionListDescription>
-              <DeviceResourceStatus device={device} monitorType="cpu" />
+              <DeviceResourceStatus device={device} monitorType="CPU" />
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTerm>{t('Disk pressure')}</DescriptionListTerm>
             <DescriptionListDescription>
-              <DeviceResourceStatus device={device} monitorType="disk" />
+              <DeviceResourceStatus device={device} monitorType="Disk" />
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTerm>{t('Memory pressure')}</DescriptionListTerm>
             <DescriptionListDescription>
-              <DeviceResourceStatus device={device} monitorType="memory" />
+              <DeviceResourceStatus device={device} monitorType="Memory" />
             </DescriptionListDescription>
           </DescriptionListGroup>
         </FlightControlDescriptionList>

--- a/libs/ui-components/src/components/Status/DeviceResourceStatus.tsx
+++ b/libs/ui-components/src/components/Status/DeviceResourceStatus.tsx
@@ -13,15 +13,15 @@ import { useTranslation } from '../../hooks/useTranslation';
 import { StatusLevel } from '../../utils/status/common';
 import { StatusDisplayContent } from './StatusDisplay';
 
-type MonitorType = keyof DeviceResourceStatus; /* cpu / disk / memory */
+type MonitorType = keyof DeviceResourceStatus; /* CPU / Disk / Memory */
 
 const getMonitorTypeLabel = (monitorType: MonitorType, t: TFunction) => {
   switch (monitorType) {
-    case 'cpu':
+    case 'CPU':
       return t('CPU');
-    case 'memory':
+    case 'Memory':
       return t('Memory');
-    case 'disk':
+    case 'Disk':
       return t('Disk');
   }
 };


### PR DESCRIPTION
Device resources alertRules details were not being displayed in the UI since the `monitorType` casing didn't match between two types.

This changes in https://github.com/flightctl/flightctl/pull/1079, and now the UI will show those details.

![image](https://github.com/user-attachments/assets/c0648e2d-4f96-4f8b-bd05-2cd3b95da15c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Standardized the casing of system resource labels (CPU, Memory, Disk) to ensure consistent and clear display across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->