### PR TITLE
EDM-1511: Keep app volumes

### DIFF
--- a/libs/ui-components/src/types/deviceSpec.ts
+++ b/libs/ui-components/src/types/deviceSpec.ts
@@ -4,6 +4,7 @@ import {
   GitConfigProviderSpec,
   HttpConfigProviderSpec,
   ImageApplicationProviderSpec,
+  ImagePullPolicy,
   InlineApplicationProviderSpec,
   InlineConfigProviderSpec,
   KubernetesSecretProviderSpec,
@@ -48,6 +49,11 @@ type AppBase = {
   // appType: AppType - commented out for now, since it only accepts one value ("compose")
   name?: string;
   variables: { name: string; value: string }[];
+  volumes?: {
+    name: string;
+    reference: string;
+    pullPolicy?: ImagePullPolicy;
+  }[];
 };
 
 export type InlineAppForm = AppBase & {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for specifying and managing application volumes in device configuration forms.
	- Users can now input, view, and edit volume details (name, reference, and pull policy) when configuring applications.

- **Bug Fixes**
	- Ensured accurate display and handling of volume information when editing or reviewing device application settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->