### PR TITLE
Fix release branch check: verify commit is in the correct branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,11 +13,11 @@ jobs:
     outputs:
       skip: ${{ steps.check.outputs.skip }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22.x
       - name: Check if PR is draft
@@ -35,9 +35,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22.x
       - name: Install dependencies
@@ -51,9 +51,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22.x
       - name: Install dependencies
@@ -65,9 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22.x
       - name: Install dependencies
@@ -80,8 +80,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22.x
       - name: Run integration tests

--- a/.github/workflows/push-to-main.yaml
+++ b/.github/workflows/push-to-main.yaml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       image_tags: ${{ steps.get-tags.outputs.image_tags }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-tags]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build
         id: build
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-tags]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build
         id: build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,17 +15,43 @@ jobs:
   publish-to-npm:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
       - name: Check workflow runs in a release branch
         run: |
-          if [[ "${{ github.event.release.target_commitish }}" != *release-* ]]; then
-            echo "Expecting to be in a release branch, but we are in: ${{ github.event.release.target_commitish }}"
+          TAG_NAME="${{ github.event.release.tag_name }}"
+
+          # Extract major.minor version from tag (e.g., v0.10.5-rc1 -> 0.10)
+          TAG_VERSION=$(echo "${TAG_NAME}" | sed 's/^v//' | grep -oE '^[0-9]+\.[0-9]+')
+          if [[ -z "${TAG_VERSION}" ]]; then
+            echo "✗ Error: Could not extract version from tag ${TAG_NAME}"
             exit 1
           fi
 
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.release.target_commitish }}
-          fetch-depth: 0
+          EXPECTED_BRANCH="release-${TAG_VERSION}"
+          echo "Tag version: ${TAG_VERSION}.x"
+          echo "Expected release branch: ${EXPECTED_BRANCH}"
+
+          # Get the commit SHA for the tag
+          TAG_COMMIT=$(git rev-list -n 1 "${TAG_NAME}")
+          echo "Tag ${TAG_NAME} points to commit: ${TAG_COMMIT}"
+
+          # Get all branches containing this commit
+          BRANCHES=$(git branch -r --contains ${TAG_COMMIT} | sed 's|^[[:space:]]*origin/||' | grep -v HEAD)
+          echo "Branches containing this commit:"
+          echo "${BRANCHES}"
+
+          # Check if the expected release branch contains this commit
+          if echo "${BRANCHES}" | grep -q "^${EXPECTED_BRANCH}$"; then
+            echo "✓ Tag ${TAG_NAME} is on the correct release branch: ${EXPECTED_BRANCH}"
+          else
+            echo "✗ Error: Tag ${TAG_NAME} (version ${TAG_VERSION}) is not on branch ${EXPECTED_BRANCH}"
+            echo "Available branches: ${BRANCHES}"
+            exit 1
+          fi
 
       - name: Lookup for workspaces to be published
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
   publish-to-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
@@ -69,7 +69,7 @@ jobs:
           git config user.name '${{ github.actor }}'
           git config user.email '${{ github.actor }}@users.noreply.github.com'
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           cache: npm
           node-version: 22.x


### PR DESCRIPTION
When creating a new release, we were relying on `github.event.release.target_commitish` which I believe is only properly populated when the tag has been created via the Github UI and the "target branch" dropdown is displayed.

Now we'll check that the tag name is with the correct pattern `vA.B.C(rc-X etc)` and we verify that the commit the tag is pointing that is on the `release-A.B` branch. 

Valid run (correct tag for release branch): https://github.com/celdrake/flightctl-ui/actions/runs/18719086571/job/53386217740#step:3:41

Invalid run (tag commit not found in correct release branch) https://github.com/celdrake/flightctl-ui/actions/runs/18719768628/job/53388641329#step:3:41

- Also updated `actions/checkout` and `actions/setup-node` to v4, as v3 is now EOL..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release workflow validation to extract version from tags, verify the expected release branch contains the tagged commit, and provide clearer logging and error reporting.
  * Upgraded CI and release workflow tooling to newer action versions and adjusted checkout behavior for accurate tag handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->