### PR TITLE
EDM-259: Unify form labels format

### DIFF
--- a/libs/cypress/pages/CreateFleetWizardPage.ts
+++ b/libs/cypress/pages/CreateFleetWizardPage.ts
@@ -16,7 +16,7 @@ export class CreateFleetWizardPage {
   }
 
   get newFleetNameField() {
-    return cy.get('input[aria-label="Name"]');
+    return cy.get('input[aria-label="Fleet name"]');
   }
 
   openFleetRichValidationsPopover() {

--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -260,6 +260,7 @@
   "Update policies allow you to control when updates should be downloaded and applied.": "Update policies allow you to control when updates should be downloaded and applied.",
   "Default update policy": "Default update policy",
   "The device will download and apply updates as soon as they are available.": "The device will download and apply updates as soon as they are available.",
+  "Device alias": "Device alias",
   "Device labels": "Device labels",
   "Inline": "Inline",
   "Image based": "Image based",

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/steps/GeneralInfoStep.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/steps/GeneralInfoStep.tsx
@@ -44,7 +44,7 @@ const GeneralInfoStep = () => {
       <FlightCtlForm>
         <RichValidationTextField
           fieldName="deviceAlias"
-          aria-label={t('Alias')}
+          aria-label={t('Device alias')}
           validations={getLabelValueValidations(t)}
         />
         <FormGroup label={t('Device labels')}>

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ReviewDeviceStep.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ReviewDeviceStep.tsx
@@ -35,7 +35,7 @@ const ReviewStep = ({ error }: { error?: string }) => {
           }}
         >
           <DescriptionListGroup>
-            <DescriptionListTerm>{t('Alias')}</DescriptionListTerm>
+            <DescriptionListTerm>{t('Device alias')}</DescriptionListTerm>
             <DescriptionListDescription>{values.deviceAlias || t('Untitled')}</DescriptionListDescription>
           </DescriptionListGroup>
           {values.labels.length > 0 && (

--- a/libs/ui-components/src/components/Fleet/CreateFleet/steps/GeneralInfoStep.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/steps/GeneralInfoStep.tsx
@@ -24,7 +24,7 @@ const GeneralInfoStep = ({ isEdit }: { isEdit: boolean }) => {
       <FlightCtlForm>
         <NameField
           name="name"
-          aria-label={t('Name')}
+          aria-label={t('Fleet name')}
           isRequired
           isDisabled={isEdit}
           resourceType="fleets"

--- a/libs/ui-components/src/components/Fleet/CreateFleet/steps/ReviewStep.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/steps/ReviewStep.tsx
@@ -40,7 +40,7 @@ const ReviewStep = ({ error }: { error?: unknown }) => {
           }}
         >
           <DescriptionListGroup>
-            <DescriptionListTerm>{t('Name')}</DescriptionListTerm>
+            <DescriptionListTerm>{t('Fleet name')}</DescriptionListTerm>
             <DescriptionListDescription>{values.name}</DescriptionListDescription>
           </DescriptionListGroup>
           {values.fleetLabels.length > 0 && (


### PR DESCRIPTION
Change the format for name/alias fields so that it's always prefixed by the resource king (eg. Device alias, Fleet name)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new translation for "Device alias" in the English locale.

- **Style**
  - Updated labels and accessibility attributes to use more specific terms: "Alias" changed to "Device alias" and "Name" changed to "Fleet name" in relevant device and fleet components for improved clarity and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->