### PR TITLE
Adding application type Quadlet support

### DIFF
--- a/libs/ui-components/src/components/Device/EditDeviceWizard/deviceSpecUtils.ts
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/deviceSpecUtils.ts
@@ -228,7 +228,7 @@ export const toAPIApplication = (app: AppForm): ApplicationProviderSpec => {
 
   return {
     name: app.name,
-    appType: AppType.AppTypeCompose,
+    appType: app.appType || AppType.AppTypeCompose,
     inline: app.files.map(
       (file): InlineApplicationFileFixed => ({
         path: file.path,
@@ -396,6 +396,7 @@ export const getApplicationValues = (deviceSpec?: DeviceSpec): AppForm[] => {
       if (isImageAppProvider(app)) {
         return {
           specType: AppSpecType.OCI_IMAGE,
+          appType: app.appType,
           name: app.name || '',
           image: app.image,
           variables: getAppFormVariables(app),
@@ -405,6 +406,7 @@ export const getApplicationValues = (deviceSpec?: DeviceSpec): AppForm[] => {
       // TODO EDM-2451: Add support for artifact applications
       return {
         specType: AppSpecType.INLINE,
+        appType: app.appType,
         name: app.name || '',
         files: (app as InlineApplicationProviderSpec).inline.map((file) => ({
           path: file.path || '',

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ApplicationTemplates.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ApplicationTemplates.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 
-import { Button, FormGroup, FormSection, Grid, Split, SplitItem } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { FormGroup, FormSection } from '@patternfly/react-core/dist/esm/components/Form';
+import { Grid } from '@patternfly/react-core/dist/esm/layouts/Grid';
+import { Split, SplitItem } from '@patternfly/react-core/dist/esm/layouts/Split';
 import { FieldArray, useField, useFormikContext } from 'formik';
 import { MinusCircleIcon } from '@patternfly/react-icons/dist/js/icons/minus-circle-icon';
 import { PlusCircleIcon } from '@patternfly/react-icons/dist/js/icons/plus-circle-icon';
@@ -45,6 +48,7 @@ const ApplicationSection = ({ index, isReadOnly }: { index: number; isReadOnly?:
       setValue(
         {
           specType: AppSpecType.INLINE,
+          appType: (app.appType || ('compose' as unknown as AppForm['appType'])),
           name: app.name || '',
           files: [{ path: '', content: '' }],
           variables: [],
@@ -55,6 +59,7 @@ const ApplicationSection = ({ index, isReadOnly }: { index: number; isReadOnly?:
       setValue(
         {
           specType: AppSpecType.OCI_IMAGE,
+          appType: app.appType,
           name: app.name || '',
           image: '',
           variables: [],
@@ -62,7 +67,7 @@ const ApplicationSection = ({ index, isReadOnly }: { index: number; isReadOnly?:
         false,
       );
     }
-  }, [isImageIncomplete, isInlineIncomplete, app.name, setValue]);
+  }, [isImageIncomplete, isInlineIncomplete, app.name, app.appType, setValue]);
 
   return (
     <ExpandableFormSection
@@ -91,6 +96,20 @@ const ApplicationSection = ({ index, isReadOnly }: { index: number; isReadOnly?:
         >
           <TextField aria-label={t('Application name')} name={`${appFieldName}.name`} isDisabled={isReadOnly} />
         </FormGroupWithHelperText>
+
+        {isInlineAppForm(app) && (
+          <FormGroup label={t('Application format')} isRequired>
+            <FormSelect
+              items={{
+                compose: t('Compose'),
+                quadlet: t('Quadlet'),
+              }}
+              name={`${appFieldName}.appType`}
+              placeholderText={t('Select a format')}
+              isDisabled={isReadOnly}
+            />
+          </FormGroup>
+        )}
 
         {isImageAppForm(app) && <ApplicationImageForm app={app} index={index} isReadOnly={isReadOnly} />}
         {isInlineAppForm(app) && <ApplicationInlineForm app={app} index={index} isReadOnly={isReadOnly} />}

--- a/libs/ui-components/src/types/deviceSpec.ts
+++ b/libs/ui-components/src/types/deviceSpec.ts
@@ -1,4 +1,5 @@
 import {
+  AppType,
   ArtifactApplicationProviderSpec,
   ConfigProviderSpec,
   DisruptionBudget,
@@ -46,7 +47,7 @@ type InlineContent = {
 
 type AppBase = {
   specType: AppSpecType;
-  // appType: AppType - commented out for now, since it only accepts one value ("compose")
+  appType?: AppType;
   name?: string;
   variables: { name: string; value: string }[];
   volumes?: {


### PR DESCRIPTION
Inline applications now support Compose/Quadlet in the editor, appType is preserved from the API, and emitted on save.
Vibe coding
<img width="1415" height="1141" alt="Screenshot 2025-11-11 at 16 49 41" src="https://github.com/user-attachments/assets/f64bb7f0-5fdd-4ad0-816f-69ba98b3461e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added application format selector (Compose/Quadlet) for inline applications in the device wizard.
  * Application type preferences are now preserved when switching between application types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->