### PR TITLE
EDM-2612: Logout method in OCP is POST. Remove cookie on logout

### DIFF
--- a/proxy/auth/common.go
+++ b/proxy/auth/common.go
@@ -73,10 +73,11 @@ func setCookie(w http.ResponseWriter, value TokenData) error {
 	if err != nil {
 		return err
 	}
+	secure := config.TlsCertPath != ""
 	cookie := http.Cookie{
 		Name:     common.CookieSessionName,
 		Value:    b64.StdEncoding.EncodeToString(cookieVal),
-		Secure:   config.TlsCertPath != "",
+		Secure:   secure,
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
 		Path:     "/",
@@ -576,15 +577,24 @@ func clearPKCEVerifierCookie(w http.ResponseWriter, providerName string) {
 		Path:     "/",
 		Secure:   config.TlsCertPath != "",
 		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode, // Use Lax to match the set cookie
+		SameSite: http.SameSiteLaxMode,
 	}
 	http.SetCookie(w, &cookie)
 }
 
 // clearSessionCookie removes the session cookie
 func clearSessionCookie(w http.ResponseWriter, r *http.Request) {
-	// TODO EDM-2612 Setting cookie here was not working, removed the code - needs to be investigated.
-	// Set Clear-Site-Data header to instruct browser to clear cookies
+	cookie := http.Cookie{
+		Name:     common.CookieSessionName,
+		Value:    "",
+		MaxAge:   -1,
+		Path:     "/",
+		Secure:   config.TlsCertPath != "",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	}
+	http.SetCookie(w, &cookie)
+
 	w.Header().Set("Clear-Site-Data", `"cookies"`)
 }
 

--- a/proxy/auth/openshift.go
+++ b/proxy/auth/openshift.go
@@ -2,9 +2,7 @@ package auth
 
 import (
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -143,48 +141,7 @@ func (o *OpenShiftAuthHandler) RefreshToken(refreshToken string) (TokenData, *in
 }
 
 func (o *OpenShiftAuthHandler) Logout(token string) (string, error) {
-	// OpenShift OAuth logout endpoint is typically at {issuer}/logout
-	// Try to discover it from the OAuth discovery endpoint
-	discoveryURL := fmt.Sprintf("%s/.well-known/oauth-authorization-server", o.apiServerURL)
-	req, err := http.NewRequest(http.MethodGet, discoveryURL, nil)
-	if err != nil {
-		return "", nil
-	}
-
-	httpClient := http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: o.tlsConfig,
-		},
-	}
-
-	res, err := httpClient.Do(req)
-	if err != nil {
-		return "", nil
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return "", nil
-	}
-
-	bodyBytes, err := io.ReadAll(res.Body)
-	if err != nil {
-		return "", nil
-	}
-
-	var discovery openshiftOAuthDiscovery
-	if err := json.Unmarshal(bodyBytes, &discovery); err != nil {
-		return "", nil
-	}
-
-	if discovery.Issuer != "" {
-		logoutURL, err := url.Parse(discovery.Issuer)
-		if err == nil {
-			logoutURL.Path = "/logout"
-			return logoutURL.String(), nil
-		}
-	}
-
+	// The cookie will be cleared by the proxy
 	return "", nil
 }
 


### PR DESCRIPTION
Fixes issues on logout:

1. Cookie not being cleared - this works on Chrome but it doesn't seem to work on Firefox however
2. An error from OpenShift related to GET <clusterUrl>/logout not being allowed. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session cookies are now reliably cleared on logout; the browser is instructed to remove cookie data.

* **Improvements**
  * Cookie security attributes now adapt to deployment (Secure flag applied appropriately).
  * OpenShift logout flow simplified — the proxy now handles cookie clearing without external discovery calls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->