### PR TITLE
EDM-1227: Overwrite OCP style for labels in Decommission device switch

### DIFF
--- a/apps/ocp-plugin/src/components/AppContext/AppContext.css
+++ b/apps/ocp-plugin/src/components/AppContext/AppContext.css
@@ -1,0 +1,7 @@
+/* 
+  Overwrites style set by OCP's console global CSS
+  Classname is not passed to the root "label" element, we must target the PF switch first
+ */
+.pf-v5-c-switch .fctl-switch__label {
+  font-weight: normal;
+}

--- a/apps/ocp-plugin/src/components/AppContext/AppContext.tsx
+++ b/apps/ocp-plugin/src/components/AppContext/AppContext.tsx
@@ -22,6 +22,8 @@ import { getUser } from '@openshift-console/dynamic-plugin-sdk/lib/app/core/redu
 import { useSelector } from 'react-redux';
 import { useFetch } from '../../hooks/useFetch';
 
+import './AppContext.css';
+
 export const OCPPluginAppContext = AppContext.Provider;
 
 const appRoutes = {

--- a/libs/ui-components/src/components/Device/DevicesPage/DecommissionedDevicesTable.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/DecommissionedDevicesTable.tsx
@@ -100,7 +100,7 @@ const DecommissionedDevicesTable = ({
             <ToolbarItem alignSelf="center">
               <Switch
                 id="decommissioned-devices-switch"
-                label={t('Show only decommissioned devices')}
+                label={<span className="fctl-switch__label">{t('Show only decommissioned devices')}</span>}
                 isChecked
                 onChange={() => {
                   setOnlyDecommissioned(false);

--- a/libs/ui-components/src/components/Device/DevicesPage/EnrolledDevicesTable.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/EnrolledDevicesTable.tsx
@@ -155,7 +155,7 @@ const EnrolledDevicesTable = ({
         <ToolbarItem alignSelf="center">
           <Switch
             id="enrolled-devices-switch"
-            label={t('Show only decommissioned devices')}
+            label={<span className="fctl-switch__label">{t('Show only decommissioned devices')}</span>}
             isChecked={false}
             onChange={() => {
               clearAllFilters();


### PR DESCRIPTION
Overwrites the CSS style created from the OCP console's CSS [here](https://github.com/openshift/console/blob/main/frontend/public/style/ancillary/_bootstrap-residual.scss#L16) which effectively styles all labels with a bold font.

![loaded-style](https://github.com/user-attachments/assets/4ea42722-6462-45ca-9c38-72fd19b777c7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved the appearance of switch labels in device tables for better visual consistency.
  - Adjusted font weight of switch labels to match the overall design.

- **Chores**
  - Updated CSS handling to ensure consistent styling overrides within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->