### PR TITLE
EDM-1629: Change label for switch of device type

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -156,7 +156,7 @@
   "Desired system image: {{ desiredOsImage }}": "Desired system image: {{ desiredOsImage }}",
   "Connection was closed": "Connection was closed",
   "Reconnect": "Reconnect",
-  "Show only decommissioned devices": "Show only decommissioned devices",
+  "Show decommissioned devices": "Show decommissioned devices",
   "Devices table": "Devices table",
   "Device already started decommissioning and cannot be edited.": "Device already started decommissioning and cannot be edited.",
   "View device details": "View device details",

--- a/libs/ui-components/src/components/Device/DevicesPage/DecommissionedDevicesTable.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/DecommissionedDevicesTable.tsx
@@ -100,12 +100,12 @@ const DecommissionedDevicesTable = ({
             <ToolbarItem alignSelf="center">
               <Switch
                 id="decommissioned-devices-switch"
-                label={<span className="fctl-switch__label">{t('Show only decommissioned devices')}</span>}
+                label={<span className="fctl-switch__label">{t('Show decommissioned devices')}</span>}
                 isChecked
                 onChange={() => {
                   setOnlyDecommissioned(false);
                 }}
-                ouiaId={t('Show only decommissioned devices')}
+                ouiaId={t('Show decommissioned devices')}
               />
             </ToolbarItem>
           </ToolbarGroup>

--- a/libs/ui-components/src/components/Device/DevicesPage/EnrolledDevicesTable.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/EnrolledDevicesTable.tsx
@@ -155,13 +155,13 @@ const EnrolledDevicesTable = ({
         <ToolbarItem alignSelf="center">
           <Switch
             id="enrolled-devices-switch"
-            label={<span className="fctl-switch__label">{t('Show only decommissioned devices')}</span>}
+            label={<span className="fctl-switch__label">{t('Show decommissioned devices')}</span>}
             isChecked={false}
             onChange={() => {
               clearAllFilters();
               setOnlyDecommissioned(true);
             }}
-            ouiaId={t('Show only decommissioned devices')}
+            ouiaId={t('Show decommissioned devices')}
           />
         </ToolbarItem>
       </DeviceTableToolbar>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the label text for the switch controlling decommissioned devices from "Show only decommissioned devices" to "Show decommissioned devices" for a clearer user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->