### PR TITLE
EDM-1939: Prevent crash when users type special characters

### DIFF
--- a/libs/ui-components/src/components/Device/DevicesPage/DeviceToolbarFilters.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/DeviceToolbarFilters.tsx
@@ -40,6 +40,9 @@ type LabelFleetSelectorProps = {
   placeholder?: string;
 };
 
+// Escapes special characters (eg. 'hello.world' becomes 'hello\\.world')
+const escapeRegExp = (text: string) => text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 const LabelFleetResults = ({
   filterText,
   allLabels,
@@ -56,7 +59,8 @@ const LabelFleetResults = ({
   allLabels: FlightCtlLabel[];
 }) => {
   const { t } = useTranslation();
-  const regexp = React.useMemo(() => new RegExp(`(${filterText})`, 'g'), [filterText]);
+
+  const regexp = React.useMemo(() => new RegExp(`(${escapeRegExp(filterText)})`, 'g'), [filterText]);
 
   const searchHighlighter = React.useCallback(
     (text: string) => {


### PR DESCRIPTION
Prevent crashing the Devices page when users type opening parenthesis/brackets in the Search field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter functionality to handle special characters correctly when searching, ensuring accurate and reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->