### PR TITLE
EDM-3284: "root" stays the default user for applications

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -407,7 +407,7 @@
   "System integrity protection disabled": "System integrity protection disabled",
   "Prevents this workload from modifying critical host operating system files. We recommend keeping this enabled to maintain system integrity.": "Prevents this workload from modifying critical host operating system files. We recommend keeping this enabled to maintain system integrity.",
   "Rootless user identity": "Rootless user identity",
-  "By default, workloads run as the '{{ runAsUser }}' user. To specify a custom user identity, edit the application configuration via YAML or CLI.": "By default, workloads run as the '{{ runAsUser }}' user. To specify a custom user identity, edit the application configuration via YAML or CLI.",
+  "The recommended user identity is '{{ runAsUser }}'. To specify a custom user identity, edit the application configuration via YAML or CLI.": "The recommended user identity is '{{ runAsUser }}'. To specify a custom user identity, edit the application configuration via YAML or CLI.",
   "Application {{ appNum }}": "Application {{ appNum }}",
   "Application type": "Application type",
   "Select an application type": "Select an application type",

--- a/libs/ui-components/src/components/DetailsPage/Tables/ApplicationsTable.tsx
+++ b/libs/ui-components/src/components/DetailsPage/Tables/ApplicationsTable.tsx
@@ -6,7 +6,7 @@ import { DeviceApplicationStatus } from '@flightctl/types';
 import { useTranslation } from '../../../hooks/useTranslation';
 import ApplicationStatus from '../../Status/ApplicationStatus';
 import { getAppTypeLabel } from '../../../utils/apps';
-import { RUN_AS_DEFAULT_USER } from '../../../types/deviceSpec';
+import { RUN_AS_ROOT_USER } from '../../../types/deviceSpec';
 
 type ApplicationsTableProps = {
   appsStatus: DeviceApplicationStatus[];
@@ -45,7 +45,7 @@ const ApplicationsTable = ({ appsStatus }: ApplicationsTableProps) => {
               <Td dataLabel={t('Type')}>
                 {app.appType ? <Label variant="outline">{getAppTypeLabel(app.appType, t)}</Label> : '-'}
               </Td>
-              <Td dataLabel={t('Run as user')}>{app.runAs || RUN_AS_DEFAULT_USER}</Td>
+              <Td dataLabel={t('Run as user')}>{app.runAs || RUN_AS_ROOT_USER}</Td>
               <Td dataLabel={t('Embedded')}>{app.embedded ? t('Yes') : t('No')}</Td>
             </Tr>
           );

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ApplicationIntegritySettings.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ApplicationIntegritySettings.tsx
@@ -5,7 +5,7 @@ import { Content, FormGroup, FormSection, Switch } from '@patternfly/react-core'
 import { useTranslation } from '../../../../hooks/useTranslation';
 import TextField from '../../../form/TextField';
 import { DefaultHelperText } from '../../../form/FieldHelperText';
-import { RUN_AS_DEFAULT_USER, RUN_AS_ROOT_USER } from '../../../../types/deviceSpec';
+import { RUN_AS_FLIGHTCTL_USER, RUN_AS_ROOT_USER } from '../../../../types/deviceSpec';
 
 type ApplicationIntegritySettingsProps = {
   index: number;
@@ -27,7 +27,7 @@ const ApplicationIntegritySettings = ({ index, isReadOnly }: ApplicationIntegrit
           label={isRootless ? t('System integrity protection enabled') : t('System integrity protection disabled')}
           isChecked={isRootless}
           onChange={async (_, checked) => {
-            await setRunAs(checked ? RUN_AS_DEFAULT_USER : RUN_AS_ROOT_USER);
+            await setRunAs(checked ? RUN_AS_FLIGHTCTL_USER : RUN_AS_ROOT_USER);
           }}
           isDisabled={isReadOnly}
         />
@@ -46,13 +46,13 @@ const ApplicationIntegritySettings = ({ index, isReadOnly }: ApplicationIntegrit
           <TextField
             aria-label={t('Rootless user identity')}
             name={`${appFieldName}.runAs`}
-            value={runAs || RUN_AS_DEFAULT_USER}
+            value={runAs}
             isDisabled
             readOnly
             helperText={t(
-              "By default, workloads run as the '{{ runAsUser }}' user. To specify a custom user identity, edit the application configuration via YAML or CLI.",
+              "The recommended user identity is '{{ runAsUser }}'. To specify a custom user identity, edit the application configuration via YAML or CLI.",
               {
-                runAsUser: RUN_AS_DEFAULT_USER,
+                runAsUser: RUN_AS_FLIGHTCTL_USER,
               },
             )}
           />

--- a/libs/ui-components/src/types/deviceSpec.ts
+++ b/libs/ui-components/src/types/deviceSpec.ts
@@ -17,8 +17,9 @@ import {
 import { FlightCtlLabel } from './extraTypes';
 import { UpdateScheduleMode } from '../utils/time';
 
-export const RUN_AS_DEFAULT_USER = 'flightctl';
+// At the moment the "root" user is the default user when no user is specified.
 export const RUN_AS_ROOT_USER = 'root';
+export const RUN_AS_FLIGHTCTL_USER = 'flightctl';
 
 export enum ConfigType {
   GIT = 'git',


### PR DESCRIPTION
After some discussions, the Backend won't make `flightctl` the default user for the `runAs` field.

So we must treat unset "runAs" values as "root", though we want to promote the user choosing "flightctl" by default when creating new applicatoins, and having the UI explicitly setting the value even when it's the default (root).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Clarified messaging: changed wording to present a recommended user identity rather than a "default" label.
  * Unified user-identity behavior across the app: run-as handling now consistently favors an explicit root recommendation where appropriate.
  * UI text and help copy updated to better guide configuration of application user identities and integrity settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->