### PR TITLE
Fix running FC UI as an OCP plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,16 @@ or provide the CA certs:
 
 ### Running UI as OCP plugin
 
+With this option, the Flight Control UI will run as a Plugin in the OCP console.
+**Note**: this setup is only for development, do not use it in Production environments!
+
 Login to OCP cluster and run:
 
 ```
 npm run dev:ocp 
 ```
+
+By default, the latest available OpenShift console image will be used. To specify a different console version, set the `CONSOLE_VERSION` environment variable.
+
+The following console versions are confirmed to be compatible: 4.16 to 4.20.
+


### PR DESCRIPTION
The `npm run dev:ocp` script was not working for latest Console versions, only for version 4.16.

Modified the auth settings so the script is compatible with Console versions 4.16 to 4.20.
Since we'd be not having user auth, added a note regarding that this setup is not intented for Production purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced instructions for running the Flight Control UI as an OpenShift Container Platform plugin, clarifying its development-only usage, default console image behavior, environment variable override, and supported OpenShift console versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->