### PR TITLE
Revert "EDM-1374: monitorType casing changed (#276)"

### DIFF
--- a/libs/types/models/DeviceResourceStatus.ts
+++ b/libs/types/models/DeviceResourceStatus.ts
@@ -7,7 +7,8 @@ import type { DeviceResourceStatusType } from './DeviceResourceStatusType';
  * Current status of the resources of the device.
  */
 export type DeviceResourceStatus = {
-  CPU: DeviceResourceStatusType;
-  Memory: DeviceResourceStatusType;
-  Disk: DeviceResourceStatusType;
+  cpu: DeviceResourceStatusType;
+  memory: DeviceResourceStatusType;
+  disk: DeviceResourceStatusType;
 };
+

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsTabContent/SystemResourcesContent.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsTabContent/SystemResourcesContent.tsx
@@ -23,19 +23,19 @@ const SystemResourcesContent = ({ device }: { device: Required<Device> }) => {
           <DescriptionListGroup>
             <DescriptionListTerm>{t('CPU pressure')}</DescriptionListTerm>
             <DescriptionListDescription>
-              <DeviceResourceStatus device={device} monitorType="CPU" />
+              <DeviceResourceStatus device={device} monitorType="cpu" />
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTerm>{t('Disk pressure')}</DescriptionListTerm>
             <DescriptionListDescription>
-              <DeviceResourceStatus device={device} monitorType="Disk" />
+              <DeviceResourceStatus device={device} monitorType="disk" />
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTerm>{t('Memory pressure')}</DescriptionListTerm>
             <DescriptionListDescription>
-              <DeviceResourceStatus device={device} monitorType="Memory" />
+              <DeviceResourceStatus device={device} monitorType="memory" />
             </DescriptionListDescription>
           </DescriptionListGroup>
         </FlightControlDescriptionList>

--- a/libs/ui-components/src/components/Status/DeviceResourceStatus.tsx
+++ b/libs/ui-components/src/components/Status/DeviceResourceStatus.tsx
@@ -13,15 +13,15 @@ import { useTranslation } from '../../hooks/useTranslation';
 import { StatusLevel } from '../../utils/status/common';
 import { StatusDisplayContent } from './StatusDisplay';
 
-type MonitorType = keyof DeviceResourceStatus; /* CPU / Disk / Memory */
+type MonitorType = keyof DeviceResourceStatus; /* cpu / disk / memory */
 
 const getMonitorTypeLabel = (monitorType: MonitorType, t: TFunction) => {
   switch (monitorType) {
-    case 'CPU':
+    case 'cpu':
       return t('CPU');
-    case 'Memory':
+    case 'memory':
       return t('Memory');
-    case 'Disk':
+    case 'disk':
       return t('Disk');
   }
 };


### PR DESCRIPTION
This reverts commit 52b8e761aaa5aee4df794df21c77f91bf896d263.


Backend reverted the changes https://github.com/flightctl/flightctl/pull/1094

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated resource type labels for device status and monitoring from uppercase (e.g., "CPU", "Memory", "Disk") to lowercase ("cpu", "memory", "disk") throughout the interface for consistency. No visible changes to functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->