### PR TITLE
EDM-2280: Add orgId parameter to console session requests

### DIFF
--- a/libs/ui-components/src/components/Device/DeviceDetails/TerminalTab.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/TerminalTab.tsx
@@ -9,6 +9,7 @@ import Terminal, { ImperativeTerminalType } from '../../Terminal/Terminal';
 import PageWithPermissions from '../../common/PageWithPermissions';
 import { useAccessReview } from '../../../hooks/useAccessReview';
 import { RESOURCE, VERB } from '../../../types/rbac';
+import { useOrganizationGuardContext } from '../../common/OrganizationGuard';
 
 type TerminalTabProps = {
   device: Device;
@@ -22,6 +23,7 @@ const wsMeta: WsMetadata = {
 const TerminalTab = ({ device }: TerminalTabProps) => {
   const { t } = useTranslation();
   const terminal = React.useRef<ImperativeTerminalType>(null);
+  const { currentOrganization } = useOrganizationGuardContext();
 
   const onMsgReceived = React.useCallback(async (message: Blob) => {
     try {
@@ -51,6 +53,7 @@ const TerminalTab = ({ device }: TerminalTabProps) => {
 
   const { sendMessage, isClosed, error, reconnect, isConnecting } = useWebSocket(
     device.metadata.name || '',
+    currentOrganization?.metadata?.name || undefined,
     onMsgReceived,
     wsMeta,
   );

--- a/libs/ui-components/src/hooks/useWebSocket.ts
+++ b/libs/ui-components/src/hooks/useWebSocket.ts
@@ -18,6 +18,7 @@ export type WsMetadata = {
 
 export const useWebSocket = <T>(
   deviceId: string,
+  organizationId: string | undefined,
   onMsgReceived: (msg: T) => Promise<void>,
   wsMetadata: WsMetadata,
 ): {
@@ -50,6 +51,12 @@ export const useWebSocket = <T>(
       const params = new URLSearchParams({
         metadata: wsMeta,
       });
+
+      // NOTE: Since webSocket connections can't use custom headers, we must add the "org_id" query parameter to the URL instead
+      if (organizationId) {
+        params.set('org_id', organizationId);
+      }
+
       const ws = new WebSocket(`${wsEndpoint}?${params.toString()}`, 'v5.channel.k8s.io');
       ws.addEventListener('open', () => setIsConnecting(false));
       ws.addEventListener('close', () => {
@@ -70,7 +77,7 @@ export const useWebSocket = <T>(
       wsRef.current?.close();
       wsRef.current = undefined;
     };
-  }, [deviceId, t, getWsEndpoint, reset, wsMetadata]);
+  }, [deviceId, organizationId, t, getWsEndpoint, reset, wsMetadata]);
 
   const reconnect = React.useCallback(() => {
     wsRef.current?.close();


### PR DESCRIPTION
When opening a terminal session and the system has organizations enabled, we need to add the "org_id" query parameter in the websocket request, otherwise the API will return error 403.

https://github.com/user-attachments/assets/6a028fb5-dc6e-47d3-85ab-3ffbb30544d2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Device Terminal connections now correctly include the selected organization, reducing connection errors and preventing cross-organization mismatches.
  * WebSocket and API routing are more organization-aware (e.g., alerts), improving consistency and reliability of real-time and API requests.
  * No UI changes; existing workflows continue to work without user action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->