### PR TITLE
EDM-1636: Update go to 1.23

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@ ENV NODE_OPTIONS='--max-old-space-size=8192'
 RUN npm ci
 RUN npm run build
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 as proxy-build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1747333074 as proxy-build
 WORKDIR /app
 COPY proxy /app
 USER 0

--- a/Containerfile.ocp
+++ b/Containerfile.ocp
@@ -12,7 +12,7 @@ ENV NODE_OPTIONS='--max-old-space-size=8192'
 RUN npm ci
 RUN npm run build:ocp
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 as proxy-build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1747333074 as proxy-build
 WORKDIR /app
 COPY proxy /app
 USER 0

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Monorepo containing UIs for [flightctl](https://github.com/flightctl/flightctl)
 
 ### Prerequisites:
-* `git`, `nodejs:18`, `npm:10`, `rsync`
+* `Git`, `Node.js v18.x`, `npm v10.x`, `rsync`, `go` (>= 1.23)
 
 ## Building
 

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -1,6 +1,6 @@
 module github.com/flightctl/flightctl-ui
 
-go 1.21
+go 1.23
 
 require (
 	github.com/flightctl/flightctl v0.2.0

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -2,6 +2,8 @@ module github.com/flightctl/flightctl-ui
 
 go 1.23
 
+toolchain go1.23.0
+
 require (
 	github.com/flightctl/flightctl v0.2.0
 	github.com/gorilla/handlers v1.5.2


### PR DESCRIPTION
UI will use the same go version as the Backend. See https://github.com/flightctl/flightctl/pull/1206

Added also go toolchain 1.23.0 as in https://github.com/flightctl/flightctl/pull/1211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Go toolset version used for building the application to 1.23.
  - Updated documentation to reflect the new Go version requirement (1.23 or higher).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->