### PR TITLE
Autodetect kind cluster configuration

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,50 @@
+# Flight Control UI configuration
+
+This document describes all environment variables and configuration options available for the Flight Control UI.
+
+## Feature toggles
+
+| Variable               | Description                               | Default | Values          |
+| ---------------------- | ----------------------------------------- | ------- | --------------- |
+| `ENABLE_ORGANIZATIONS` | Enable/disable organizations support      | `false` | `true`, `false` |
+| `ENABLE_CLI_ARTIFACTS` | Enable/disable CLI download functionality | `true`  | `true`, `false` |
+| `ENABLE_ALERTMANAGER`  | Enable/disable alerts functionality       | `true`  | `true`, `false` |
+
+## Backend configuration
+
+| Variable                                | Description                          | Default                  | Values                                 |
+| --------------------------------------- | ------------------------------------ | ------------------------ | -------------------------------------- |
+| `BASE_UI_URL`                           | Base URL for UI application          | `http://localhost:9000`  | `https://ui.flightctl.example.com`     |
+| `FLIGHTCTL_SERVER`                      | Flight Control API server URL        | `https://localhost:3443` | `https://api.flightctl.example.com`    |
+| `FLIGHTCTL_SERVER_INSECURE_SKIP_VERIFY` | Skip backend server TLS verification | `false`                  | `true`, `false`                        |
+| `FLIGHTCTL_CLI_ARTIFACTS_SERVER`        | CLI artifacts server URL             | `http://localhost:8090`  | `https://cli.flightctl.example.com`    |
+| `FLIGHTCTL_ALERTMANAGER_PROXY`          | AlertManager proxy server URL        | `https://localhost:8443` | `https://alerts.flightctl.example.com` |
+| `INTERNAL_AUTH_URL`                     | Internal authentication URL          | _(empty)_                | `https://auth.internal.example.com`    |
+| `AUTH_INSECURE_SKIP_VERIFY`             | Skip auth server TLS verification    | `false`                  | `true`, `false`                        |
+| `AUTH_CLIENT_ID`                        | OAuth client ID for authentication   | `flightctl`              | Custom client ID                       |
+| `TLS_CERT`                              | Path to TLS certificate              | _(empty)_                | `/path/to/server.crt`                  |
+| `TLS_KEY`                               | Path to TLS private key              | _(empty)_                | `/path/to/server.key`                  |
+| `API_PORT`                              | UI proxy server port                 | `3001`                   | `8080`, `3000`, etc.                   |
+| `K8S_RBAC_NS`                           | Kubernetes RBAC namespace            | _(empty)_                | `flightctl`                            |
+| `IS_OCP_PLUGIN`                         | Run as OpenShift Console plugin      | `false`                  | `true`, `false`                        |
+| `IS_RHEM`                               | Red Hat Enterprise Mode              | _(empty)_                | `true`, `false`                        |
+
+## Configuration examples
+
+```shell
+# Use auto-detection of all configuration settings
+npm run dev:kind
+```
+
+```shell
+# Use auto-detection and override desired settings
+ENABLE_CLI_ARTIFACTS=false npm run dev:kind
+```
+
+```shell
+# Use remote backend and custom settings
+FLIGHTCTL_SERVER=https://flightctl.prod.example.com \
+ENABLE_ORGANIZATIONS=false \
+ENABLE_CLI_ARTIFACTS=false \
+npm run dev
+```

--- a/README.md
+++ b/README.md
@@ -1,44 +1,51 @@
 # Flight Control UI
 
-Monorepo containing UIs for [flightctl](https://github.com/flightctl/flightctl)
+Monorepo containing UIs for [Flight Control](https://github.com/flightctl/flightctl)
 
-### Prerequisites:
-* `Git`, `Node.js v22.x`, `npm v10.x`, `rsync`, `go` (>= 1.23)
+## Prerequisites
+
+- `Git`, `Node.js v22.x`, `npm v10.x`, `rsync`, `go` (>= 1.23)
 
 ## Building
 
-### Checkout the repo and from within the repo run:
+### Checkout the repository and run
 
-```
+```shell
+cd flightctl-ui
 npm ci
 npm run build
 ```
 
 ### Running Standalone UI with backend running in Kind
 
-Choose one of the two options to run the UI application
+If backend is running in your Kind cluster, use the following command to start the UI application.
+It will automatically detect your Flight Control deployment settings and it will configure the UI accordingly. (Requires `kind`, `kubectl`)
 
-  ```
-  npm run dev:kind
-  ```
+```shell
+npm run dev:kind
+```
 
+See [CONFIGURATION.md](CONFIGURATION.md) for complete configuration options.
 
 ### Running Standalone UI with backend not running in Kind
-- If backend is not running in your Kind cluster, you need to specify the API endpoint
 
-```
+If backend is not running in your Kind cluster, you need to specify your Flight Control deployment settings.
+
+```shell
 FLIGHTCTL_SERVER=<api_server_url> npm run dev
 ```
 
-If the backend, or Auth provider is running self-signed certs, you will need to disable the verification via env variables:
+If the backend, or Auth provider is running self-signed certs, you will need to disable the verification via environment variables:
 
- - `FLIGHTCTL_SERVER_INSECURE_SKIP_VERIFY='true'` - to disable verification of backend certs
- - `AUTH_INSECURE_SKIP_VERIFY='true'` - to disable verification of auth server certs
+- `FLIGHTCTL_SERVER_INSECURE_SKIP_VERIFY='true'` - to disable verification of backend certs
+- `AUTH_INSECURE_SKIP_VERIFY='true'` - to disable verification of auth server certs
 
 or provide the CA certs:
 
- - copy backend `ca.crt` to `./certs/ca.crt`
- - copy Auth `ca.crt` to `./certs/ca_auth.crt`
+- copy backend `ca.crt` to `./certs/ca.crt`
+- copy Auth `ca.crt` to `./certs/ca_auth.crt`
+
+See [CONFIGURATION.md](CONFIGURATION.md) for complete configuration options.
 
 ### Running UI as OCP plugin
 
@@ -47,15 +54,14 @@ With this option, the Flight Control UI will run as a Plugin in the OCP console.
 
 Login to OCP cluster and run:
 
-```
-npm run dev:ocp 
+```shell
+npm run dev:ocp
 ```
 
 By default, the latest available OpenShift console image will be used. To specify a different console version, set the `CONSOLE_VERSION` environment variable.
 
 The following console versions are confirmed to be compatible: 4.16 to 4.20.
 
-<br><br>
+<br />
 
 [![Watch the demo](demo-thumbnail.png)](https://www.youtube.com/watch?v=WzNG_uWnmzk)
-

--- a/apps/standalone/package.json
+++ b/apps/standalone/package.json
@@ -11,7 +11,7 @@
     "build": "NODE_ENV=production npm run ts-node ../../node_modules/.bin/webpack --mode=production",
     "start-prod": "npm run ts-node ../../node_modules/.bin/webpack serve --mode=production --color --progress",
     "dev": "concurrently \"npm run dev:proxy\" \"npm run dev:ui\"",
-    "dev:kind": "ENABLE_ORGANIZATIONS=true ENABLE_CLI_ARTIFACTS=true ENABLE_ALERTMANAGER=true source ./scripts/setup_env.sh && npm run dev",
+    "dev:kind": ". ./scripts/setup_env.sh && npm run dev",
     "dev:proxy": "cd ../../proxy && nodemon --watch 'proxy/**/*' --exec 'go run' app.go --signal SIGTERM",
     "dev:ui": "npm run ts-node ../../node_modules/.bin/webpack serve --mode=development --color --progress",
     "lint": "eslint --ext .tsx,.ts ./src/ && prettier --check './src/**/*.{tsx,ts}' && npm run i18n",


### PR DESCRIPTION
Currently, the UI needs to have the ORGANIZATIONS_ENABLED environment variable that matches the backend deployment configuration for organanizations, otherwise it fails.

Now by default, the  `npm run dev:kind` will autodetect the backend deployment settings to configure the UI accordingly.

Also made some fixes to README.md based on Coderabbit's report from `markdownlint`

Supported by Cursor AI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dev setup now validates prerequisites, autodetects cluster services and feature flags (Organizations, CLI artifacts, AlertManager), improves external-IP detection, and exits if external IP can't be determined; environment values are exported and displayed.

* **Documentation**
  * Added CONFIGURATION.md listing environment variables, defaults, and examples.
  * README clarified setup/run instructions, Kind guidance, and links to the new configuration guide.

* **Chores**
  * Dev script invocation updated to source the centralized setup script from package scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->