### PR TITLE
Update UI proxy go toolchain to 1.23.6

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -24,10 +24,10 @@ COPY --from=proxy-build /app/flightctl-ui /app/proxy
 WORKDIR /app/proxy
 LABEL \
   com.redhat.component="flightctl-ui-container" \
-  description="Flightctl User Interface Service" \
-  io.k8s.description="Flightctl User Interface Service" \
-  io.k8s.display-name="Flightctl UI" \
+  description="Flight Control User Interface Service" \
+  io.k8s.description="Flight Control User Interface Service" \
+  io.k8s.display-name="Flight Control UI" \
   name="flightctl-ui" \
-  summary="Flightctl User Interface Service"
+  summary="Flight Control User Interface Service"
 EXPOSE 8080
 CMD ./flightctl-ui

--- a/Containerfile.ocp
+++ b/Containerfile.ocp
@@ -24,10 +24,10 @@ COPY --from=proxy-build /app/flightctl-ui /app/proxy
 WORKDIR /app/proxy
 LABEL \
   com.redhat.component="flightctl-ui-ocp-container" \
-  description="Flightctl User Interface Service for OCP Integration" \
-  io.k8s.description="Flightctl User Interface Service for OCP Integration" \
-  io.k8s.display-name="Flightctl UI (OCP)" \
+  description="Flight Control User Interface Service for OCP Integration" \
+  io.k8s.description="Flight Control User Interface Service for OCP Integration" \
+  io.k8s.display-name="Flight Control UI (OCP)" \
   name="flightctl-ui-ocp" \
-  summary="Flightctl User Interface Service for OCP Integration"
+  summary="Flight Control User Interface Service for OCP Integration"
 EXPOSE 8080
 CMD ./flightctl-ui

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl-ui
 
 go 1.23
 
-toolchain go1.23.0
+toolchain go1.23.6
 
 require (
 	github.com/flightctl/flightctl v0.2.0


### PR DESCRIPTION
Following the discussions in https://github.com/flightctl/flightctl/pull/1211 and https://github.com/flightctl/flightctl/pull/1219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Chores**
  - Updated the Go toolchain version for improved stability and compatibility.
  - Refined container image metadata labels to update service naming for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->