### PR TITLE
Add flightctl-api-version for imageBuilder API

### DIFF
--- a/apps/standalone/src/app/utils/apiCalls.ts
+++ b/apps/standalone/src/app/utils/apiCalls.ts
@@ -4,8 +4,8 @@ import {
   getErrorMsgFromAlertsApiResponse,
   getErrorMsgFromApiResponse,
 } from '@flightctl/ui-components/src/utils/apiCalls';
+import { getApiVersion } from '@flightctl/ui-components/src/constants';
 import { ORGANIZATION_STORAGE_KEY } from '@flightctl/ui-components/src/utils/organizationStorage';
-import { API_VERSION } from '@flightctl/ui-components/src/constants';
 
 import { lastRefresh } from '../context/AuthContext';
 
@@ -45,7 +45,7 @@ export const fetchUiProxy = async (endpoint: string, requestInit: RequestInit): 
   return await fetch(`${uiProxyAPI}/${endpoint}`, options);
 };
 
-const getFullApiUrl = (path: string) => {
+const getFullApiUrl = (path: string): { api: 'flightctl' | 'imagebuilder' | 'alerts'; url: string } => {
   if (path.startsWith('alerts')) {
     return { api: 'alerts', url: `${uiProxyAPI}/alerts/api/v2/${path}` };
   }
@@ -106,13 +106,11 @@ const handleAlertsJSONResponse = async <R>(response: Response): Promise<R> => {
 const fetchWithRetry = async <R>(path: string, init?: RequestInit): Promise<R> => {
   const { api, url } = getFullApiUrl(path);
 
-  // Add organization header if available
   const options = addOrganizationHeader({ ...init });
-
-  // Add version header only for FlightCtl API
-  if (api === 'flightctl') {
+  const apiVersion = getApiVersion(api);
+  if (apiVersion) {
     const headers = new Headers(options.headers);
-    headers.set('Flightctl-API-Version', API_VERSION);
+    headers.set('Flightctl-API-Version', apiVersion);
     options.headers = headers;
   }
 

--- a/libs/types/scripts/openapi-typescript.js
+++ b/libs/types/scripts/openapi-typescript.js
@@ -10,7 +10,10 @@ const { rimraf, copyDir, fixImagebuilderCoreReferences } = require('./openapi-ut
 const CORE_API = 'core';
 const IMAGEBUILDER_API = 'imagebuilder';
 
-const getSwaggerUrl = (api) => `https://raw.githubusercontent.com/flightctl/flightctl/main/api/${api}/v1beta1`;
+const getSwaggerUrl = (api) => {
+  const apiVersion = api === CORE_API ? 'v1beta1' : 'v1alpha1';
+  return `https://raw.githubusercontent.com/flightctl/flightctl/main/api/${api}/${apiVersion}/openapi.yaml`;
+};
 
 const processJsonAPI = (jsonString) => {
   const json = YAML.load(jsonString);
@@ -29,12 +32,12 @@ const processJsonAPI = (jsonString) => {
 async function generateTypes(mode) {
   const config = {
     [CORE_API]: {
-      swaggerUrl: `${getSwaggerUrl(CORE_API)}/openapi.yaml`,
+      swaggerUrl: getSwaggerUrl(CORE_API),
       output: path.resolve(__dirname, '../tmp-types'),
       finalDir: path.resolve(__dirname, '../models'),
     },
     [IMAGEBUILDER_API]: {
-      swaggerUrl: `${getSwaggerUrl(IMAGEBUILDER_API)}/openapi.yaml`,
+      swaggerUrl: getSwaggerUrl(IMAGEBUILDER_API),
       output: path.resolve(__dirname, '../tmp-imagebuilder-types'),
       finalDir: path.resolve(__dirname, '../imagebuilder/models'),
     },

--- a/libs/ui-components/src/components/AuthProvider/CreateAuthProvider/utils.ts
+++ b/libs/ui-components/src/components/AuthProvider/CreateAuthProvider/utils.ts
@@ -25,7 +25,7 @@ import {
 } from './types';
 import { validKubernetesDnsSubdomain } from '../../form/validations';
 import { DynamicAuthProviderSpec, ProviderType } from '../../../types/extraTypes';
-import { API_VERSION } from '../../../constants';
+import { CORE_API_VERSION } from '../../../constants';
 
 export const getAssignmentTypeLabel = (
   type: AuthOrganizationAssignment['type'] | AuthRoleAssignment['type'] | undefined,
@@ -317,7 +317,7 @@ export const getAuthProvider = (values: AuthProviderFormValues): AuthProvider =>
   }
 
   return {
-    apiVersion: API_VERSION,
+    apiVersion: CORE_API_VERSION,
     kind: 'AuthProvider',
     metadata: {
       name: values.name,

--- a/libs/ui-components/src/components/Fleet/CreateFleet/utils.ts
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/utils.ts
@@ -1,7 +1,7 @@
 import { Fleet, PatchRequest } from '@flightctl/types';
 import { TFunction } from 'i18next';
 import * as Yup from 'yup';
-import { API_VERSION } from '../../../constants';
+import { CORE_API_VERSION } from '../../../constants';
 import { toAPILabel } from '../../../utils/labels';
 import {
   systemdUnitListValidationSchema,
@@ -178,7 +178,7 @@ export const getFleetResource = (values: FleetFormValues): Fleet => {
           },
         };
   const fleet: Fleet = {
-    apiVersion: API_VERSION,
+    apiVersion: CORE_API_VERSION,
     kind: 'Fleet',
     metadata: {
       name: values.name,

--- a/libs/ui-components/src/components/ImageBuilds/CreateImageBuildWizard/utils.ts
+++ b/libs/ui-components/src/components/ImageBuilds/CreateImageBuildWizard/utils.ts
@@ -10,7 +10,7 @@ import {
   ImageExport,
   ResourceKind,
 } from '@flightctl/types/imagebuilder';
-import { API_VERSION } from '../../../constants';
+import { IMAGEBUILDER_API_VERSION } from '../../../constants';
 import { ImageBuildFormValues } from './types';
 import { ImageBuildWithExports } from '../../../types/extraTypes';
 
@@ -162,7 +162,7 @@ export const getImageBuildResource = (values: ImageBuildFormValues): ImageBuild 
   }
 
   return {
-    apiVersion: API_VERSION,
+    apiVersion: IMAGEBUILDER_API_VERSION,
     kind: ResourceKind.IMAGE_BUILD,
     metadata: {
       name,
@@ -175,7 +175,7 @@ export const getImageExportResource = (imageBuildName: string, format: ExportFor
   const exportName = generateExportName(imageBuildName, format);
 
   return {
-    apiVersion: API_VERSION,
+    apiVersion: IMAGEBUILDER_API_VERSION,
     kind: ResourceKind.IMAGE_EXPORT,
     metadata: {
       name: exportName,

--- a/libs/ui-components/src/components/Repository/CreateRepository/utils.ts
+++ b/libs/ui-components/src/components/Repository/CreateRepository/utils.ts
@@ -16,7 +16,7 @@ import {
 } from '@flightctl/types';
 
 import { RepositoryFormValues, ResourceSyncFormValue } from './types';
-import { API_VERSION } from '../../../constants';
+import { CORE_API_VERSION } from '../../../constants';
 import { getErrorMessage } from '../../../utils/error';
 import { appendJSONPatch } from '../../../utils/patch';
 import { MAX_TARGET_REVISION_LENGTH, maxLengthString, validKubernetesDnsSubdomain } from '../../form/validations';
@@ -779,7 +779,7 @@ export const getRepository = (values: Omit<RepositoryFormValues, 'useResourceSyn
     }
 
     return {
-      apiVersion: API_VERSION,
+      apiVersion: CORE_API_VERSION,
       kind: 'Repository',
       metadata: {
         name: values.name,
@@ -877,7 +877,7 @@ export const getRepository = (values: Omit<RepositoryFormValues, 'useResourceSyn
   }
 
   return {
-    apiVersion: API_VERSION,
+    apiVersion: CORE_API_VERSION,
     kind: 'Repository',
     metadata: {
       name: values.name,
@@ -888,7 +888,7 @@ export const getRepository = (values: Omit<RepositoryFormValues, 'useResourceSyn
 
 export const getResourceSync = (repositoryId: string, values: ResourceSyncFormValue): ResourceSync => {
   return {
-    apiVersion: API_VERSION,
+    apiVersion: CORE_API_VERSION,
     kind: 'ResourceSync',
     metadata: {
       name: values.name,

--- a/libs/ui-components/src/constants.ts
+++ b/libs/ui-components/src/constants.ts
@@ -1,7 +1,20 @@
-const APP_TITLE = 'Edge Manager';
-const API_VERSION = 'v1beta1';
-const PAGE_SIZE = 15;
-const EVENT_PAGE_SIZE = 200; // It's 500 in OCP console
-const CERTIFICATE_VALIDITY_IN_YEARS = 1;
+export const APP_TITLE = 'Edge Manager';
+export const CORE_API_VERSION = 'v1beta1';
+export const IMAGEBUILDER_API_VERSION = 'v1alpha1';
 
-export { APP_TITLE, API_VERSION, PAGE_SIZE, EVENT_PAGE_SIZE, CERTIFICATE_VALIDITY_IN_YEARS };
+export const PAGE_SIZE = 15;
+export const EVENT_PAGE_SIZE = 200; // It's 500 in OCP console
+
+export const CERTIFICATE_VALIDITY_IN_YEARS = 1;
+
+export const getApiVersion = (api: 'flightctl' | 'imagebuilder' | 'alerts'): string | undefined => {
+  switch (api) {
+    case 'flightctl':
+      return CORE_API_VERSION;
+    case 'imagebuilder':
+      return IMAGEBUILDER_API_VERSION;
+    case 'alerts':
+    default:
+      return undefined;
+  }
+};

--- a/libs/ui-components/src/utils/search.ts
+++ b/libs/ui-components/src/utils/search.ts
@@ -1,5 +1,5 @@
 import fuzzy from 'fuzzysearch';
-import { API_VERSION } from '../constants';
+import { CORE_API_VERSION } from '../constants';
 
 // Must be an even number for "getSearchResultsCount" to work
 export const MAX_TOTAL_SEARCH_RESULTS = 10;
@@ -26,7 +26,7 @@ export const getSearchResultsCount = (labelCount: number, fleetCount: number) =>
 };
 
 export const getEmptyFleetSearch = () => ({
-  apiVersion: API_VERSION,
+  apiVersion: CORE_API_VERSION,
   kind: 'Fleet',
   metadata: {},
   items: [],


### PR DESCRIPTION
Adapts the UI to send the expected header for ImageBuilder API (`v1alpha1`).

Requires https://github.com/flightctl/flightctl/pull/2452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced API versioning system to dynamically manage versions across multiple APIs (flightctl, imagebuilder, alerts).
  * Improved request header construction to use dynamic API versioning instead of static values.
  * Reorganized internal constants to better support multi-API architecture and improved system flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->