### PR TITLE
EDM-2755: Show errors in all duplicate files

### DIFF
--- a/libs/ui-components/src/components/form/validations.ts
+++ b/libs/ui-components/src/components/form/validations.ts
@@ -386,17 +386,26 @@ const uniqueFilePathsTest =
       return true;
     }
 
-    const parentFiles = (testContext.parent as { files?: (QuadletInlineAppForm | ComposeInlineAppForm)['files'] })
-      .files;
-    const duplicateIndex = (parentFiles || []).findIndex((file) => duplicateFilePaths.includes(file.path));
+    // Create errors for all files with duplicate paths
+    const errors = files.reduce((errors, file, index) => {
+      if (duplicateFilePaths.includes(file.path)) {
+        errors.push(
+          new Yup.ValidationError(
+            t('Each file of the same application must use different paths.'),
+            '',
+            `${testContext.path}[${index}].path`,
+          ),
+        );
+      }
+      return errors;
+    }, [] as Yup.ValidationError[]);
 
-    if (duplicateIndex === -1) {
+    if (errors.length === 0) {
       return true;
     }
 
     return testContext.createError({
-      path: `${testContext.path}[${duplicateIndex}].path`,
-      message: () => t('Each file of the same application must use different paths.'),
+      message: () => errors,
     });
   };
 


### PR DESCRIPTION
Previously the UI was only setting an error on the first file from a set of files with duplicate names.
Since errors are only shown for touched fields, we may not be displaying the error at all.

Now we ensure we'll always display at least one error about the duplicate names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File validation now reports an error for each file that shares a duplicate path (instead of only the first), giving clearer, per-file feedback during uploads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->