### PR TITLE
NO-ISSUE: Override UBI inherited labels for Flightctl images

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -22,5 +22,12 @@ FROM registry.access.redhat.com/ubi9/ubi-micro
 COPY --from=ui-build /app/apps/standalone/dist /app/proxy/dist
 COPY --from=proxy-build /app/flightctl-ui /app/proxy
 WORKDIR /app/proxy
+LABEL \
+  com.redhat.component="flightctl-ui-container" \
+  description="Flightctl User Interface Service" \
+  io.k8s.description="Flightctl User Interface Service" \
+  io.k8s.display-name="Flightctl UI" \
+  name="flightctl-ui" \
+  summary="Flightctl User Interface Service"
 EXPOSE 8080
 CMD ./flightctl-ui

--- a/Containerfile.ocp
+++ b/Containerfile.ocp
@@ -22,5 +22,12 @@ FROM registry.access.redhat.com/ubi9/ubi-micro
 COPY --from=ui-build /app/apps/ocp-plugin/dist /app/proxy/dist
 COPY --from=proxy-build /app/flightctl-ui /app/proxy
 WORKDIR /app/proxy
+LABEL \
+  com.redhat.component="flightctl-ui-ocp-container" \
+  description="Flightctl User Interface Service for OCP Integration" \
+  io.k8s.description="Flightctl User Interface Service for OCP Integration" \
+  io.k8s.display-name="Flightctl UI (OCP)" \
+  name="flightctl-ui-ocp" \
+  summary="Flightctl User Interface Service for OCP Integration"
 EXPOSE 8080
 CMD ./flightctl-ui


### PR DESCRIPTION
To comply with release policies, override the following inherited labels in the container images:
- com.redhat.component
- description
- io.k8s.description
- io.k8s.display-name
- name
- summary

Adjusted values based on product definitions for:
- flightctl-ui
- flightctl-ui-ocp

This ensures accurate metadata and resolves Conforma policy violations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added descriptive metadata labels to container images, enhancing identification and documentation without impacting runtime behavior or build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->