### PR TITLE
EDM-1997: Show alert title as received from the API by default

### DIFF
--- a/libs/ui-components/src/components/OverviewPage/Cards/Alerts/AlertsCard.tsx
+++ b/libs/ui-components/src/components/OverviewPage/Cards/Alerts/AlertsCard.tsx
@@ -116,6 +116,12 @@ const resourceKindLabel = (t: TFunction, resourceKind: ResourceKind | undefined)
       return t('Template version');
   }
 };
+const getAlertTitle = (alert: AlertManagerAlert, defaultTitle: string) => {
+  if (alert.annotations.summary) {
+    return alert.annotations.summary;
+  }
+  return defaultTitle;
+};
 
 const AlertsCard = () => {
   const { t } = useTranslation();
@@ -154,7 +160,7 @@ const AlertsCard = () => {
                   <Icon status="danger" size="md">
                     <ExclamationCircleIcon />
                   </Icon>{' '}
-                  <strong>{alertTypes[alertName] || alertName}</strong>
+                  <strong>{getAlertTitle(alert, alertTypes[alertName] || alertName)}</strong>
                 </StackItem>
                 <StackItem>
                   <TextContent>


### PR DESCRIPTION
By default, show the human-readable message for alerts provided by the API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alert cards now prioritize showing an alert’s provided summary as the title when available, improving clarity and context.
  * When no summary is present, titles seamlessly fall back to the usual default/translated title.
  * This update affects only how titles are displayed; performance, data loading, and other behaviors remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->