### PR TITLE
Update doc links with new format

### DIFF
--- a/libs/ui-components/src/hooks/useAppLinks.ts
+++ b/libs/ui-components/src/hooks/useAppLinks.ts
@@ -3,7 +3,7 @@ import { FlightCtlApp, useAppContext } from './useAppContext';
 // Links to other flightctl upstream resources
 export const DEMO_REPOSITORY_URL = 'https://github.com/flightctl/flightctl-demos';
 
-const ACM_VERSION = '2.13';
+const ACM_VERSION = '2.14';
 const AAP_VERSION = '2.5';
 
 const upstreamDocsBase = 'https://github.com/flightctl/flightctl/blob/main/docs';
@@ -12,10 +12,10 @@ const aapDownstreamDocsBase = `https://docs.redhat.com/en/documentation/red_hat_
 
 const links = {
   fc: {
-    createApp: `${upstreamDocsBase}/user/managing-devices.md#creating-applications`,
-    useTemplateVars: `${upstreamDocsBase}/user/managing-fleets.md#defining-device-templates`,
-    addNewDevice: `${upstreamDocsBase}/user/getting-started.md#building-a-bootable-container-image-including-the-flight-control-agent`,
-    createAcmRepo: `${upstreamDocsBase}/user/registering-microshift-devices-acm.md#creating-the-acm-registration-repository`,
+    createApp: `${upstreamDocsBase}/user/using/managing-devices.md#creating-applications`,
+    useTemplateVars: `${upstreamDocsBase}/user/using/managing-fleets.md#defining-device-templates`,
+    addNewDevice: `${upstreamDocsBase}/user/building/building-images.md#choosing-an-enrollment-method`,
+    createAcmRepo: `${upstreamDocsBase}/user/using/registering-microshift-devices-acm.md#auto-registering-devices-with-microshift-into-acm`,
   },
   acm: {
     createApp: `${acmDownstreamDocsBase}#build-app-packages`,


### PR DESCRIPTION
Links in flightctl now have a different structure

https://github.com/flightctl/flightctl/blob/main/docs/user/using/managing-devices.md#creating-applications
https://github.com/flightctl/flightctl/blob/main/docs/user/using/managing-fleets.md#defining-device-templates
https://github.com/flightctl/flightctl/blob/main/docs/user/building/building-images.md#building-the-os-image-bootc
https://github.com/flightctl/flightctl/blob/main/docs/user/using/registering-microshift-devices-acm.md#creating-the-acm-registration-repository

- Updated ACM version to 2.14. Will check with the docs team for new links in case they'll also change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Version bumped to 2.14 and refreshed help links across key workflows: application creation, device template configuration, device enrollment method selection, and device registration with ACM to ensure users see up-to-date guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->