### PR TITLE
EDM-532: Allow navigating menus via Keyboard

### DIFF
--- a/libs/ui-components/src/components/DetailsPage/DetailsPageActions.tsx
+++ b/libs/ui-components/src/components/DetailsPage/DetailsPageActions.tsx
@@ -127,6 +127,8 @@ const DetailsPageActions = ({ children }: React.PropsWithChildren) => {
       onSelect={() => setActionsOpen(false)}
       onOpenChange={(isOpen: boolean) => setActionsOpen(isOpen)}
       popperProps={{ position: 'left', preventOverflow: true }}
+      shouldFocusToggleOnSelect
+      shouldFocusFirstItemOnOpen
       toggle={(toggleRef) => (
         <MenuToggle
           ref={toggleRef}

--- a/libs/ui-components/src/components/form/FilterSelect.tsx
+++ b/libs/ui-components/src/components/form/FilterSelect.tsx
@@ -43,6 +43,8 @@ const FilterSelect = ({ placeholder, selectedFilters, isFilterUpdating, children
     <Select
       aria-label={placeholder}
       role="menu"
+      shouldFocusToggleOnSelect
+      shouldFocusFirstItemOnOpen
       toggle={(toggleRef) => (
         <MenuToggle
           ref={toggleRef}

--- a/libs/ui-components/src/components/form/FormSelect.tsx
+++ b/libs/ui-components/src/components/form/FormSelect.tsx
@@ -66,6 +66,8 @@ const FormSelect = ({
           setValue(value as string, true);
           setIsOpen(false);
         }}
+        shouldFocusToggleOnSelect
+        shouldFocusFirstItemOnOpen
         toggle={(toggleRef) => (
           <MenuToggle
             status={statusToggle}


### PR DESCRIPTION
Allows to navigate with the Dropdown menus in the application with the keyboard.
Works both for the "normal" Dropdowns, as well as the Typeahead ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved keyboard navigation and focus management across select, typeahead select, filter select, and dropdown components.
  * Added options to auto-focus the toggle after selection and to focus the first item when opening menus.
  * Enhanced ARIA linkage and focus indicators to improve accessibility for keyboard users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->