### PR TITLE
EDM-2632: Update types with new ApplicationStatus when there are no apps

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -1068,6 +1068,7 @@
   "Device is not suspended.": "Device is not suspended.",
   "Error": "Error",
   "Degraded": "Degraded",
+  "No applications": "No applications",
   "Healthy": "Healthy",
   "Preparing": "Preparing",
   "Starting": "Starting",

--- a/libs/types/models/AapProviderSpec.ts
+++ b/libs/types/models/AapProviderSpec.ts
@@ -2,8 +2,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { AuthOrganizationAssignment } from './AuthOrganizationAssignment';
-import type { AuthRoleAssignment } from './AuthRoleAssignment';
 /**
  * AapProviderSpec describes an Ansible Automation Platform (AAP) provider configuration.
  */
@@ -21,14 +19,28 @@ export type AapProviderSpec = {
    */
   apiUrl: string;
   /**
-   * The external AAP API URL (for external access).
+   * The OAuth2 authorization endpoint URL.
    */
-  externalApiUrl?: string;
+  authorizationUrl: string;
+  /**
+   * The OAuth2 token endpoint URL.
+   */
+  tokenUrl: string;
+  /**
+   * The OAuth2 client ID.
+   */
+  clientId: string;
+  /**
+   * The OAuth2 client secret.
+   */
+  clientSecret: string;
   /**
    * Whether this AAP provider is enabled.
    */
   enabled?: boolean;
-  organizationAssignment: AuthOrganizationAssignment;
-  roleAssignment: AuthRoleAssignment;
+  /**
+   * List of OAuth2 scopes to request.
+   */
+  scopes: Array<string>;
 };
 

--- a/libs/types/models/ApplicationProviderSpec.ts
+++ b/libs/types/models/ApplicationProviderSpec.ts
@@ -11,6 +11,6 @@ export type ApplicationProviderSpec = (ApplicationEnvVars & {
    * The application name must be 1–253 characters long, start with a letter or number, and contain no whitespace.
    */
   name?: string;
-  appType?: AppType;
+  appType: AppType;
 } & (ImageApplicationProviderSpec | InlineApplicationProviderSpec));
 

--- a/libs/types/models/ApplicationResourceLimits.ts
+++ b/libs/types/models/ApplicationResourceLimits.ts
@@ -7,11 +7,11 @@
  */
 export type ApplicationResourceLimits = {
   /**
-   * CPU limit in cores (e.g., "1", "0.75").
+   * CPU limit in cores. Format restricted based on application type.
    */
   cpu?: string;
   /**
-   * Memory limit with unit (e.g., "256m", "2g") using Podman format (b=bytes, k=kibibytes, m=mebibytes, g=gibibytes).
+   * Memory limit with optional unit. Format restricted based on application type.
    */
   memory?: string;
 };

--- a/libs/types/models/ApplicationsSummaryStatusType.ts
+++ b/libs/types/models/ApplicationsSummaryStatusType.ts
@@ -10,4 +10,5 @@ export enum ApplicationsSummaryStatusType {
   ApplicationsSummaryStatusDegraded = 'Degraded',
   ApplicationsSummaryStatusError = 'Error',
   ApplicationsSummaryStatusUnknown = 'Unknown',
+  ApplicationsSummaryStatusNoApplications = 'NoApplications',
 }

--- a/libs/ui-components/src/types/deviceSpec.ts
+++ b/libs/ui-components/src/types/deviceSpec.ts
@@ -7,13 +7,11 @@ import {
   HttpConfigProviderSpec,
   ImageApplicationProviderSpec,
   ImagePullPolicy,
-  InlineApplicationProviderSpec,
   InlineConfigProviderSpec,
   KubernetesSecretProviderSpec,
 } from '@flightctl/types';
-import { FlightCtlLabel } from './extraTypes';
+import { ApplicationProviderSpecFixed, FlightCtlLabel } from './extraTypes';
 import { UpdateScheduleMode } from '../utils/time';
-import { ApplicationProviderSpecFixed } from './extraTypes';
 
 export enum ConfigType {
   GIT = 'git',
@@ -117,10 +115,9 @@ export type AppForm =
   | ComposeInlineAppForm
   | SingleContainerAppForm;
 
-export const isInlineAppProvider = (app: ApplicationProviderSpecFixed): app is InlineApplicationProviderSpec =>
-  'inline' in app;
-export const isImageAppProvider = (app: ApplicationProviderSpecFixed): app is ImageApplicationProviderSpec =>
-  'image' in app;
+export const isImageAppProvider = (
+  app: ApplicationProviderSpecFixed,
+): app is ApplicationProviderSpecFixed & ImageApplicationProviderSpec => 'image' in app;
 
 // Type guards for the 5 explicit types
 export const isQuadletImageAppForm = (app: AppBase): app is QuadletImageAppForm =>

--- a/libs/ui-components/src/types/extraTypes.ts
+++ b/libs/ui-components/src/types/extraTypes.ts
@@ -47,7 +47,7 @@ export type InlineApplicationFileFixed = FileContent & RelativePath;
 export type ApplicationProviderSpecFixed = ApplicationEnvVars &
   ApplicationVolumeProviderSpec & {
     name?: string;
-    appType?: AppType;
+    appType: AppType;
   } & (ImageApplicationProviderSpec | { inline: InlineApplicationFileFixed[] });
 
 type CliArtifact = {

--- a/libs/ui-components/src/utils/status/applications.ts
+++ b/libs/ui-components/src/utils/status/applications.ts
@@ -5,6 +5,7 @@ import {
   ApplicationsSummaryStatusType as AppSummaryStatus,
 } from '@flightctl/types';
 import { StatusItem } from './common';
+import AsleepIcon from '@patternfly/react-icons/dist/js/icons/asleep-icon';
 
 export const getApplicationSummaryStatusItems = (t: TFunction): StatusItem<AppSummaryStatus>[] => [
   {
@@ -22,6 +23,12 @@ export const getApplicationSummaryStatusItems = (t: TFunction): StatusItem<AppSu
     id: AppSummaryStatus.ApplicationsSummaryStatusUnknown,
     label: t('Unknown'),
     level: 'unknown',
+  },
+  {
+    id: AppSummaryStatus.ApplicationsSummaryStatusNoApplications,
+    label: t('No applications'),
+    level: 'info',
+    customIcon: AsleepIcon,
   },
   {
     id: AppSummaryStatus.ApplicationsSummaryStatusHealthy,


### PR DESCRIPTION
Adds the new "ApplicationsSummaryStatusNoApplications" to the UI

Without applications defined:
<img width="2051" height="555" alt="no-applicatoins" src="https://github.com/user-attachments/assets/d82619a9-f748-4454-965d-7943a0dff164" />


After applications are defined and reported:
<img width="1508" height="1605" alt="Screenshot From 2025-11-26 09-56-10" src="https://github.com/user-attachments/assets/92c777e6-7f4d-4c92-b3f1-a62470b5db2f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "No applications" status display with a visual indicator when no applications are present.

* **Documentation**
  * Updated resource limit field descriptions for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->