### PR TITLE
Do now show login error before flow starts

### DIFF
--- a/apps/standalone/src/app/context/AuthContext.ts
+++ b/apps/standalone/src/app/context/AuthContext.ts
@@ -102,7 +102,14 @@ export const useAuthContext = () => {
           });
 
           if (resp.status === 401) {
-            // Extract error message from response if available
+            const isOnAuthPage = ['/login', '/callback'].includes(window.location.pathname);
+            if (!isOnAuthPage) {
+              // The user is not authenticated - start the login process, and do not show any authentication errors yet
+              setLoading(false);
+              redirectToLogin();
+              return;
+            }
+
             let errorMessage = t('Authentication failed. Please try logging in again.');
             try {
               const contentType = resp.headers.get('content-type');
@@ -119,10 +126,6 @@ export const useAuthContext = () => {
               // If parsing fails, use default error message
             }
             setError(errorMessage);
-            // Don't redirect if we're already on the login or login callback pages
-            if (!['/login', '/callback'].includes(window.location.pathname)) {
-              redirectToLogin();
-            }
             setLoading(false);
             return;
           }


### PR DESCRIPTION
When the user first went to the UI page, we'd briefly show an error as "getUserInfo" returned statusCode 401.
Now we will start the login flow and the errors will be shown if the login fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error handling for unauthorized access scenarios. The app now more efficiently manages login redirects when encountering authentication failures outside of authentication pages, ensuring a smoother user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->