### PR TITLE
Do not show warning icon for unsupported integrity status

### DIFF
--- a/libs/ui-components/src/utils/status/integrity.ts
+++ b/libs/ui-components/src/utils/status/integrity.ts
@@ -1,4 +1,5 @@
 import { TFunction } from 'react-i18next';
+import { InfoCircleIcon } from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
 
 import { DeviceIntegrityCheckStatusType, DeviceIntegrityStatusSummaryType } from '@flightctl/types';
 import { StatusItem } from './common';
@@ -12,7 +13,8 @@ export const getIntegrityStatusItems = (t: TFunction): StatusItem<DeviceIntegrit
   {
     id: DeviceIntegrityStatusSummaryType.DeviceIntegrityStatusUnsupported,
     label: t('Unsupported'),
-    level: 'unknown',
+    level: 'info',
+    customIcon: InfoCircleIcon,
   },
   {
     id: DeviceIntegrityStatusSummaryType.DeviceIntegrityStatusUnknown,


### PR DESCRIPTION
Needs confirmation from UX that we should show also the InfoIcon for the integrity status higher level.
<img width="541" height="382" alt="integrity-all" src="https://github.com/user-attachments/assets/c2f8c2e1-bf82-491b-ae97-7d981794f750" />
