### PR TITLE
EDM-1839: FIPS-enable the UI proxy image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -16,9 +16,9 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as proxy-build
 WORKDIR /app
 COPY proxy /app
 USER 0
-RUN go build
+RUN CGO_ENABLED=1 CGO_CFLAGS=-flto GOEXPERIMENT=strictfipsruntime go build
 
-FROM registry.access.redhat.com/ubi9/ubi-micro
+FROM quay.io/flightctl/flightctl-base:9.6-1752500771
 COPY --from=ui-build /app/apps/standalone/dist /app/proxy/dist
 COPY --from=proxy-build /app/flightctl-ui /app/proxy
 WORKDIR /app/proxy

--- a/Containerfile.ocp
+++ b/Containerfile.ocp
@@ -16,9 +16,9 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as proxy-build
 WORKDIR /app
 COPY proxy /app
 USER 0
-RUN go build
+RUN CGO_ENABLED=1 CGO_CFLAGS=-flto GOEXPERIMENT=strictfipsruntime go build
 
-FROM registry.access.redhat.com/ubi9/ubi-micro
+FROM quay.io/flightctl/flightctl-base:9.6-1752500771
 COPY --from=ui-build /app/apps/ocp-plugin/dist /app/proxy/dist
 COPY --from=proxy-build /app/flightctl-ui /app/proxy
 WORKDIR /app/proxy


### PR DESCRIPTION
This patch adds the environment variables to make the go-toolset build the proxy binary with FIPS-compatible crypto. As this requires OpenSSL's libcrypto.so shared library to be present, it also updates the base Container image to one containing that lib.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process to enhance security and optimization for the proxy component.
  * Changed the base image used for deployments to a new, custom image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->