### PR TITLE
EDM-2403: Handle initialization errors gracefully instead of panic

### DIFF
--- a/proxy/app.go
+++ b/proxy/app.go
@@ -38,7 +38,8 @@ func main() {
 
 	tlsConfig, err := bridge.GetTlsConfig()
 	if err != nil {
-		panic(err)
+		log.WithError(err).Error("Failed to get TLS configuration")
+		os.Exit(1)
 	}
 
 	apiRouter.Handle("/flightctl/{forward:.*}", bridge.NewFlightCtlHandler(tlsConfig))
@@ -73,7 +74,8 @@ func main() {
 	if config.OcpPlugin != "true" {
 		authHandler, err := auth.NewAuth(tlsConfig)
 		if err != nil {
-			panic(err)
+			log.WithError(err).Error("Failed to initialize authentication")
+			os.Exit(1)
 		}
 		apiRouter.HandleFunc("/login", authHandler.Login)
 		apiRouter.HandleFunc("/login/info", authHandler.GetUserInfo)
@@ -92,7 +94,8 @@ func main() {
 	if config.TlsKeyPath != "" && config.TlsCertPath != "" {
 		cert, err := tls.LoadX509KeyPair(config.TlsCertPath, config.TlsKeyPath)
 		if err != nil {
-			panic(err)
+			log.WithError(err).Error("Failed to load TLS certificate")
+			os.Exit(1)
 		}
 		serverTlsconfig = &tls.Config{
 			Certificates: []tls.Certificate{cert},

--- a/proxy/bridge/handler.go
+++ b/proxy/bridge/handler.go
@@ -5,10 +5,12 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 
 	"github.com/gorilla/mux"
 
 	"github.com/flightctl/flightctl-ui/config"
+	"github.com/flightctl/flightctl-ui/log"
 )
 
 type handler struct {
@@ -28,7 +30,8 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func createReverseProxy(apiURL string) (*url.URL, *httputil.ReverseProxy) {
 	target, err := url.Parse(apiURL)
 	if err != nil {
-		panic(err)
+		log.GetLogger().WithError(err).Errorf("Failed to parse URL '%s'", apiURL)
+		os.Exit(1)
 	}
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	proxy.ModifyResponse = func(r *http.Response) error {


### PR DESCRIPTION
Substitute all cases in which the UI was panicking by gracefully logging the error and exiting the main process.

Logs example when `FLIGHTCTL_SERVER` is an invalid URL:

Before:
```
Oct 23 XX:XX:XX flightctl-ui[XXXXX]: panic: parse "ht!tp://invalid url with spaces": first path segment in URL cannot contain colon
Oct 23 XX:XX:XX flightctl-ui[XXXXX]:
Oct 23 XX:XX:XX flightctl-ui[XXXXX]: goroutine 1 [running]:
Oct 23 XX:XX:XX flightctl-ui[XXXXX]: github.com/flightctl/flightctl-ui/bridge.createReverseProxy(...)
Oct 23 XX:XX:XX flightctl-ui[XXXXX]:         /app/bridge/handler.go:31
Oct 23 XX:XX:XX flightctl-ui[XXXXX]: github.com/flightctl/flightctl-ui/bridge.NewFlightCtlHandler(...)
Oct 23 XX:XX:XX systemd[1]: flightctl-ui.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
```

After:
```
Oct 23 04:58:14 flightctl-ui[27486]: time="2025-10-23T08:58:14Z" level=warning msg="Using InsecureSkipVerify for API communication"
Oct 23 04:58:14 flightctl-ui[27486]: time="2025-10-23T08:58:14Z" level=error msg="Failed to parse URL 'ht!tp://invalid url with spaces'" func=github.com/flightctl/flightctl-ui/bridge.createReverseProxy file="/app/bridge/handler.go:33" error="parse \"ht!tp://invalid url with spaces\": first path segment in URL cannot contain colon"
Oct 23 04:58:14 podman[27496]: container died ac4f87344bbc64c549d1d951eec08adc735f957e14460a002b621602c58f217a
Oct 23 04:58:14 systemd[1]: flightctl-ui.service: Main process exited, code=exited, status=1/FAILURE
Oct 23 04:58:14 systemd[1]: flightctl-ui.service: Failed with result 'exit-code'.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced error handling during startup with structured logging, replacing unexpected process crashes with graceful termination for improved diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->