### PR TITLE
Update lodash to >= v4.17.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
       ],
       "dependencies": {
         "fast-json-patch": "^3.1.1",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.23",
+        "lodash-es": "^4.17.23"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.24.0",
@@ -11949,15 +11950,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   },
   "dependencies": {
     "fast-json-patch": "^3.1.1",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.23",
+    "lodash-es": "^4.17.23"
   },
   "overrides": {
     "node-forge": "^1.3.2"


### PR DESCRIPTION
Related to https://github.com/flightctl/flightctl-ui/security/dependabot/67 and https://github.com/flightctl/flightctl-ui/security/dependabot/68

`npm list lodash/lodash-es` shows all packages use 4.17.23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated and added core utility library dependencies to their latest stable versions. These updates deliver enhanced security features, improved application performance and responsiveness, better overall reliability and stability, and full compatibility with modern development standards, while maintaining complete backward compatibility with existing code and preserving all functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->