### PR TITLE
Adjust new subnav bar to UX designs

### DIFF
--- a/apps/standalone/src/app/components/AppLayout/AppNavigation.tsx
+++ b/apps/standalone/src/app/components/AppLayout/AppNavigation.tsx
@@ -10,7 +10,7 @@ const AppNavigation = () => {
   const { t } = useTranslation();
   return (
     <Nav id="flightclt-nav" theme="dark">
-      <NavList id="flightclt-navlist">
+      <NavList id="flightclt-navlist" style={{ padding: 0 }}>
         {getAppRoutes(t)
           .filter((route) => route.showInNav)
           .map((route) => {

--- a/apps/standalone/src/app/components/AppLayout/AppToolbar.css
+++ b/apps/standalone/src/app/components/AppLayout/AppToolbar.css
@@ -1,3 +1,15 @@
-.fctl-app_toolbar {
-    justify-content: end;
+.fctl-app_toolbar,
+.fctl-subnav_toolbar {
+  justify-content: flex-end;
+}
+
+/* Extra navigation bar for global actions (organization switcher, copy login command, etc.) */
+/* We make it as tall as the navigation menu items on the left */
+#global-actions-masthead {
+  padding: 0;
+  --pf-v5-c-masthead--m-display-inline__content--MinHeight: 3.5rem;
+}
+
+#global-actions-masthead .fctl-subnav_toolbar {
+  --pf-v5-c-toolbar--BackgroundColor: var(--pf-v5-global--BackgroundColor--dark-300);
 }

--- a/libs/ui-components/src/components/common/PageNavigation.tsx
+++ b/libs/ui-components/src/components/common/PageNavigation.tsx
@@ -3,6 +3,8 @@ import {
   Dropdown,
   DropdownItem,
   DropdownList,
+  Masthead,
+  MastheadContent,
   MenuToggle,
   MenuToggleElement,
   PageSection,
@@ -44,6 +46,7 @@ const OrganizationDropdown = ({ organizationName, onSwitchOrganization }: Organi
           {organizationName}
         </MenuToggle>
       )}
+      popperProps={{ position: 'right' }}
     >
       <DropdownList>
         <DropdownItem onClick={onSwitchOrganization}>{t('Change Organization')}</DropdownItem>
@@ -52,14 +55,12 @@ const OrganizationDropdown = ({ organizationName, onSwitchOrganization }: Organi
   );
 };
 
-const PageNavigation = ({ children }: React.PropsWithChildren) => {
+const PageNavigation = () => {
   const { currentOrganization, availableOrganizations } = useOrganizationGuardContext();
   const [showOrganizationModal, setShowOrganizationModal] = React.useState(false);
 
   const showOrganizationSelection = availableOrganizations.length > 1;
-  const hasChildren = React.Children.count(children) > 0;
-
-  if (!showOrganizationSelection && !hasChildren) {
+  if (!showOrganizationSelection) {
     return null;
   }
 
@@ -68,21 +69,24 @@ const PageNavigation = ({ children }: React.PropsWithChildren) => {
   return (
     <>
       <PageSection variant="light" padding={{ default: 'noPadding' }}>
-        <Toolbar isFullHeight isStatic className="fctl-app_toolbar">
-          <ToolbarContent>
-            {hasChildren && <ToolbarItem>{children}</ToolbarItem>}
-            {showOrganizationSelection && (
-              <ToolbarItem>
-                <OrganizationDropdown
-                  organizationName={currentOrgDisplayName}
-                  onSwitchOrganization={() => {
-                    setShowOrganizationModal(true);
-                  }}
-                />
-              </ToolbarItem>
-            )}
-          </ToolbarContent>
-        </Toolbar>
+        <Masthead id="global-actions-masthead">
+          <MastheadContent>
+            <Toolbar isFullHeight isStatic className="fctl-subnav_toolbar">
+              <ToolbarContent>
+                {showOrganizationSelection && (
+                  <ToolbarItem>
+                    <OrganizationDropdown
+                      organizationName={currentOrgDisplayName}
+                      onSwitchOrganization={() => {
+                        setShowOrganizationModal(true);
+                      }}
+                    />
+                  </ToolbarItem>
+                )}
+              </ToolbarContent>
+            </Toolbar>
+          </MastheadContent>
+        </Masthead>
       </PageSection>
 
       {showOrganizationModal && (


### PR DESCRIPTION
The current design had some misalignments to the UX designs:
- Subnav should be in the same background color as the left navigation menu
- Subnav height should be the same as the first element  in the left navigation menu
- The "Change organization" dropdown item text was slightly cut

Before the changes:
<img width="2442" height="1318" alt="subnav-before" src="https://github.com/user-attachments/assets/59b3443a-7755-4efa-89df-386ca5b889f0" />

After the changes:
<img width="2442" height="1318" alt="subnav-fixed" src="https://github.com/user-attachments/assets/e662b406-d99c-4718-9a79-c3290b95d80a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced header toolbar with a Masthead layout; page navigation now only shows the organization selector when multiple organizations exist and no longer accepts nested children.

* **Style**
  * Removed padding from the main navigation list.
  * Aligned toolbar and subnav content to the end.
  * Added a global actions masthead region with zero padding and standardized height.
  * Applied a darker masthead/subnav background.

* **Enhancements**
  * Organization dropdown supports right-side positioning for improved usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->