### PR TITLE
Update go to v1.25

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       skip: ${{ steps.check.outputs.skip }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup Node.js
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x

--- a/.github/workflows/push-to-main.yaml
+++ b/.github/workflows/push-to-main.yaml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       image_tags: ${{ steps.get-tags.outputs.image_tags }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-tags]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build
         id: build
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-tags]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build
         id: build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
   publish-to-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@ ENV NODE_OPTIONS='--max-old-space-size=8192'
 RUN npm ci
 RUN npm run build
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as proxy-build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.3-1763633888 as proxy-build
 WORKDIR /app
 COPY proxy /app
 USER 0

--- a/Containerfile.ocp
+++ b/Containerfile.ocp
@@ -12,7 +12,7 @@ ENV NODE_OPTIONS='--max-old-space-size=8192'
 RUN npm ci
 RUN npm run build:ocp
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as proxy-build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.3-1763633888 as proxy-build
 WORKDIR /app
 COPY proxy /app
 USER 0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Monorepo containing UIs for [Flight Control](https://github.com/flightctl/flight
 
 ## Prerequisites
 
-- `Git`, `Node.js v22.x`, `npm v10.x`, `rsync`, `go` (>= 1.24)
+- `Git`, `Node.js v22.x`, `npm v10.x`, `rsync`, `go` (>= 1.25)
 
 ## Building
 

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -1,8 +1,8 @@
 module github.com/flightctl/flightctl-ui
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.6
+toolchain go1.25.3
 
 require (
 	github.com/flightctl/flightctl v1.0.0-main.0.20251127101911-da85f5a8551a


### PR DESCRIPTION
Following changes in https://github.com/flightctl/flightctl/pull/2108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions checkout action to v6 across all CI/CD workflows
  * Upgraded Go toolchain version to 1.25.3 in build environments

* **Documentation**
  * Updated minimum Go version requirement to 1.25 in project prerequisites

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->