### PR TITLE
EDM-1374: API structure for MonitorResource changed

### DIFF
--- a/libs/types/index.ts
+++ b/libs/types/index.ts
@@ -23,7 +23,6 @@ export { ConditionType } from './models/ConditionType';
 export type { ConfigProviderSpec } from './models/ConfigProviderSpec';
 export type { CpuResourceMonitorSpec } from './models/CpuResourceMonitorSpec';
 export type { CronExpression } from './models/CronExpression';
-export type { CustomResourceMonitorSpec } from './models/CustomResourceMonitorSpec';
 export type { Device } from './models/Device';
 export type { DeviceApplicationsSummaryStatus } from './models/DeviceApplicationsSummaryStatus';
 export type { DeviceApplicationStatus } from './models/DeviceApplicationStatus';

--- a/libs/types/models/CpuResourceMonitorSpec.ts
+++ b/libs/types/models/CpuResourceMonitorSpec.ts
@@ -3,5 +3,10 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { ResourceMonitorSpec } from './ResourceMonitorSpec';
-export type CpuResourceMonitorSpec = ResourceMonitorSpec;
+export type CpuResourceMonitorSpec = ({
+  /**
+   * The type of resource to monitor.
+   */
+  monitorType: string;
+} & ResourceMonitorSpec);
 

--- a/libs/types/models/CustomResourceMonitorSpec.ts
+++ b/libs/types/models/CustomResourceMonitorSpec.ts
@@ -1,7 +1,0 @@
-/* generated using openapi-typescript-codegen -- do no edit */
-/* istanbul ignore file */
-/* tslint:disable */
-/* eslint-disable */
-import type { ResourceMonitorSpec } from './ResourceMonitorSpec';
-export type CustomResourceMonitorSpec = (ResourceMonitorSpec & Record<string, any>);
-

--- a/libs/types/models/DiskResourceMonitorSpec.ts
+++ b/libs/types/models/DiskResourceMonitorSpec.ts
@@ -5,6 +5,11 @@
 import type { ResourceMonitorSpec } from './ResourceMonitorSpec';
 export type DiskResourceMonitorSpec = (ResourceMonitorSpec & {
   /**
+   * The type of resource to monitor.
+   */
+  monitorType: string;
+} & {
+  /**
    * The directory path to monitor for disk usage.
    */
   path: string;

--- a/libs/types/models/MemoryResourceMonitorSpec.ts
+++ b/libs/types/models/MemoryResourceMonitorSpec.ts
@@ -3,5 +3,10 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { ResourceMonitorSpec } from './ResourceMonitorSpec';
-export type MemoryResourceMonitorSpec = ResourceMonitorSpec;
+export type MemoryResourceMonitorSpec = ({
+  /**
+   * The type of resource to monitor.
+   */
+  monitorType: string;
+} & ResourceMonitorSpec);
 

--- a/libs/types/models/ResourceMonitorSpec.ts
+++ b/libs/types/models/ResourceMonitorSpec.ts
@@ -8,10 +8,6 @@ import type { ResourceAlertRule } from './ResourceAlertRule';
  */
 export type ResourceMonitorSpec = {
   /**
-   * The type of resource to monitor.
-   */
-  monitorType: string;
-  /**
    * Array of alert rules. Only one alert per severity is allowed.
    */
   alertRules: Array<ResourceAlertRule>;

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsTabContent/SystemResourcesContent.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsTabContent/SystemResourcesContent.tsx
@@ -10,7 +10,7 @@ import { Device } from '@flightctl/types';
 import { useTranslation } from '../../../../hooks/useTranslation';
 import DetailsPageCard, { DetailsPageCardBody } from '../../../DetailsPage/DetailsPageCard';
 import FlightControlDescriptionList from '../../../common/FlightCtlDescriptionList';
-import DeviceResourceStatus from '../../../Status/DeviceResourceStatus';
+import DeviceResourceStatus, { MonitorType } from '../../../Status/DeviceResourceStatus';
 
 const SystemResourcesContent = ({ device }: { device: Required<Device> }) => {
   const { t } = useTranslation();
@@ -23,19 +23,19 @@ const SystemResourcesContent = ({ device }: { device: Required<Device> }) => {
           <DescriptionListGroup>
             <DescriptionListTerm>{t('CPU pressure')}</DescriptionListTerm>
             <DescriptionListDescription>
-              <DeviceResourceStatus device={device} monitorType="cpu" />
+              <DeviceResourceStatus device={device} monitorType={MonitorType.cpu} />
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTerm>{t('Disk pressure')}</DescriptionListTerm>
             <DescriptionListDescription>
-              <DeviceResourceStatus device={device} monitorType="disk" />
+              <DeviceResourceStatus device={device} monitorType={MonitorType.disk} />
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTerm>{t('Memory pressure')}</DescriptionListTerm>
             <DescriptionListDescription>
-              <DeviceResourceStatus device={device} monitorType="memory" />
+              <DeviceResourceStatus device={device} monitorType={MonitorType.memory} />
             </DescriptionListDescription>
           </DescriptionListGroup>
         </FlightControlDescriptionList>

--- a/libs/ui-components/src/components/Status/DeviceResourceStatus.tsx
+++ b/libs/ui-components/src/components/Status/DeviceResourceStatus.tsx
@@ -6,28 +6,32 @@ import {
   DeviceResourceStatus,
   DeviceResourceStatusType,
   ResourceAlertSeverityType,
-  ResourceMonitorSpec,
+  ResourceMonitor,
 } from '@flightctl/types';
 
 import { useTranslation } from '../../hooks/useTranslation';
 import { StatusLevel } from '../../utils/status/common';
 import { StatusDisplayContent } from './StatusDisplay';
 
-type MonitorType = keyof DeviceResourceStatus; /* cpu / disk / memory */
+export enum MonitorType {
+  cpu = 'cpu',
+  disk = 'disk',
+  memory = 'memory',
+}
 
 const getMonitorTypeLabel = (monitorType: MonitorType, t: TFunction) => {
   switch (monitorType) {
-    case 'cpu':
+    case MonitorType.cpu:
       return t('CPU');
-    case 'memory':
+    case MonitorType.memory:
       return t('Memory');
-    case 'disk':
+    case MonitorType.disk:
       return t('Disk');
   }
 };
 
 const getTriggeredResourceAlert = (
-  resourcesInfo: Array<ResourceMonitorSpec>,
+  resourcesInfo: Array<ResourceMonitor>,
   monitorType: MonitorType,
   monitorStatus?: DeviceResourceStatusType,
 ) => {
@@ -41,7 +45,7 @@ const getTriggeredResourceAlert = (
     return null;
   }
   const monitorDetails = resourcesInfo.find(
-    (item) => item.monitorType.toLowerCase() === monitorType.toLowerCase() && item.alertRules.length > 0,
+    (item) => item.monitorType.toLowerCase() === monitorType && item.alertRules.length > 0,
   );
   if (!monitorDetails) {
     return null;


### PR DESCRIPTION
Aligns to the latest changes in https://github.com/flightctl/flightctl/pull/1110 which were already merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized the use of a `MonitorType` enum throughout the user interface, replacing string literals for resource types.
  - Updated type definitions for resource monitors to require a `monitorType` property where applicable.
  - Removed and cleaned up unused or redundant type definitions related to custom resource monitors.

- **Style**
  - Improved consistency in how resource monitor types are referenced and displayed in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->