### PR TITLE
EDM-3219: Add missing permissions related to ImageBuilder

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -910,6 +910,7 @@
   "Image builds cannot be edited. Use Retry to create a new image build based on this one.": "Image builds cannot be edited. Use Retry to create a new image build based on this one.",
   "Date": "Date",
   "Build failed. Please retry.": "Build failed. Please retry.",
+  "Build failed.": "Build failed.",
   "View more": "View more",
   "There are no image builds in your environment.": "There are no image builds in your environment.",
   "Generate system images for consistent deployment to edge devices.": "Generate system images for consistent deployment to edge devices.",

--- a/libs/ui-components/src/components/ImageBuilds/ImageBuildDetails/ImageBuildExportsGallery.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/ImageBuildDetails/ImageBuildExportsGallery.tsx
@@ -4,7 +4,9 @@ import { saveAs } from 'file-saver';
 
 import { ExportFormatType, ImageExport } from '@flightctl/types/imagebuilder';
 import { ImageBuildWithExports } from '../../../types/extraTypes';
+import { RESOURCE, VERB } from '../../../types/rbac';
 import { useFetch } from '../../../hooks/useFetch';
+import { usePermissionsContext } from '../../common/PermissionsContext';
 import { getErrorMessage } from '../../../utils/error';
 import { getImageExportResource } from '../CreateImageBuildWizard/utils';
 import { ViewImageBuildExportCard } from '../ImageExportCards';
@@ -30,8 +32,15 @@ const createDownloadLink = (url: string) => {
   document.body.removeChild(link);
 };
 
+const imageBuildExportsPermissions = [
+  { kind: RESOURCE.IMAGE_EXPORT, verb: VERB.CREATE },
+  { kind: RESOURCE.IMAGE_EXPORT_DOWNLOAD, verb: VERB.GET },
+];
+
 const ImageBuildExportsGallery = ({ imageBuild, refetch }: ImageBuildExportsGalleryProps) => {
   const { post, proxyFetch } = useFetch();
+  const { checkPermissions } = usePermissionsContext();
+  const [canCreateExport, canDownload] = checkPermissions(imageBuildExportsPermissions);
   const [error, setError] = React.useState<{
     format: ExportFormatType;
     message: string;
@@ -117,8 +126,8 @@ const ImageBuildExportsGallery = ({ imageBuild, refetch }: ImageBuildExportsGall
             isDownloading={downloadingFormat === format}
             isDisabled={isDisabled}
             onDismissError={() => setError(undefined)}
-            onExportImage={handleExportImage}
-            onDownload={handleDownload}
+            onExportImage={canCreateExport ? handleExportImage : undefined}
+            onDownload={canDownload ? handleDownload : undefined}
           />
         );
       })}

--- a/libs/ui-components/src/components/ImageBuilds/ImageBuildRow.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/ImageBuildRow.tsx
@@ -18,6 +18,7 @@ type ImageBuildRowProps = {
   rowIndex: number;
   onRowSelect: (imageBuild: ImageBuild) => OnSelect;
   isRowSelected: (imageBuild: ImageBuild) => boolean;
+  canCreate: boolean;
   canDelete: boolean;
   onDeleteClick: VoidFunction;
   refetch: VoidFunction;
@@ -29,6 +30,7 @@ const ImageBuildRow = ({
   onRowSelect,
   isRowSelected,
   onDeleteClick,
+  canCreate,
   canDelete,
   refetch,
 }: ImageBuildRowProps) => {
@@ -48,12 +50,14 @@ const ImageBuildRow = ({
     },
   ];
 
-  actions.push({
-    title: buildReason === ImageBuildConditionReason.ImageBuildConditionReasonFailed ? t('Retry') : t('Duplicate'),
-    onClick: () => {
-      navigate({ route: ROUTE.IMAGE_BUILD_EDIT, postfix: imageBuildName });
-    },
-  });
+  if (canCreate) {
+    actions.push({
+      title: buildReason === ImageBuildConditionReason.ImageBuildConditionReasonFailed ? t('Retry') : t('Duplicate'),
+      onClick: () => {
+        navigate({ route: ROUTE.IMAGE_BUILD_EDIT, postfix: imageBuildName });
+      },
+    });
+  }
 
   if (canDelete) {
     actions.push({
@@ -114,17 +118,25 @@ const ImageBuildRow = ({
                           <ExclamationCircleIcon />
                         </Icon>
                       </FlexItem>
-                      <FlexItem>
-                        <Content>{t('Build failed. Please retry.')}</Content>
-                      </FlexItem>
-                      <FlexItem>
-                        <Button
-                          variant="link"
-                          onClick={() => navigate({ route: ROUTE.IMAGE_BUILD_EDIT, postfix: imageBuildName })}
-                        >
-                          {t('Retry')}
-                        </Button>
-                      </FlexItem>
+                      {canCreate ? (
+                        <>
+                          <FlexItem>
+                            <Content>{t('Build failed. Please retry.')}</Content>
+                          </FlexItem>
+                          <FlexItem>
+                            <Button
+                              variant="link"
+                              onClick={() => navigate({ route: ROUTE.IMAGE_BUILD_EDIT, postfix: imageBuildName })}
+                            >
+                              {t('Retry')}
+                            </Button>
+                          </FlexItem>
+                        </>
+                      ) : (
+                        <FlexItem>
+                          <Content>{t('Build failed.')}</Content>
+                        </FlexItem>
+                      )}
                     </Flex>
                   )}
                   <StackItem>

--- a/libs/ui-components/src/components/ImageBuilds/ImageBuildsPage.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/ImageBuildsPage.tsx
@@ -58,18 +58,20 @@ const imageBuildTablePermissions = [
   { kind: RESOURCE.IMAGE_BUILD, verb: VERB.DELETE },
 ];
 
-const ImageBuildsEmptyState = ({ onCreateClick }: { onCreateClick: () => void }) => {
+const ImageBuildsEmptyState = ({ onCreateClick }: { onCreateClick?: VoidFunction }) => {
   const { t } = useTranslation();
   return (
     <ResourceListEmptyState icon={PlusCircleIcon} titleText={t('There are no image builds in your environment.')}>
       <EmptyStateBody>{t('Generate system images for consistent deployment to edge devices.')}</EmptyStateBody>
-      <EmptyStateFooter>
-        <EmptyStateActions>
-          <Button variant="primary" onClick={onCreateClick} icon={<PlusIcon />}>
-            {t('Build new image')}
-          </Button>
-        </EmptyStateActions>
-      </EmptyStateFooter>
+      {onCreateClick && (
+        <EmptyStateFooter>
+          <EmptyStateActions>
+            <Button variant="primary" onClick={onCreateClick} icon={<PlusIcon />}>
+              {t('Build new image')}
+            </Button>
+          </EmptyStateActions>
+        </EmptyStateFooter>
+      )}
     </ResourceListEmptyState>
   );
 };
@@ -138,6 +140,7 @@ const ImageBuildTable = () => {
               key={name}
               imageBuild={imageBuild}
               rowIndex={rowIndex}
+              canCreate={canCreate}
               canDelete={canDelete}
               onDeleteClick={() => {
                 setImageBuildToDeleteId(name);
@@ -150,7 +153,9 @@ const ImageBuildTable = () => {
         })}
       </Table>
       <TablePagination pagination={pagination} isUpdating={isUpdating} />
-      {!isUpdating && imageBuilds.length === 0 && !name && <ImageBuildsEmptyState onCreateClick={handleCreateClick} />}
+      {!isUpdating && imageBuilds.length === 0 && !name && (
+        <ImageBuildsEmptyState onCreateClick={canCreate ? handleCreateClick : undefined} />
+      )}
 
       {imageBuildToDeleteId && (
         <DeleteImageBuildModal

--- a/libs/ui-components/src/types/rbac.ts
+++ b/libs/ui-components/src/types/rbac.ts
@@ -21,4 +21,8 @@ export enum RESOURCE {
   ALERTS = 'alerts',
   AUTH_PROVIDER = 'authproviders',
   IMAGE_BUILD = 'imagebuilds',
+  IMAGE_BUILD_LOG = 'imagebuilds/log',
+  IMAGE_EXPORT = 'imageexports',
+  IMAGE_EXPORT_LOG = 'imageexports/log',
+  IMAGE_EXPORT_DOWNLOAD = 'imageexports/download',
 }


### PR DESCRIPTION
UI was missing some permission checks for actions related to imageBuilder:

- View logs
- Download image exports
- Create image exports
- Create image builds (in EmptyState)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI respects role-based permissions: Logs tab and routing, export/download buttons, retry/duplicate/create actions, and empty-state create button are shown or hidden per user.
  * Export cards and actions adapt to permissions and available exports; labels/descriptions are improved and conditional actions are clearer.

* **Localization**
  * Added English translation for the "Build failed." message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->