### PR TITLE
Update node-forge to v1.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "workspaces": [
         "./libs/ui-components",
         "./libs/types",
-        "./libs/cypress",
         "./libs/i18n",
         "./libs/ansible",
         "./apps/ocp-plugin",
@@ -28,6 +27,7 @@
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "concurrently": "^8.2.2",
+        "cypress": "^14.0.0",
         "eslint": "^8.44.0",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -291,6 +291,7 @@
     "libs/cypress": {
       "name": "@flightctl/ui-tests-cypress",
       "version": "0.0.0",
+      "extraneous": true,
       "license": "MIT",
       "devDependencies": {
         "cypress": "^14.0.0"
@@ -2605,10 +2606,6 @@
     },
     "node_modules/@flightctl/ui-components": {
       "resolved": "libs/ui-components",
-      "link": true
-    },
-    "node_modules/@flightctl/ui-tests-cypress": {
-      "resolved": "libs/cypress",
       "link": true
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -12792,9 +12789,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
+      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
       "dev": true,
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
   "dependencies": {
     "fast-json-patch": "^3.1.1",
     "lodash": "^4.17.21"
+  },
+  "overrides": {
+    "node-forge": "^1.3.2"
   }
 }


### PR DESCRIPTION
Fixes security issue.
The dependency is coming from `webpack-dev-server` which we can't upgrade, so I added an override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced dependency resolution to ensure consistent versions of key dependencies across installations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->