### PR TITLE
EDM-2830:Show reload organizations only when it can succeed

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -228,6 +228,7 @@
   "Unable to log in to the application": "Unable to log in to the application",
   "You do not have access to any organizations.": "You do not have access to any organizations.",
   "Please contact your administrator to be granted access to an organization.": "Please contact your administrator to be granted access to an organization.",
+  "You will need to log out and log in again to access the application.": "You will need to log out and log in again to access the application.",
   "We cannot log you in as we could not determine what organizations you have access to.": "We cannot log you in as we could not determine what organizations you have access to.",
   "Please try refreshing the page. If the problem persists, contact your administrator.": "Please try refreshing the page. If the problem persists, contact your administrator.",
   "Error details": "Error details",

--- a/libs/ui-components/src/components/common/OrganizationSelector.tsx
+++ b/libs/ui-components/src/components/common/OrganizationSelector.tsx
@@ -194,6 +194,7 @@ const OrganizationSelector = ({ onClose, isFirstLogin = true }: OrganizationSele
                 <>
                   <Text>{t('You do not have access to any organizations.')}</Text>
                   <Text>{t('Please contact your administrator to be granted access to an organization.')}</Text>
+                  <Text>{t('You will need to log out and log in again to access the application.')}</Text>
                 </>
               ) : (
                 <>
@@ -212,15 +213,17 @@ const OrganizationSelector = ({ onClose, isFirstLogin = true }: OrganizationSele
                 </>
               )}
             </TextContent>
-            <ActionList className="pf-v5-u-mt-md">
-              <ActionListGroup>
-                <ActionListItem>
-                  <Button variant="primary" onClick={handleRefetch} isDisabled={isReloading}>
-                    {t('Reload organizations')}
-                  </Button>
-                </ActionListItem>
-              </ActionListGroup>
-            </ActionList>
+            {!isEmptyOrganizations && (
+              <ActionList className="pf-v5-u-mt-md">
+                <ActionListGroup>
+                  <ActionListItem>
+                    <Button variant="primary" onClick={handleRefetch} isDisabled={isReloading}>
+                      {t('Reload organizations')}
+                    </Button>
+                  </ActionListItem>
+                </ActionListGroup>
+              </ActionList>
+            )}
           </Alert>
         </Bullseye>
       </PageSection>


### PR DESCRIPTION
The button for reloading the organization will not succeed while the user stays logged in, so it's best to remove it.

We only keep it for the case where there's an unknown error which may be transient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user notification prompting users to log out and log back in to regain access in specific scenarios.

* **Bug Fixes**
  * Reload action now appears only when organizations are available, clarifying when users can retry loading content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->