### PR TITLE
EDM-2649 fix OIDC flow failing for cookie size

### DIFF
--- a/proxy/auth/aap.go
+++ b/proxy/auth/aap.go
@@ -122,18 +122,6 @@ func getClient(authorizationUrl, tokenUrl string, tlsConfig *tls.Config, clientI
 	return client, nil
 }
 
-func (a *AAPAuthHandler) GetToken(loginParams LoginParameters) (TokenData, *int64, error) {
-	// UI proxy uses PKCE only - client_secret is not used
-	return exchangeToken(loginParams, a.internalClient, a.tokenURL, a.clientId, config.BaseUiUrl+"/callback")
-}
-
-func (a *AAPAuthHandler) GetUserInfo(tokenData TokenData) (string, *http.Response, error) {
-	resp := &http.Response{
-		StatusCode: http.StatusInternalServerError,
-	}
-	return "", resp, fmt.Errorf("User information should be retrieved through the flightctl API")
-}
-
 func (a *AAPAuthHandler) Logout(token string) (string, error) {
 	data := url.Values{}
 	data.Set("client_id", a.clientId)
@@ -158,10 +146,6 @@ func (a *AAPAuthHandler) Logout(token string) (string, error) {
 	}
 	defer res.Body.Close()
 	return "", nil
-}
-
-func (a *AAPAuthHandler) RefreshToken(refreshToken string) (TokenData, *int64, error) {
-	return refreshOAuthToken(refreshToken, a.internalClient)
 }
 
 func (a *AAPAuthHandler) GetLoginRedirectURL(codeChallenge string) string {

--- a/proxy/auth/auth.go
+++ b/proxy/auth/auth.go
@@ -391,7 +391,7 @@ func (a AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		tokenData, expiresIn := convertTokenResponseToTokenData(tokenResp, providerName)
+		tokenData, expiresIn := convertTokenResponseToTokenData(tokenResp, providerConfig)
 		respondWithToken(w, tokenData, expiresIn)
 	} else {
 		respondWithError(w, http.StatusMethodNotAllowed, "Method not allowed")
@@ -448,7 +448,7 @@ func (a AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Convert backend response to TokenData
-	newTokenData, expiresIn := convertTokenResponseToTokenData(tokenResp, tokenData.Provider)
+	newTokenData, expiresIn := convertTokenResponseToTokenData(tokenResp, providerConfig)
 	respondWithToken(w, newTokenData, expiresIn)
 }
 
@@ -494,7 +494,7 @@ func (a AuthHandler) GetUserInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token := tokenData.GetAuthToken()
+	token := tokenData.Token
 	if token == "" {
 		clearSessionCookie(w, r)
 		respondWithError(w, http.StatusUnauthorized, "No authentication token found in session")
@@ -546,7 +546,7 @@ func (a AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 
 	// If we have a provider, call its Logout method
 	if tokenData.Provider != "" {
-		authToken := tokenData.GetAuthToken()
+		authToken := tokenData.Token
 		if authToken == "" {
 			// No valid session, but still clear cookies and return success
 			clearSessionCookie(w, r)

--- a/proxy/auth/common.go
+++ b/proxy/auth/common.go
@@ -3,16 +3,12 @@ package auth
 import (
 	"crypto/rand"
 	"crypto/sha256"
-	"crypto/tls"
 	b64 "encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
-	"reflect"
-	"strconv"
 	"strings"
 
 	"github.com/flightctl/flightctl-ui/common"
@@ -45,9 +41,6 @@ type LoginParameters struct {
 }
 
 type AuthProvider interface {
-	GetToken(loginParams LoginParameters) (TokenData, *int64, error)
-	GetUserInfo(tokenData TokenData) (string, *http.Response, error)
-	RefreshToken(refreshToken string) (TokenData, *int64, error)
 	Logout(token string) (string, error)
 	GetLoginRedirectURL(codeChallenge string) string
 }
@@ -99,52 +92,6 @@ func ParseSessionCookie(r *http.Request) (TokenData, error) {
 	return tokenData, nil
 }
 
-func getUserInfo(token string, tlsConfig *tls.Config, authURL string, userInfoEndpoint string) (*[]byte, *http.Response, error) {
-	client := &http.Client{Transport: &http.Transport{
-		TLSClientConfig: tlsConfig,
-	}}
-
-	req, err := http.NewRequest(http.MethodGet, userInfoEndpoint, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	req.Header.Add(common.AuthHeaderKey, "Bearer "+token)
-
-	proxyUrl, err := url.Parse(authURL)
-	if err != nil {
-		return nil, nil, err
-	}
-	req.Header.Add("X-Forwarded-Host", proxyUrl.Host)
-	req.Header.Add("X-Forwarded-Proto", proxyUrl.Scheme)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, resp, err
-		}
-		return &body, resp, nil
-	}
-
-	return nil, resp, nil
-}
-
-func getToken(r *http.Request) (string, error) {
-	headerVal := r.Header.Get(common.AuthHeaderKey)
-	token := strings.TrimPrefix(headerVal, "Bearer ")
-	if token == headerVal {
-		return "", errors.New("incorrect auth header value")
-	}
-	token = strings.TrimSpace(token)
-	return token, nil
-}
-
 type ErrorResponse struct {
 	Error string `json:"error"`
 }
@@ -158,234 +105,6 @@ func respondWithError(w http.ResponseWriter, statusCode int, message string) {
 		return
 	}
 	w.Write(response)
-}
-
-// exchangeToken exchanges an authorization code for an access token
-// PKCE is required - code_verifier must be present. The function extracts the token URL
-// and TLS config from the osincli client and manually constructs the token exchange request
-// with PKCE parameters.
-// If tokenURL, clientID, and redirectURI are provided, they will be used instead of reflection.
-func exchangeToken(loginParams LoginParameters, client *osincli.Client, tokenURL string, clientID string, redirectURI string) (TokenData, *int64, error) {
-	// PKCE is required - fail if code_verifier is missing
-	if loginParams.CodeVerifier == "" {
-		return TokenData{}, nil, fmt.Errorf("PKCE code_verifier is required but not provided")
-	}
-
-	// Manually construct the token request with PKCE parameters
-	// Use provided config values if available, otherwise extract from client using reflection
-	var configValue reflect.Value
-	if tokenURL == "" || clientID == "" || redirectURI == "" {
-		// Extract token URL from client config using reflection
-		// osincli.Client.Config is not exported, so we use reflection to access it
-		clientValue := reflect.ValueOf(client)
-		if clientValue.Kind() == reflect.Ptr {
-			if clientValue.IsNil() {
-				return TokenData{}, nil, fmt.Errorf("client is nil")
-			}
-			clientValue = clientValue.Elem()
-		}
-
-		configField := clientValue.FieldByName("Config")
-		if !configField.IsValid() {
-			configField = clientValue.FieldByName("config")
-			if !configField.IsValid() {
-				return TokenData{}, nil, fmt.Errorf("Failed to obtain the client config for PKCE flow")
-			}
-		}
-
-		// Handle both pointer and non-pointer Config field
-		configValue = configField
-		if configField.Kind() == reflect.Ptr {
-			if configField.IsNil() {
-				return TokenData{}, nil, fmt.Errorf("client config is nil")
-			}
-			configValue = configField.Elem()
-		}
-
-		if tokenURL == "" {
-			tokenURLField := configValue.FieldByName("TokenUrl")
-			if !tokenURLField.IsValid() {
-				// Try alternative field name
-				tokenURLField = configValue.FieldByName("tokenUrl")
-				if !tokenURLField.IsValid() {
-					return TokenData{}, nil, fmt.Errorf("Failed to obtain the token URL for PKCE flow")
-				}
-			}
-			tokenURL = tokenURLField.String()
-		}
-
-		if clientID == "" {
-			// Extract client ID from config
-			clientIDField := configValue.FieldByName("ClientId")
-			if !clientIDField.IsValid() {
-				// Try alternative field name
-				clientIDField = configValue.FieldByName("clientId")
-				if !clientIDField.IsValid() {
-					return TokenData{}, nil, fmt.Errorf("Failed to obtain the client ID for PKCE flow")
-				}
-			}
-			clientID = clientIDField.String()
-		}
-
-		if redirectURI == "" {
-			// Extract redirect URI from config
-			redirectURIField := configValue.FieldByName("RedirectUrl")
-			if !redirectURIField.IsValid() {
-				// Try alternative field name
-				redirectURIField = configValue.FieldByName("redirectUrl")
-				if !redirectURIField.IsValid() {
-					return TokenData{}, nil, fmt.Errorf("Failed to obtain the redirect URI for PKCE flow")
-				}
-			}
-			redirectURI = redirectURIField.String()
-		}
-	}
-
-	// Extract TLS config from client's Transport
-	var tlsConfig *tls.Config
-	if client.Transport != nil {
-		transportValue := reflect.ValueOf(client.Transport)
-		// Handle both *http.Transport and wrapped transports (like AAPRoundTripper)
-		if transportValue.Kind() == reflect.Ptr {
-			transportValue = transportValue.Elem()
-		}
-		// Check if it's an http.Transport or has a Transport field (for wrapped transports)
-		tlsConfigField := transportValue.FieldByName("TLSClientConfig")
-		if tlsConfigField.IsValid() && tlsConfigField.Kind() == reflect.Ptr {
-			if !tlsConfigField.IsNil() {
-				tlsConfig = tlsConfigField.Interface().(*tls.Config)
-			}
-		} else {
-			// Try to get Transport field for wrapped transports
-			transportField := transportValue.FieldByName("Transport")
-			if transportField.IsValid() {
-				nestedTransport := transportField.Interface()
-				nestedValue := reflect.ValueOf(nestedTransport)
-				if nestedValue.Kind() == reflect.Ptr {
-					nestedValue = nestedValue.Elem()
-				}
-				tlsConfigField = nestedValue.FieldByName("TLSClientConfig")
-				if tlsConfigField.IsValid() && tlsConfigField.Kind() == reflect.Ptr {
-					if !tlsConfigField.IsNil() {
-						tlsConfig = tlsConfigField.Interface().(*tls.Config)
-					}
-				}
-			}
-		}
-	}
-
-	// Manually construct the token exchange request with PKCE parameters
-	ret := TokenData{}
-
-	// Prepare form data for token request
-	data := url.Values{}
-	data.Set("grant_type", "authorization_code")
-	data.Set("code", loginParams.Code)
-	data.Set("code_verifier", loginParams.CodeVerifier)
-	data.Set("client_id", clientID)
-	data.Set("redirect_uri", redirectURI)
-
-	// Create HTTP request
-	req, err := http.NewRequest(http.MethodPost, tokenURL, strings.NewReader(data.Encode()))
-	if err != nil {
-		return ret, nil, fmt.Errorf("failed to create token request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Accept", "application/json") // Request JSON response
-
-	// Create HTTP client with TLS config
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
-	}
-
-	// Execute request
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return ret, nil, fmt.Errorf("failed to exchange token: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// Read response body
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return ret, nil, fmt.Errorf("failed to read token response: %w", err)
-	}
-
-	// Check for HTTP error status
-	if resp.StatusCode != http.StatusOK {
-		return ret, nil, fmt.Errorf("token exchange failed with status %d", resp.StatusCode)
-	}
-
-	// Check content type to determine response format
-	contentType := resp.Header.Get("Content-Type")
-
-	// Parse response based on content type
-	var tokenResponse map[string]interface{}
-
-	// GitHub and some OAuth providers return form-encoded responses
-	if strings.Contains(contentType, "application/x-www-form-urlencoded") {
-		// Parse as form-encoded
-		values, err := url.ParseQuery(string(body))
-		if err != nil {
-			return ret, nil, fmt.Errorf("failed to parse form-encoded token response: %w", err)
-		}
-
-		// Check for errors in form-encoded response
-		errorParam := values.Get("error")
-		if errorParam != "" {
-			errorDesc := values.Get("error_description")
-			return ret, nil, fmt.Errorf("oauth error: %s - %s", errorParam, errorDesc)
-		}
-
-		// Convert form values to map
-		tokenResponse = make(map[string]interface{})
-		for k, v := range values {
-			if len(v) > 0 {
-				tokenResponse[k] = v[0]
-			}
-		}
-	} else {
-		// Try to parse as JSON
-		if err := json.Unmarshal(body, &tokenResponse); err != nil {
-			return ret, nil, fmt.Errorf("failed to parse token response: %w", err)
-		}
-
-		// Check for errors in JSON response (some providers return JSON error responses)
-		if errorParam, ok := tokenResponse["error"].(string); ok && errorParam != "" {
-			errorDesc := ""
-			if desc, ok := tokenResponse["error_description"].(string); ok {
-				errorDesc = desc
-			}
-			return ret, nil, fmt.Errorf("oauth error: %s - %s", errorParam, errorDesc)
-		}
-	}
-
-	if idToken, ok := tokenResponse["id_token"].(string); ok && idToken != "" {
-		ret.Token = idToken
-	} else if accessToken, ok := tokenResponse["access_token"].(string); ok {
-		ret.Token = accessToken
-	}
-
-	if refreshToken, ok := tokenResponse["refresh_token"].(string); ok {
-		ret.RefreshToken = refreshToken
-	}
-
-	// Extract expires_in
-	expiresIn, err := getExpiresIn(osincli.ResponseData(tokenResponse))
-	if err != nil {
-		return ret, nil, fmt.Errorf("failed to parse expires_in: %w", err)
-	}
-
-	return ret, expiresIn, nil
-}
-
-// refreshOAuthToken refreshes an access token using a refresh token
-func refreshOAuthToken(refreshToken string, client *osincli.Client) (TokenData, *int64, error) {
-	req := client.NewAccessRequest(osincli.REFRESH_TOKEN, &osincli.AuthorizeData{Code: refreshToken})
-	return executeOAuthFlow(req)
 }
 
 // loginRedirect generates the OAuth login redirect URL with provider state and PKCE parameters
@@ -417,59 +136,6 @@ func loginRedirect(client *osincli.Client, providerName string, codeChallenge st
 	parsedURL.RawQuery = query.Encode()
 
 	return parsedURL.String()
-}
-
-// executeOAuthFlow executes the OAuth token exchange flow
-func executeOAuthFlow(req *osincli.AccessRequest) (TokenData, *int64, error) {
-	ret := TokenData{}
-	// Exchange refresh token for a new access token
-	accessData, err := req.GetToken()
-	if err != nil {
-		return ret, nil, fmt.Errorf("failed to refresh token: %w", err)
-	}
-
-	expiresIn, err := getExpiresIn(accessData.ResponseData)
-	if err != nil {
-		return ret, nil, fmt.Errorf("failed to refresh token: %w", err)
-	}
-
-	if idTokenRaw, exists := accessData.ResponseData["id_token"]; exists {
-		if idToken, ok := idTokenRaw.(string); ok && idToken != "" {
-			ret.Token = idToken
-		} else {
-			ret.Token = accessData.AccessToken
-		}
-	} else {
-		ret.Token = accessData.AccessToken
-	}
-
-	ret.RefreshToken = accessData.RefreshToken
-
-	return ret, expiresIn, nil
-}
-
-// getExpiresIn extracts the expires_in value from OAuth response data
-// Based on GetToken() from osincli which parses the expires_in to int32 that may overflow
-func getExpiresIn(ret osincli.ResponseData) (*int64, error) {
-	expires_in_raw, ok := ret["expires_in"]
-	if ok {
-		rv := reflect.ValueOf(expires_in_raw)
-		switch rv.Kind() {
-		case reflect.Float64:
-			expiration := int64(rv.Float())
-			return &expiration, nil
-		case reflect.String:
-			// if string convert to integer
-			ei, err := strconv.ParseInt(rv.String(), 10, 64)
-			if err != nil {
-				return nil, err
-			}
-			return &ei, nil
-		default:
-			return nil, errors.New("invalid parameter value")
-		}
-	}
-	return nil, nil
 }
 
 // buildScopeParam builds a space-separated scope string from provider scopes or default scopes

--- a/proxy/auth/k8s.go
+++ b/proxy/auth/k8s.go
@@ -30,11 +30,6 @@ func NewTokenAuthProvider(apiTlsConfig *tls.Config, authURL string, providerName
 	}
 }
 
-// GetToken does not exist for token auth
-func (t *TokenAuthProvider) GetToken(loginParams LoginParameters) (TokenData, *int64, error) {
-	return TokenData{}, nil, fmt.Errorf("token auth does not use OAuth code flow")
-}
-
 // ValidateToken validates a K8s token by calling the backend API
 func (t *TokenAuthProvider) ValidateToken(token string) (TokenData, *int64, error) {
 	client := &http.Client{Transport: &http.Transport{
@@ -115,19 +110,6 @@ func extractTokenExpiration(token string) *int64 {
 	}
 
 	return &expiresIn
-}
-
-// GetUserInfo retrieves user information from the provided JWT token
-func (t *TokenAuthProvider) GetUserInfo(tokenData TokenData) (string, *http.Response, error) {
-	resp := &http.Response{
-		StatusCode: http.StatusInternalServerError,
-	}
-	return "", resp, fmt.Errorf("User information should be retrieved through the flightctl API")
-}
-
-// RefreshToken is not applicable for K8s token auth
-func (t *TokenAuthProvider) RefreshToken(refreshToken string) (TokenData, *int64, error) {
-	return TokenData{}, nil, fmt.Errorf("token refresh not supported for K8s token auth")
 }
 
 // Logout for token auth just clears the session

--- a/proxy/auth/k8s.go
+++ b/proxy/auth/k8s.go
@@ -73,7 +73,7 @@ func (t *TokenAuthProvider) ValidateToken(token string) (TokenData, *int64, erro
 
 	// Store the validated K8s JWT token
 	tokenData := TokenData{
-		IDToken:      token,
+		Token:        token,
 		RefreshToken: "",
 	}
 

--- a/proxy/auth/oauth2.go
+++ b/proxy/auth/oauth2.go
@@ -78,25 +78,10 @@ func getOAuth2AuthHandler(provider *v1beta1.AuthProvider, oauth2Spec *v1beta1.OA
 	return handler, nil
 }
 
-func (o *OAuth2AuthHandler) GetToken(loginParams LoginParameters) (TokenData, *int64, error) {
-	return exchangeToken(loginParams, o.internalClient, o.tokenURL, o.clientId, config.BaseUiUrl+"/callback")
-}
-
-func (o *OAuth2AuthHandler) GetUserInfo(tokenData TokenData) (string, *http.Response, error) {
-	resp := &http.Response{
-		StatusCode: http.StatusInternalServerError,
-	}
-	return "", resp, fmt.Errorf("User information should be retrieved through the flightctl API")
-}
-
 func (o *OAuth2AuthHandler) Logout(token string) (string, error) {
 	// OAuth2 providers typically don't have a standardized logout endpoint
 	// Return empty string to indicate no logout URL
 	return "", nil
-}
-
-func (o *OAuth2AuthHandler) RefreshToken(refreshToken string) (TokenData, *int64, error) {
-	return refreshOAuthToken(refreshToken, o.internalClient)
 }
 
 func (o *OAuth2AuthHandler) GetLoginRedirectURL(codeChallenge string) string {

--- a/proxy/auth/oidc.go
+++ b/proxy/auth/oidc.go
@@ -168,17 +168,6 @@ func getOIDCClient(oidcConfig oidcServerResponse, tlsConfig *tls.Config, clientI
 	return client, nil
 }
 
-func (a *OIDCAuthHandler) GetToken(loginParams LoginParameters) (TokenData, *int64, error) {
-	return exchangeToken(loginParams, a.internalClient, a.tokenEndpoint, a.clientId, config.BaseUiUrl+"/callback")
-}
-
-func (o *OIDCAuthHandler) GetUserInfo(tokenData TokenData) (string, *http.Response, error) {
-	resp := &http.Response{
-		StatusCode: http.StatusInternalServerError,
-	}
-	return "", resp, fmt.Errorf("User information should be retrieved through the flightctl API")
-}
-
 func (o *OIDCAuthHandler) Logout(token string) (string, error) {
 	u, err := url.Parse(o.endSessionEndpoint)
 	if err != nil {
@@ -190,10 +179,6 @@ func (o *OIDCAuthHandler) Logout(token string) (string, error) {
 	uq.Add("client_id", o.clientId)
 	u.RawQuery = uq.Encode()
 	return u.String(), nil
-}
-
-func (o *OIDCAuthHandler) RefreshToken(refreshToken string) (TokenData, *int64, error) {
-	return refreshOAuthToken(refreshToken, o.internalClient)
 }
 
 func (a *OIDCAuthHandler) GetLoginRedirectURL(codeChallenge string) string {

--- a/proxy/auth/openshift.go
+++ b/proxy/auth/openshift.go
@@ -124,22 +124,6 @@ func getOpenShiftAuthHandlerFromSpec(provider *v1beta1.AuthProvider, openshiftSp
 	return handler, nil
 }
 
-func (o *OpenShiftAuthHandler) GetToken(loginParams LoginParameters) (TokenData, *int64, error) {
-	// OpenShift typically doesn't require client_secret with PKCE
-	return exchangeToken(loginParams, o.internalClient, o.tokenURL, o.clientId, config.BaseUiUrl+"/callback")
-}
-
-func (o *OpenShiftAuthHandler) GetUserInfo(tokenData TokenData) (string, *http.Response, error) {
-	resp := &http.Response{
-		StatusCode: http.StatusInternalServerError,
-	}
-	return "", resp, fmt.Errorf("User information should be retrieved through the flightctl API")
-}
-
-func (o *OpenShiftAuthHandler) RefreshToken(refreshToken string) (TokenData, *int64, error) {
-	return refreshOAuthToken(refreshToken, o.internalClient)
-}
-
 func (o *OpenShiftAuthHandler) Logout(token string) (string, error) {
 	// The cookie will be cleared by the proxy
 	return "", nil

--- a/proxy/middleware/auth.go
+++ b/proxy/middleware/auth.go
@@ -15,7 +15,7 @@ func AuthMiddleware(next http.Handler) http.Handler {
 		if err != nil {
 			log.GetLogger().Warn(err.Error())
 		} else {
-			token := tokenData.GetAuthToken()
+			token := tokenData.Token
 			if token != "" {
 				r.Header.Add(common.AuthHeaderKey, "Bearer "+token)
 			}


### PR DESCRIPTION
The authentication for a provider such as Keycloak was failing as the UI couldn't store the cookie with the PKCE flow information due to it passing the max allowed size.

I also removed the unused methods from the specific authentication providers, since now we're centralizing the flow via the Flight Control API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PKCE support for stronger auth flows.
  * Enforced session cookie size validation to avoid oversized cookies.

* **Refactor**
  * Unified token representation for consistent handling across providers.
  * Simplified auth provider surface: only logout and redirect flows remain exposed; token exchange, user-info retrieval, and refresh flows removed.

* **Chores**
  * Updated cookie and session handling for more robust PKCE/state management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->