### PR TITLE
EDM-2081: Add better placeholder for device tracked systemd units

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -296,7 +296,6 @@
   "Add service": "Add service",
   "Tracked systemd services": "Tracked systemd services",
   "Systemd service name": "Systemd service name",
-  "Type here": "Type here",
   "Track services": "Track services",
   "Approve": "Approve",
   "Certificate signing request": "Certificate signing request",

--- a/libs/ui-components/src/components/Device/SystemdUnitsModal/TrackSystemdUnitsForm.tsx
+++ b/libs/ui-components/src/components/Device/SystemdUnitsModal/TrackSystemdUnitsForm.tsx
@@ -56,7 +56,7 @@ const TrackSystemdUnitsForm: React.FC<TrackSystemdUnitsFormProps> = ({ onClose, 
     <FlightCtlForm>
       <TextInput
         aria-label={t('Systemd service name')}
-        placeholder={t('Type here')}
+        placeholder="name.service"
         value={currentText}
         onBlur={onAdd}
         onKeyDown={(ev) => {


### PR DESCRIPTION
Use "name.service" in devices details page, same as in EditFleet wizard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Track Systemd Units input placeholder to “name.service” for clearer guidance.
* **Chores**
  * Removed the “Type here” translation entry from the English locale.
  * Placeholder for the Track Systemd Units input is no longer localized and will display in English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->