### PR TITLE
Make the subnav style consistent with the current theme

### DIFF
--- a/apps/standalone/src/app/components/AppLayout/AppToolbar.css
+++ b/apps/standalone/src/app/components/AppLayout/AppToolbar.css
@@ -1,15 +1,3 @@
-.fctl-app_toolbar,
-.fctl-subnav_toolbar {
+.fctl-app_toolbar {
   justify-content: flex-end;
-}
-
-/* Extra navigation bar for global actions (organization switcher, copy login command, etc.) */
-/* We make it as tall as the navigation menu items on the left */
-#global-actions-masthead {
-  padding: 0;
-  --pf-v5-c-masthead--m-display-inline__content--MinHeight: 3.5rem;
-}
-
-#global-actions-masthead .fctl-subnav_toolbar {
-  --pf-v5-c-toolbar--BackgroundColor: var(--pf-v5-global--BackgroundColor--dark-300);
 }

--- a/libs/ui-components/src/components/common/PageNavigation.css
+++ b/libs/ui-components/src/components/common/PageNavigation.css
@@ -1,0 +1,9 @@
+.fctl-subnav_panel {
+  border-bottom: 1px solid var(--pf-v5-global--BorderColor--100);
+  --pf-v5-c-panel__main-body--PaddingTop: 0.6rem;
+  --pf-v5-c-panel__main-body--PaddingBottom: 0.6rem;
+}
+
+.fctl-subnav_toolbar {
+  justify-content: flex-end;
+}

--- a/libs/ui-components/src/components/common/PageNavigation.tsx
+++ b/libs/ui-components/src/components/common/PageNavigation.tsx
@@ -4,11 +4,11 @@ import {
   Dropdown,
   DropdownItem,
   DropdownList,
-  Masthead,
-  MastheadContent,
   MenuToggle,
   MenuToggleElement,
-  PageSection,
+  Panel,
+  PanelMain,
+  PanelMainBody,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
@@ -21,6 +21,8 @@ import { useOrganizationGuardContext } from './OrganizationGuard';
 import OrganizationSelector from './OrganizationSelector';
 import { RESOURCE, VERB } from '../../types/rbac';
 import { usePermissionsContext } from './PermissionsContext';
+
+import './PageNavigation.css';
 
 type OrganizationDropdownProps = {
   organizationName?: string;
@@ -80,9 +82,9 @@ const PageNavigation = ({ showSettings = true }: { showSettings?: boolean }) => 
 
   return (
     <>
-      <PageSection variant="light" padding={{ default: 'noPadding' }}>
-        <Masthead id="global-actions-masthead">
-          <MastheadContent>
+      <Panel className="fctl-subnav_panel">
+        <PanelMain>
+          <PanelMainBody>
             <Toolbar isFullHeight isStatic className="fctl-subnav_toolbar">
               <ToolbarContent>
                 {showOrganizationSelection && (
@@ -111,9 +113,9 @@ const PageNavigation = ({ showSettings = true }: { showSettings?: boolean }) => 
                 )}
               </ToolbarContent>
             </Toolbar>
-          </MastheadContent>
-        </Masthead>
-      </PageSection>
+          </PanelMainBody>
+        </PanelMain>
+      </Panel>
 
       {showOrganizationModal && (
         <OrganizationSelector

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.6
 
 require (
-	github.com/flightctl/flightctl v1.0.0-rc1
+	github.com/flightctl/flightctl v1.0.0-main.0.20251127101911-da85f5a8551a
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3

--- a/proxy/go.sum
+++ b/proxy/go.sum
@@ -12,8 +12,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvw
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/flightctl/flightctl v1.0.0-rc1 h1:PbWJuz9cOePiGz4/wCKR0HZrILHOVL6o8D4ZuX4bbNo=
-github.com/flightctl/flightctl v1.0.0-rc1/go.mod h1:Gi6cCJ4Jg42yooeBq3cCUpsBvUbWct8US92JEYX7fc4=
+github.com/flightctl/flightctl v1.0.0-main.0.20251127101911-da85f5a8551a h1:c2S7l5FqLwcfeN+axL+DYHrauwqKsyweuj/pM4pY1z4=
+github.com/flightctl/flightctl v1.0.0-main.0.20251127101911-da85f5a8551a/go.mod h1:Gi6cCJ4Jg42yooeBq3cCUpsBvUbWct8US92JEYX7fc4=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/getkin/kin-openapi v0.132.0 h1:3ISeLMsQzcb5v26yeJrBcdTCEQTag36ZjaGk7MIRUwk=


### PR DESCRIPTION
As suggested by @pamparan, the `Panel` fits the UX needs better than the `Masthead`, specially since Panel respects the light/dark theme.

<img width="2412" height="665" alt="panel-rhem+acm" src="https://github.com/user-attachments/assets/5b3603f7-61bf-4f85-9215-86eb448960ca" />
<img width="2377" height="503" alt="panel-rhem" src="https://github.com/user-attachments/assets/f8d179c6-96fa-4144-b873-b5b2bf690201" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated navigation layout to a panel-based structure with adjusted spacing, paddings, and a bottom border for clearer separation.
  * Refined toolbar alignment and removed the dedicated global actions masthead styling for a leaner header appearance.

* **Chores**
  * Updated an internal module dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->