### PR TITLE
EDM-2776: Fix wrong verb for approving Enrollment Requests

### DIFF
--- a/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestDetails/EnrollmentRequestDetails.tsx
+++ b/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestDetails/EnrollmentRequestDetails.tsx
@@ -42,7 +42,7 @@ import PageWithPermissions from '../../common/PageWithPermissions';
 import './EnrollmentRequestDetails.css';
 
 const enrollmentRequestDetailsPermissions = [
-  { kind: RESOURCE.ENROLLMENT_REQUEST_APPROVAL, verb: VERB.POST },
+  { kind: RESOURCE.ENROLLMENT_REQUEST_APPROVAL, verb: VERB.UPDATE },
   { kind: RESOURCE.ENROLLMENT_REQUEST, verb: VERB.DELETE },
 ];
 


### PR DESCRIPTION
The verb for approving Enrollment Requests is PUT and not POST.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authorization for approving enrollment requests so the Approve action is now correctly gated by the appropriate update permission.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->