### PR TITLE
EDM-2697: Removing resource limits PATCH fixed

### DIFF
--- a/libs/ui-components/src/components/Device/EditDeviceWizard/deviceSpecUtils.ts
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/deviceSpecUtils.ts
@@ -2,6 +2,7 @@ import {
   AppType,
   // eslint-disable-next-line no-restricted-imports
   ApplicationProviderSpec,
+  ApplicationResourceLimits,
   ApplicationVolume,
   ConfigProviderSpec,
   DeviceSpec,
@@ -256,8 +257,15 @@ export const toAPIApplication = (app: AppForm): ApplicationProviderSpec => {
     if (app.ports) {
       data.ports = app.ports.map((p) => `${p.hostPort}:${p.containerPort}`);
     }
-    const appLimits = app.limits || {};
-    if (appLimits.cpu || appLimits.memory) {
+    // Removed fields must not appear in the resources object
+    const appLimits: ApplicationResourceLimits = {};
+    if (app.limits?.cpu) {
+      appLimits.cpu = app.limits.cpu;
+    }
+    if (app.limits?.memory) {
+      appLimits.memory = app.limits.memory;
+    }
+    if (Object.keys(appLimits).length > 0) {
       data.resources = {
         limits: appLimits,
       };


### PR DESCRIPTION
We were still attempting to PATCH resource limits with empty values.
Now resource limits that are unset are not added to the application payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty or partially empty application resource limits from being included in API payloads for single-container apps, producing cleaner and more accurate requests.
  * Result: API requests no longer include unnecessary or empty limits fields, reducing noise and potential validation issues.
  * Impact: Improves reliability of device updates and reduces chance of unintended configuration changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->