### PR TITLE
EDM-2733: Ignore errors in advanced block if basic is selected

### DIFF
--- a/libs/ui-components/src/components/Device/EditDeviceWizard/utils.ts
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/utils.ts
@@ -34,7 +34,8 @@ export const getValidationSchema = (t: TFunction) =>
       labels: validLabelsSchema(t),
       configTemplates: validConfigTemplatesSchema(t),
       applications: validApplicationsSchema(t),
-      updatePolicy: values.updatePolicy.isAdvanced ? validUpdatePolicySchema(t) : Yup.object(),
+      updatePolicy:
+        !values.useBasicUpdateConfig && values.updatePolicy.isAdvanced ? validUpdatePolicySchema(t) : Yup.object(),
     }),
   );
 


### PR DESCRIPTION
We ignore the errors in the advanced block when users select "use basic configurations" again.

This was properly working already in the EditFleetWizard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for device update policy: advanced update settings now require basic update configuration to be turned off before they can be applied, preventing invalid advanced-policy submissions and reducing configuration errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->