### PR TITLE
EDM-1499: Update go to version 1.23.9

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@ ENV NODE_OPTIONS='--max-old-space-size=8192'
 RUN npm ci
 RUN npm run build
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1747333074 as proxy-build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as proxy-build
 WORKDIR /app
 COPY proxy /app
 USER 0

--- a/Containerfile.ocp
+++ b/Containerfile.ocp
@@ -12,7 +12,7 @@ ENV NODE_OPTIONS='--max-old-space-size=8192'
 RUN npm ci
 RUN npm run build:ocp
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1747333074 as proxy-build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as proxy-build
 WORKDIR /app
 COPY proxy /app
 USER 0

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl-ui
 
 go 1.23
 
-toolchain go1.23.6
+toolchain go1.23.9
 
 require (
 	github.com/flightctl/flightctl v0.2.0


### PR DESCRIPTION
Fixes CVE in go 1.23.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the base image and Go toolchain version to improve environment consistency and maintain up-to-date dependencies. No changes to features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->