### PR TITLE
EDM-1634: Switch YAML viewer theme

### DIFF
--- a/libs/ui-components/src/components/Masthead/UserPreferencesModal.tsx
+++ b/libs/ui-components/src/components/Masthead/UserPreferencesModal.tsx
@@ -20,7 +20,7 @@ type UserPreferencesModalProps = {
 
 const UserPreferencesModal: React.FC<UserPreferencesModalProps> = ({ onClose }) => {
   const { t } = useTranslation();
-  const { theme, setTheme } = React.useContext(UserPreferencesContext);
+  const { userTheme, setUserTheme } = React.useContext(UserPreferencesContext);
 
   const themeLabels = getThemeLabels(t);
 
@@ -39,12 +39,12 @@ const UserPreferencesModal: React.FC<UserPreferencesModalProps> = ({ onClose }) 
                   onClick={() => setThemeExpanded(true)}
                   isExpanded={themeExpanded}
                 >
-                  {themeLabels[theme]}
+                  {themeLabels[userTheme]}
                 </MenuToggle>
               )}
-              selected={theme}
+              selected={userTheme}
               onSelect={(_, value) => {
-                setTheme(value as Theme);
+                setUserTheme(value as Theme);
                 setThemeExpanded(false);
               }}
               aria-label="theme"

--- a/libs/ui-components/src/components/Masthead/UserPreferencesProvider.tsx
+++ b/libs/ui-components/src/components/Masthead/UserPreferencesProvider.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
-import { Theme, useThemePreferences } from '../../hooks/useThemePreferences';
+import { ResolvedTheme, Theme, useThemePreferences } from '../../hooks/useThemePreferences';
 
-export const UserPreferencesContext = React.createContext<{
-  theme: Theme;
-  setTheme: (theme: Theme) => void;
-}>({
-  theme: 'system',
-  setTheme: () => {},
+type ThemeContext = {
+  userTheme: Theme; // Theme setting chosen by the user
+  resolvedTheme: ResolvedTheme; // Resolved theme based on user theme and system settings
+  setUserTheme: (theme: Theme) => void;
+};
+
+export const UserPreferencesContext = React.createContext<ThemeContext>({
+  userTheme: 'system',
+  resolvedTheme: 'dark',
+  setUserTheme: () => {},
 });
 
 export type UserPreferencesProviderProps = {
@@ -14,13 +18,14 @@ export type UserPreferencesProviderProps = {
 };
 
 export const UserPreferencesProvider: React.FC<UserPreferencesProviderProps> = ({ children }) => {
-  const { theme, setTheme } = useThemePreferences();
+  const { userTheme, resolvedTheme, setUserTheme } = useThemePreferences();
 
   return (
     <UserPreferencesContext.Provider
       value={{
-        theme,
-        setTheme,
+        userTheme,
+        resolvedTheme,
+        setUserTheme,
       }}
     >
       {children}

--- a/libs/ui-components/src/components/common/CodeEditor/YamlEditor.css
+++ b/libs/ui-components/src/components/common/CodeEditor/YamlEditor.css
@@ -2,7 +2,11 @@
   min-height: 70vh;
 }
 
-/* Style of the bar with the line numbers */
+/* Style of the bar with the line numbers for light and dark themes */
 .fctl-yaml-editor .monaco-editor .margin {
+  --vscode-editorGutter-background: #f5f5f5;
+}
+
+.pf-v5-theme-dark .fctl-yaml-editor .monaco-editor .margin {
   --vscode-editorGutter-background: #292e34;
 }

--- a/libs/ui-components/src/components/common/CodeEditor/YamlEditorBase.tsx
+++ b/libs/ui-components/src/components/common/CodeEditor/YamlEditorBase.tsx
@@ -10,6 +10,7 @@ import type * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 import ErrorBoundary from '../ErrorBoundary';
 import FlightCtlForm from '../../form/FlightCtlForm';
 import { useTranslation } from '../../../hooks/useTranslation';
+import { useThemePreferences } from '../../../hooks/useThemePreferences';
 // TODO add useShortcutPopover when adding saving capabilities to the YAML editor
 import { defineConsoleThemes } from './CodeEditorTheme';
 
@@ -30,6 +31,7 @@ const YamlEditorBase = ({ filename, code, onCancel, onReload }: YamlEditorBasePr
   const { t } = useTranslation();
   const editorRef = React.useRef<monacoEditor.editor.IStandaloneCodeEditor | null>(null);
   const monacoRef = React.useRef<typeof monacoEditor | null>(null);
+  const { resolvedTheme } = useThemePreferences();
 
   const [editorMounted, setEditorMounted] = React.useState(false);
 
@@ -87,7 +89,7 @@ const YamlEditorBase = ({ filename, code, onCancel, onReload }: YamlEditorBasePr
             monacoRef.current = instance;
           }}
           options={{
-            theme: 'console-dark',
+            theme: `console-${resolvedTheme}`,
             readOnly: true,
             readOnlyMessage: {
               value: t('Yaml is currently read-only'),

--- a/libs/ui-components/src/hooks/useThemePreferences.ts
+++ b/libs/ui-components/src/hooks/useThemePreferences.ts
@@ -2,18 +2,12 @@ import * as React from 'react';
 import { useUserPreferences } from './useUserPreferences';
 
 export const THEME_LOCAL_STORAGE_KEY = 'flightctl/theme';
+export const OCP_CONSOLE_THEME_LOCAL_STORAGE_KEY = 'bridge/theme';
+
 const THEME_DARK_CLASS = 'pf-v5-theme-dark';
 
 export type Theme = 'dark' | 'light' | 'system';
-
-export const updateThemeClass = (htmlTagElement: HTMLElement, theme: string | null) => {
-  const systemTheme: Theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-  if (theme === 'dark' || (!theme && systemTheme === 'dark')) {
-    htmlTagElement.classList.add(THEME_DARK_CLASS);
-  } else {
-    htmlTagElement.classList.remove(THEME_DARK_CLASS);
-  }
-};
+export type ResolvedTheme = Exclude<Theme, 'system'>;
 
 const getTheme = (storageTheme: string | null): Theme => {
   switch (storageTheme) {
@@ -29,9 +23,26 @@ const getTheme = (storageTheme: string | null): Theme => {
   }
 };
 
+const getDarkThemeMq = () => window.matchMedia('(prefers-color-scheme: dark)');
+
+const getResolvedTheme = (darkThemeMq: MediaQueryList, theme: string | null): ResolvedTheme => {
+  const isDarkPreferred = darkThemeMq.matches;
+  return theme === 'dark' || (isDarkPreferred && getTheme(theme) === 'system') ? 'dark' : 'light';
+};
+
+export const updateThemeClass = (htmlTagElement: HTMLElement, resolvedTheme: ResolvedTheme) => {
+  if (resolvedTheme === 'dark') {
+    htmlTagElement.classList.add(THEME_DARK_CLASS);
+  } else {
+    htmlTagElement.classList.remove(THEME_DARK_CLASS);
+  }
+};
+
 export const useThemePreferences = () => {
   const htmlTagElement = document.documentElement;
-  const [value, setValue] = useUserPreferences(THEME_LOCAL_STORAGE_KEY);
+  const [userTheme, setUserTheme] = useUserPreferences(THEME_LOCAL_STORAGE_KEY);
+  const [consoleTheme] = useUserPreferences(OCP_CONSOLE_THEME_LOCAL_STORAGE_KEY);
+  const [resolvedTheme, setResolvedTheme] = React.useState<ResolvedTheme>('light');
 
   React.useEffect(() => {
     const mqListener = (e: MediaQueryListEvent) => {
@@ -41,24 +52,40 @@ export const useThemePreferences = () => {
         htmlTagElement.classList.remove(THEME_DARK_CLASS);
       }
     };
-    const darkThemeMq = window.matchMedia('(prefers-color-scheme: dark)');
-    if (!value) {
-      darkThemeMq.addEventListener('change', mqListener);
+    const darkThemeMq = getDarkThemeMq();
+    let actualTheme: ResolvedTheme;
+    if (consoleTheme) {
+      actualTheme = getResolvedTheme(darkThemeMq, consoleTheme);
+    } else {
+      actualTheme = getResolvedTheme(darkThemeMq, userTheme);
+      updateThemeClass(htmlTagElement, actualTheme);
+      if (!userTheme) {
+        darkThemeMq.addEventListener('change', mqListener);
+      }
     }
-    updateThemeClass(htmlTagElement, value);
-    return () => darkThemeMq.removeEventListener('change', mqListener);
-  }, [htmlTagElement, value]);
+    setResolvedTheme(actualTheme);
+
+    return () => {
+      if (!consoleTheme && !userTheme) {
+        darkThemeMq.removeEventListener('change', mqListener);
+      }
+    };
+  }, [htmlTagElement, userTheme, consoleTheme]);
 
   const setThemeState = React.useCallback(
     (theme: Theme) => {
-      setValue(theme);
-      updateThemeClass(htmlTagElement, theme);
+      const darkTheme = getDarkThemeMq();
+      const actualTheme = getResolvedTheme(darkTheme, theme);
+      updateThemeClass(htmlTagElement, actualTheme);
+      setUserTheme(theme);
+      setResolvedTheme(actualTheme);
     },
-    [htmlTagElement, setValue],
+    [htmlTagElement, setUserTheme],
   );
 
   return {
-    theme: getTheme(value),
-    setTheme: setThemeState,
+    userTheme: getTheme(userTheme),
+    setUserTheme: setThemeState,
+    resolvedTheme,
   };
 };


### PR DESCRIPTION
Yaml viewer theme was hardcoded to "dark".

Now it will changed base on the user settings (+browser settings when "system" is selected). 
Adapted also for the OCP plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The YAML editor now automatically adapts its appearance to match your selected theme preference (light or dark).
- **Improvements**
  - Theme selection and application are now more consistent, with enhanced handling of user, system, and console theme preferences for a smoother experience.
  - Visual updates to the YAML editor's line number gutter ensure proper styling in both light and dark themes.
  - User theme preferences now include both chosen and resolved themes, improving theme management across the application.
  - Theme-related labels and controls have been updated for clearer user interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->