### PR TITLE
Update flightctl-base image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -18,7 +18,7 @@ COPY proxy /app
 USER 0
 RUN CGO_ENABLED=1 CGO_CFLAGS=-flto GOEXPERIMENT=strictfipsruntime go build
 
-FROM quay.io/flightctl/flightctl-base:9.6-1762316544
+FROM quay.io/flightctl/flightctl-base:9.7-1762965531
 COPY --from=ui-build /app/apps/standalone/dist /app/proxy/dist
 COPY --from=proxy-build /app/flightctl-ui /app/proxy
 WORKDIR /app/proxy

--- a/Containerfile.ocp
+++ b/Containerfile.ocp
@@ -18,7 +18,7 @@ COPY proxy /app
 USER 0
 RUN CGO_ENABLED=1 CGO_CFLAGS=-flto GOEXPERIMENT=strictfipsruntime go build
 
-FROM quay.io/flightctl/flightctl-base:9.6-1762316544
+FROM quay.io/flightctl/flightctl-base:9.7-1762965531
 COPY --from=ui-build /app/apps/ocp-plugin/dist /app/proxy/dist
 COPY --from=proxy-build /app/flightctl-ui /app/proxy
 WORKDIR /app/proxy

--- a/proxy/auth/auth.go
+++ b/proxy/auth/auth.go
@@ -186,7 +186,14 @@ func getClientIdFromProviderConfig(providerConfig *v1beta1.AuthProvider) (string
 		}
 		return oauth2Spec.ClientId, nil
 	case ProviderTypeAAP:
-		return "", fmt.Errorf("AAP providers client_id needs to be retrieved")
+		aapSpec, err := providerConfig.Spec.AsAapProviderSpec()
+		if err != nil {
+			return "", fmt.Errorf("failed to parse AAP provider spec: %w", err)
+		}
+		if aapSpec.ClientId == "" {
+			return "", fmt.Errorf("AAP provider missing required ClientId")
+		}
+		return aapSpec.ClientId, nil
 	case ProviderTypeOpenShift:
 		openshiftSpec, err := providerConfig.Spec.AsOpenShiftProviderSpec()
 		if err != nil {

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.6
 
 require (
-	github.com/flightctl/flightctl v1.0.0-main.0.20251125075421-bbc6daa7c2e7
+	github.com/flightctl/flightctl v1.0.0-rc1
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3

--- a/proxy/go.sum
+++ b/proxy/go.sum
@@ -12,8 +12,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvw
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/flightctl/flightctl v1.0.0-main.0.20251125075421-bbc6daa7c2e7 h1:jDjB/bWu8NRhZErSW7jc2U0o3aRZUBL8oiEHpq1um+0=
-github.com/flightctl/flightctl v1.0.0-main.0.20251125075421-bbc6daa7c2e7/go.mod h1:Gi6cCJ4Jg42yooeBq3cCUpsBvUbWct8US92JEYX7fc4=
+github.com/flightctl/flightctl v1.0.0-rc1 h1:PbWJuz9cOePiGz4/wCKR0HZrILHOVL6o8D4ZuX4bbNo=
+github.com/flightctl/flightctl v1.0.0-rc1/go.mod h1:Gi6cCJ4Jg42yooeBq3cCUpsBvUbWct8US92JEYX7fc4=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/getkin/kin-openapi v0.132.0 h1:3ISeLMsQzcb5v26yeJrBcdTCEQTag36ZjaGk7MIRUwk=


### PR DESCRIPTION
Updates the `flightctl-base` image to the same version as the flightctl repository.
See https://github.com/flightctl/flightctl/pull/2071

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated runtime base image from version 9.6 to 9.7 for improved stability and security.
  * Bumped a module dependency to v1.0.0-rc1 to align with the newer release stream.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->