### PR TITLE
Fix fleets route in OCP Plugin

### DIFF
--- a/apps/ocp-plugin/console-extensions.json
+++ b/apps/ocp-plugin/console-extensions.json
@@ -72,7 +72,7 @@
   {
     "type": "console.page/route",
     "properties": {
-      "exact": true,
+      "exact": false,
       "path": ["/edge/fleets/:fleetId"],
       "component": { "$codeRef": "FleetDetailsPage" }
     }

--- a/apps/ocp-plugin/start-ocp-console.sh
+++ b/apps/ocp-plugin/start-ocp-console.sh
@@ -19,15 +19,18 @@ echo "Starting local OpenShift console..."
 
 
 BRIDGE_BASE_ADDRESS="http://localhost:9000"
-BRIDGE_USER_AUTH="openshift"
+# The console's internal mechanism for user authentication via OAuth is disabled.
+# We are providing the authentication token directly to the console process, which it will use for all API calls.
+BRIDGE_USER_AUTH="disabled"
 BRIDGE_K8S_MODE="off-cluster"
-BRIDGE_K8S_AUTH="bearer-token"
 BRIDGE_CA_FILE="/tmp/ca.crt"
 BRIDGE_USER_AUTH_OIDC_CLIENT_ID="console-oauth-client"
 BRIDGE_USER_AUTH_OIDC_CLIENT_SECRET_FILE="/tmp/console-client-secret"
 BRIDGE_USER_AUTH_OIDC_CA_FILE="/tmp/ca.crt"
 BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS=true
 BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=$(oc whoami --show-server)
+BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token 2>/dev/null)
+
 # The monitoring operator is not always installed (e.g. for local OpenShift). Tolerate missing config maps.
 set +e
 BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.thanosPublicURL}' 2>/dev/null)


### PR DESCRIPTION
With the new subroutes for /details and /yaml, the Fleets page route was not working in the OCP plugin.

![fixed-route](https://github.com/user-attachments/assets/ad64f46d-cfe4-4c61-a430-b49f36d0952a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved route handling to support nested URLs under fleet details pages.
- **Chores**
  - Updated authentication method for the console to use direct bearer token authentication instead of internal OAuth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->