### PR TITLE
Upgrade node to v22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 22.x
       - name: Check if PR is draft
         id: check
         run: |
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 22.x
       - name: Install dependencies
         run: npm ci
       - name: Attempt a build
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 22.x
       - name: Install dependencies
         run: npm ci
       - name: Attempt a build
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 22.x
       - name: Install dependencies
         run: npm ci
       - name: Attempt a build
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 22.x
       - name: Run integration tests
         uses: cypress-io/github-action@v6
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: npm
-          node-version: ${{ vars.NODEJS_VERSION }}
+          node-version: 22.x
 
       - name: Install dependencies
         run: npm ci

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/nodejs-18-minimal:latest as ui-build
+FROM registry.access.redhat.com/ubi9/nodejs-22-minimal:latest as ui-build
 USER root
 RUN microdnf install -y rsync
 

--- a/Containerfile.ocp
+++ b/Containerfile.ocp
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/nodejs-18-minimal:latest as ui-build
+FROM registry.access.redhat.com/ubi9/nodejs-22-minimal:latest as ui-build
 USER root
 RUN microdnf install -y rsync
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Monorepo containing UIs for [flightctl](https://github.com/flightctl/flightctl)
 
 ### Prerequisites:
-* `Git`, `Node.js v18.x`, `npm v10.x`, `rsync`, `go` (>= 1.23)
+* `Git`, `Node.js v22.x`, `npm v10.x`, `rsync`, `go` (>= 1.23)
 
 ## Building
 


### PR DESCRIPTION
Node 18 finished life support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the base image for the UI build to use Node.js 22.
  * Updated documentation to reflect Node.js 22 as a prerequisite.
  * Standardized Node.js version to 22.x in continuous integration and release workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->