### PR TITLE
EDM-2984: UI includes Flightctl-API-Version header (#465)

### DIFF
--- a/apps/ocp-plugin/src/utils/apiCalls.ts
+++ b/apps/ocp-plugin/src/utils/apiCalls.ts
@@ -7,6 +7,7 @@ import {
   getErrorMsgFromApiResponse,
 } from '@flightctl/ui-components/src/utils/apiCalls';
 import { ORGANIZATION_STORAGE_KEY } from '@flightctl/ui-components/src/utils/organizationStorage';
+import { API_VERSION } from '@flightctl/ui-components/src/constants';
 
 declare global {
   interface Window {
@@ -15,12 +16,15 @@ declare global {
   }
 }
 
-const addRequiredHeaders = (options: RequestInit): RequestInit => {
+const addRequiredHeaders = (options: RequestInit, apiVersion?: string): RequestInit => {
   const token = getCSRFToken();
   const orgId = localStorage.getItem(ORGANIZATION_STORAGE_KEY);
 
   const headers = new Headers(options.headers || {});
   headers.set('X-CSRFToken', token);
+  if (apiVersion) {
+    headers.set('Flightctl-API-Version', apiVersion);
+  }
   if (orgId) {
     headers.set('X-FlightCtl-Organization-ID', orgId);
   }
@@ -104,9 +108,9 @@ const putOrPostData = async <TRequest, TResponse = TRequest>(
     body: JSON.stringify(data),
   };
 
-  const options = addRequiredHeaders(baseOptions);
+  const { api, url } = getFullApiUrl(kind);
+  const options = addRequiredHeaders(baseOptions, api === 'flightctl' ? API_VERSION : undefined);
   try {
-    const { url } = getFullApiUrl(kind);
     const response = await fetch(url, options);
     return handleApiJSONResponse(response);
   } catch (error) {
@@ -127,9 +131,9 @@ export const deleteData = async <R>(kind: string, abortSignal?: AbortSignal): Pr
     signal: abortSignal,
   };
 
-  const options = addRequiredHeaders(baseOptions);
+  const { api, url } = getFullApiUrl(kind);
+  const options = addRequiredHeaders(baseOptions, api === 'flightctl' ? API_VERSION : undefined);
   try {
-    const { url } = getFullApiUrl(kind);
     const response = await fetch(url, options);
     return handleApiJSONResponse(response);
   } catch (error) {
@@ -148,9 +152,9 @@ export const patchData = async <R>(kind: string, data: PatchRequest, abortSignal
     signal: abortSignal,
   };
 
-  const options = addRequiredHeaders(baseOptions);
+  const { api, url } = getFullApiUrl(kind);
+  const options = addRequiredHeaders(baseOptions, api === 'flightctl' ? API_VERSION : undefined);
   try {
-    const { url } = getFullApiUrl(kind);
     const response = await fetch(url, options);
     return handleApiJSONResponse(response);
   } catch (error) {
@@ -167,7 +171,7 @@ export const fetchData = async <R>(path: string, abortSignal?: AbortSignal): Pro
       signal: abortSignal,
     };
 
-    const options = addRequiredHeaders(baseOptions);
+    const options = addRequiredHeaders(baseOptions, api === 'flightctl' ? API_VERSION : undefined);
 
     const response = await fetch(url, options);
     if (api === 'alerts') {

--- a/apps/standalone/src/app/utils/apiCalls.ts
+++ b/apps/standalone/src/app/utils/apiCalls.ts
@@ -5,6 +5,7 @@ import {
   getErrorMsgFromApiResponse,
 } from '@flightctl/ui-components/src/utils/apiCalls';
 import { ORGANIZATION_STORAGE_KEY } from '@flightctl/ui-components/src/utils/organizationStorage';
+import { API_VERSION } from '@flightctl/ui-components/src/constants';
 
 import { lastRefresh } from '../context/AuthContext';
 
@@ -107,6 +108,13 @@ const fetchWithRetry = async <R>(path: string, init?: RequestInit): Promise<R> =
 
   // Add organization header if available
   const options = addOrganizationHeader({ ...init });
+
+  // Add version header only for FlightCtl API
+  if (api === 'flightctl') {
+    const headers = new Headers(options.headers);
+    headers.set('Flightctl-API-Version', API_VERSION);
+    options.headers = headers;
+  }
 
   const prevRefresh = lastRefresh;
   let response = await fetch(url, options);

--- a/proxy/app.go
+++ b/proxy/app.go
@@ -21,7 +21,7 @@ func corsHandler(router *mux.Router) http.Handler {
 	return gorillaHandlers.CORS(
 		gorillaHandlers.AllowedOrigins([]string{"http://localhost:9000"}),
 		gorillaHandlers.AllowedMethods([]string{"GET", "POST", "PUT", "DELETE", "PATCH"}),
-		gorillaHandlers.AllowedHeaders([]string{"Content-Type", "Authorization", "X-FlightCtl-Organization-ID"}),
+		gorillaHandlers.AllowedHeaders([]string{"Content-Type", "Authorization", "X-FlightCtl-Organization-ID", "Flightctl-API-Version"}),
 		gorillaHandlers.AllowCredentials(),
 	)(router)
 }


### PR DESCRIPTION
* EDM-2984: Allow Flightctl-API-Version header

(cherry picked from commit 1a7373b785f7dba6fd05ac8aca54031d0fa7ff05)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure & Improvements**
  * Added API version header support to HTTP requests across the application to enhance API compatibility and enable improved version management.
  * Updated cross-origin resource sharing (CORS) configuration to support API version headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->