### PR TITLE
Force the user to enter their credentials / select account for new login

### DIFF
--- a/proxy/auth/common.go
+++ b/proxy/auth/common.go
@@ -128,6 +128,11 @@ func loginRedirect(client *osincli.Client, state string, codeChallenge string) s
 	query.Set("code_challenge", codeChallenge)
 	query.Set("code_challenge_method", "S256")
 
+	// Force that when a new auth flow starts, the user is prompted to select
+	// their account and enter credentials, even if they're already logged in
+	// Does not work for all providers (eg. OpenShift)
+	query.Set("prompt", "login select_account")
+
 	parsedURL.RawQuery = query.Encode()
 
 	return parsedURL.String()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth authentication flow now requires users to select their account and provide credentials during each login, ensuring consistent user verification across supported providers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->