### PR TITLE
Quadlet spec

### DIFF
--- a/libs/types/index.ts
+++ b/libs/types/index.ts
@@ -13,6 +13,7 @@ export type { ApplicationVolume } from './models/ApplicationVolume';
 export type { ApplicationVolumeProviderSpec } from './models/ApplicationVolumeProviderSpec';
 export type { ApplicationVolumeStatus } from './models/ApplicationVolumeStatus';
 export { AppType } from './models/AppType';
+export type { ArtifactApplicationProviderSpec } from './models/ArtifactApplicationProviderSpec';
 export type { AuthConfig } from './models/AuthConfig';
 export type { AuthOrganizationsConfig } from './models/AuthOrganizationsConfig';
 export type { Batch } from './models/Batch';

--- a/libs/types/models/AppType.ts
+++ b/libs/types/models/AppType.ts
@@ -7,4 +7,5 @@
  */
 export enum AppType {
   AppTypeCompose = 'compose',
+  AppTypeQuadlet = 'quadlet',
 }

--- a/libs/types/models/ApplicationProviderSpec.ts
+++ b/libs/types/models/ApplicationProviderSpec.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 import type { ApplicationEnvVars } from './ApplicationEnvVars';
 import type { AppType } from './AppType';
+import type { ArtifactApplicationProviderSpec } from './ArtifactApplicationProviderSpec';
 import type { ImageApplicationProviderSpec } from './ImageApplicationProviderSpec';
 import type { InlineApplicationProviderSpec } from './InlineApplicationProviderSpec';
 export type ApplicationProviderSpec = (ApplicationEnvVars & {
@@ -12,5 +13,5 @@ export type ApplicationProviderSpec = (ApplicationEnvVars & {
    */
   name?: string;
   appType?: AppType;
-} & (ImageApplicationProviderSpec | InlineApplicationProviderSpec));
+} & (ImageApplicationProviderSpec | ArtifactApplicationProviderSpec | InlineApplicationProviderSpec));
 

--- a/libs/types/models/ArtifactApplicationProviderSpec.ts
+++ b/libs/types/models/ArtifactApplicationProviderSpec.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ArtifactApplicationProviderSpec = {
+  /**
+   * Reference to an OCI artifact for the application package.
+   */
+  artifact: string;
+};
+

--- a/libs/types/models/EnrollmentRequestSpec.ts
+++ b/libs/types/models/EnrollmentRequestSpec.ts
@@ -16,5 +16,9 @@ export type EnrollmentRequestSpec = {
    * A set of labels that the service will apply to this device when its enrollment is approved.
    */
   labels?: Record<string, string>;
+  /**
+   * The rendered version of the device from desired.json (optional).
+   */
+  knownRenderedVersion?: string;
 };
 

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/deviceSpecUtils.ts
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/deviceSpecUtils.ts
@@ -25,6 +25,7 @@ import {
   InlineConfigTemplate,
   KubeSecretTemplate,
   SpecConfigTemplate,
+  isArtifactAppProvider,
   isGitConfigTemplate,
   isGitProviderSpec,
   isHttpConfigTemplate,
@@ -284,6 +285,7 @@ export const getApplicationPatches = (
       value: updatedApps.map(toAPIApplication),
     });
   } else {
+    // TODO EDM-2451: Add support for artifact applications
     const needsPatch = currentApps.some((currentApp, index) => {
       const updatedApp = updatedApps[index];
       const isCurrentImageApp = isImageAppProvider(currentApp);
@@ -307,7 +309,9 @@ export const getApplicationPatches = (
       if (isCurrentImageApp) {
         return (updatedApp as ImageAppForm).image !== currentApp.image;
       }
-
+      if (isArtifactAppProvider(currentApp)) {
+        return false;
+      }
       return hasInlineApplicationChanged(currentApp, updatedApp as InlineAppForm);
     });
     if (needsPatch) {
@@ -386,28 +390,31 @@ const getAppFormVolumes = (app: ApplicationProviderSpecFixed) =>
 
 export const getApplicationValues = (deviceSpec?: DeviceSpec): AppForm[] => {
   const apps = deviceSpec?.applications || [];
-  return apps.map((app) => {
-    if (isImageAppProvider(app)) {
+  return apps
+    .filter((app) => !isArtifactAppProvider(app))
+    .map((app) => {
+      if (isImageAppProvider(app)) {
+        return {
+          specType: AppSpecType.OCI_IMAGE,
+          name: app.name || '',
+          image: app.image,
+          variables: getAppFormVariables(app),
+          volumes: getAppFormVolumes(app),
+        };
+      }
+      // TODO EDM-2451: Add support for artifact applications
       return {
-        specType: AppSpecType.OCI_IMAGE,
+        specType: AppSpecType.INLINE,
         name: app.name || '',
-        image: app.image,
+        files: (app as InlineApplicationProviderSpec).inline.map((file) => ({
+          path: file.path || '',
+          content: file.content,
+          base64: file.contentEncoding === EncodingType.EncodingBase64,
+        })),
         variables: getAppFormVariables(app),
         volumes: getAppFormVolumes(app),
       };
-    }
-    return {
-      specType: AppSpecType.INLINE,
-      name: app.name || '',
-      files: app.inline.map((file) => ({
-        path: file.path || '',
-        content: file.content,
-        base64: file.contentEncoding === EncodingType.EncodingBase64,
-      })),
-      variables: getAppFormVariables(app),
-      volumes: getAppFormVolumes(app),
-    };
-  });
+    });
 };
 
 export const getConfigTemplatesValues = (deviceSpec?: DeviceSpec, registerMicroShift?: boolean) => {

--- a/libs/ui-components/src/types/deviceSpec.ts
+++ b/libs/ui-components/src/types/deviceSpec.ts
@@ -1,4 +1,5 @@
 import {
+  ArtifactApplicationProviderSpec,
   ConfigProviderSpec,
   DisruptionBudget,
   GitConfigProviderSpec,
@@ -87,6 +88,8 @@ export const isInlineAppProvider = (app: ApplicationProviderSpecFixed): app is I
   'inline' in app;
 export const isImageAppProvider = (app: ApplicationProviderSpecFixed): app is ImageApplicationProviderSpec =>
   'image' in app;
+export const isArtifactAppProvider = (app: ApplicationProviderSpecFixed): app is ArtifactApplicationProviderSpec =>
+  'artifact' in app;
 
 export const isImageAppForm = (app: AppBase): app is ImageAppForm => app.specType === AppSpecType.OCI_IMAGE;
 export const isInlineAppForm = (app: AppBase): app is InlineAppForm => app.specType === AppSpecType.INLINE;

--- a/libs/ui-components/src/types/extraTypes.ts
+++ b/libs/ui-components/src/types/extraTypes.ts
@@ -2,6 +2,7 @@ import {
   AppType,
   ApplicationEnvVars,
   ApplicationVolumeProviderSpec,
+  ArtifactApplicationProviderSpec,
   ConditionType,
   Device,
   EnrollmentRequest,
@@ -45,7 +46,7 @@ export type ApplicationProviderSpecFixed = ApplicationEnvVars &
   ApplicationVolumeProviderSpec & {
     name?: string;
     appType?: AppType;
-  } & (ImageApplicationProviderSpec | { inline: InlineApplicationFileFixed[] });
+  } & (ImageApplicationProviderSpec | ArtifactApplicationProviderSpec | { inline: InlineApplicationFileFixed[] });
 
 type CliArtifact = {
   os: string;


### PR DESCRIPTION
Adapts the UI to the new types introduced in https://github.com/flightctl/flightctl/pull/1855 to support Quadlet  and Artifact applications.

Support not yet added either on the Backend or UI, that will be done later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for artifact-based application provider specifications alongside existing image and inline types.
  * UI now recognizes artifact-based apps in device workflows and adjusts form/patch handling (scaffolding for future full support).
  * Introduced Quadlet as a new application type option.
  * Added tracking of rendered device versions for enrollment requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->