### PR TITLE
EDM-1933: Use basic configurations can be disabled

### DIFF
--- a/libs/ui-components/src/components/Fleet/CreateFleet/steps/UpdatePolicyStep.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/steps/UpdatePolicyStep.tsx
@@ -27,7 +27,7 @@ const UpdatePolicyStep = ({ isReadOnly }: { isReadOnly: boolean }) => {
   return (
     <Grid lg={8}>
       <FlightCtlForm>
-        <CheckboxField name="useBasicUpdateConfig" label={t('Use basic configurations')} />
+        <CheckboxField name="useBasicUpdateConfig" label={t('Use basic configurations')} isDisabled={isReadOnly} />
         {!useBasicUpdateConfig ? (
           <FormSection title={t('Advanced configurations')} titleElement="h1" className="pf-v5-u-mt-sm">
             {/* Rollout policies */}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The update policy checkbox is now disabled when the form is in read-only mode, improving clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->