### PR TITLE
EDM-977: Allow to close the Actions menu when focus is lost

### DIFF
--- a/libs/ui-components/src/components/DetailsPage/DetailsPageActions.tsx
+++ b/libs/ui-components/src/components/DetailsPage/DetailsPageActions.tsx
@@ -80,6 +80,7 @@ const DetailsPageActions = ({ children }: React.PropsWithChildren<unknown>) => {
     <Dropdown
       isOpen={actionsOpen}
       onSelect={() => setActionsOpen(false)}
+      onOpenChange={(isOpen: boolean) => setActionsOpen(isOpen)}
       popperProps={{ position: 'left', preventOverflow: true }}
       toggle={(toggleRef) => (
         <MenuToggle


### PR DESCRIPTION
Allows the Details page actions to be closed when focus is lost (click somewhere outside, or with "Esc" key)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved dropdown menu behavior on the details page, allowing for more consistent opening and closing of actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->