### PR TITLE
Update go to 1.24

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -12,13 +12,13 @@ ENV NODE_OPTIONS='--max-old-space-size=8192'
 RUN npm ci
 RUN npm run build
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as proxy-build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as proxy-build
 WORKDIR /app
 COPY proxy /app
 USER 0
 RUN CGO_ENABLED=1 CGO_CFLAGS=-flto GOEXPERIMENT=strictfipsruntime go build
 
-FROM quay.io/flightctl/flightctl-base:9.6-1758714456
+FROM quay.io/flightctl/flightctl-base:9.6-1762316544
 COPY --from=ui-build /app/apps/standalone/dist /app/proxy/dist
 COPY --from=proxy-build /app/flightctl-ui /app/proxy
 WORKDIR /app/proxy

--- a/Containerfile.ocp
+++ b/Containerfile.ocp
@@ -12,13 +12,13 @@ ENV NODE_OPTIONS='--max-old-space-size=8192'
 RUN npm ci
 RUN npm run build:ocp
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as proxy-build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as proxy-build
 WORKDIR /app
 COPY proxy /app
 USER 0
 RUN CGO_ENABLED=1 CGO_CFLAGS=-flto GOEXPERIMENT=strictfipsruntime go build
 
-FROM quay.io/flightctl/flightctl-base:9.6-1758714456
+FROM quay.io/flightctl/flightctl-base:9.6-1762316544
 COPY --from=ui-build /app/apps/ocp-plugin/dist /app/proxy/dist
 COPY --from=proxy-build /app/flightctl-ui /app/proxy
 WORKDIR /app/proxy

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Monorepo containing UIs for [Flight Control](https://github.com/flightctl/flight
 
 ## Prerequisites
 
-- `Git`, `Node.js v22.x`, `npm v10.x`, `rsync`, `go` (>= 1.23)
+- `Git`, `Node.js v22.x`, `npm v10.x`, `rsync`, `go` (>= 1.24)
 
 ## Building
 

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -1,8 +1,8 @@
 module github.com/flightctl/flightctl-ui
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.9
+toolchain go1.24.6
 
 require (
 	github.com/flightctl/flightctl v0.10.0-rc1


### PR DESCRIPTION
Aligns to the backend changes in https://github.com/flightctl/flightctl/pull/1921

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain requirement to version 1.24 (from 1.23).
  * Updated base container images to latest stable versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->