### PR TITLE
EDM-1582: Redirect to Device details after approving from ER details

### DIFF
--- a/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestDetails/EnrollmentRequestDetails.tsx
+++ b/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestDetails/EnrollmentRequestDetails.tsx
@@ -47,7 +47,7 @@ const EnrollmentRequestDetails = () => {
     router: { useParams },
   } = useAppContext();
   const { enrollmentRequestId } = useParams() as { enrollmentRequestId: string };
-  const [er, loading, error, refetch] = useFetchPeriodically<EnrollmentRequest>({
+  const [er, loading, error] = useFetchPeriodically<EnrollmentRequest>({
     endpoint: `enrollmentrequests/${enrollmentRequestId}`,
   });
   const { remove } = useFetch();
@@ -58,6 +58,7 @@ const EnrollmentRequestDetails = () => {
   const [isApprovalModalOpen, setIsApprovalModalOpen] = React.useState(false);
   const erSystemInfo = useDeviceSpecSystemInfo(er?.spec.deviceStatus?.systemInfo, t);
   const hasDefaultLabels = Object.keys(er?.spec.labels || {}).length > 0;
+  const deviceId = er?.metadata.name as string;
 
   const { deleteAction, deleteModal } = useDeleteAction({
     resourceName: enrollmentRequestId,
@@ -74,7 +75,7 @@ const EnrollmentRequestDetails = () => {
     <DetailsPage
       loading={loading}
       error={error}
-      id={er?.metadata.name as string}
+      id={deviceId}
       resourceLink={ROUTE.DEVICES}
       resourceType="Devices"
       resourceTypeLabel={t('Devices')}
@@ -101,7 +102,7 @@ const EnrollmentRequestDetails = () => {
               <FlightControlDescriptionList columnModifier={{ lg: '3Col' }}>
                 <DescriptionListGroup>
                   <DescriptionListTerm>{t('Name')}</DescriptionListTerm>
-                  <DescriptionListDescription>{er?.metadata.name || '-'}</DescriptionListDescription>
+                  <DescriptionListDescription>{deviceId}</DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
                   <DescriptionListTerm>{t('Last seen')}</DescriptionListTerm>
@@ -209,9 +210,9 @@ const EnrollmentRequestDetails = () => {
       {er && isApprovalModalOpen && (
         <ApproveDeviceModal
           enrollmentRequest={er}
-          onClose={(updateList) => {
+          onClose={(isApproved) => {
             setIsApprovalModalOpen(false);
-            updateList && refetch();
+            isApproved && navigate({ route: ROUTE.DEVICE_DETAILS, postfix: deviceId });
           }}
         />
       )}


### PR DESCRIPTION
If the approval fails, we keep the Approve device modal open and show the error.
If the approval succeeds, we redirect the user to the Device details page for the newly approved device.

https://github.com/user-attachments/assets/5634942a-3b6e-412f-9ab9-9699302a3694



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the consistency of device ID usage throughout the enrollment request details view.
  - Simplified state management by updating navigation behavior after device approval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->