### PR TITLE
EDM-3097: Disabled import option has a tooltip

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -708,6 +708,7 @@
   "URL": "URL",
   "Sync status": "Sync status",
   "Last transition": "Last transition",
+  "No Git repositories found": "No Git repositories found",
   "Use an existing Git repository": "Use an existing Git repository",
   "Use a new Git repository": "Use a new Git repository",
   "A resource sync is an automated Gitops method that helps manage your imported fleets by monitoring source repository changes and updating your fleet configuration accordingly.": "A resource sync is an automated Gitops method that helps manage your imported fleets by monitoring source repository changes and updating your fleet configuration accordingly.",

--- a/libs/ui-components/src/components/Fleet/ImportFleetWizard/steps/RepositoryStep.tsx
+++ b/libs/ui-components/src/components/Fleet/ImportFleetWizard/steps/RepositoryStep.tsx
@@ -14,6 +14,7 @@ import FormSelect from '../../../form/FormSelect';
 import FlightCtlForm from '../../../form/FlightCtlForm';
 import { usePermissionsContext } from '../../../common/PermissionsContext';
 import { RESOURCE, VERB } from '../../../../types/rbac';
+import WithTooltip from '../../../common/WithTooltip';
 
 export const repositoryStepId = 'repository';
 
@@ -93,14 +94,16 @@ const RepositoryStep = ({ repositories, hasLoaded }: { repositories: Repository[
         {canCreateRepo && (
           <FormSection>
             <FormGroup isInline>
-              <Radio
-                isChecked={values.useExistingRepo}
-                onChange={() => setFieldValue('useExistingRepo', true, true)}
-                id="existing-repo"
-                name="repo"
-                label={t('Use an existing Git repository')}
-                isDisabled={noRepositoriesExist}
-              />
+              <WithTooltip showTooltip={noRepositoriesExist} content={t('No Git repositories found')}>
+                <Radio
+                  isChecked={values.useExistingRepo}
+                  onChange={() => setFieldValue('useExistingRepo', true, true)}
+                  id="existing-repo"
+                  name="repo"
+                  label={t('Use an existing Git repository')}
+                  isDisabled={noRepositoriesExist}
+                />
+              </WithTooltip>
               <Radio
                 isChecked={!values.useExistingRepo}
                 onChange={() => setFieldValue('useExistingRepo', false, true)}

--- a/libs/ui-components/src/components/Repository/CreateRepository/CreateRepositoryForm.css
+++ b/libs/ui-components/src/components/Repository/CreateRepository/CreateRepositoryForm.css
@@ -3,5 +3,9 @@
 }
 
 .fctl-create-repo__adv-section--nested {
-    margin-left: 1.5rem;
+  margin-left: 1.5rem;
+}
+
+.fctl-create-repo__rs-checkbox {
+  --pf-v6-c-check__input--TranslateY: 0.75rem;
 }

--- a/libs/ui-components/src/components/Repository/CreateRepository/CreateRepositoryForm.tsx
+++ b/libs/ui-components/src/components/Repository/CreateRepository/CreateRepositoryForm.tsx
@@ -402,6 +402,7 @@ const CreateRepositoryFormContent = ({ isEdit, isReadOnly, onClose, children }: 
           {showResourceSyncs && canCreateRS && (
             <Checkbox
               id="use-resource-syncs"
+              className="fctl-create-repo__rs-checkbox"
               label={
                 <LabelWithHelperText
                   label={t('Use resource syncs')}


### PR DESCRIPTION
Added an explanation tooltip when the "Use an existing Git repository" option cannot be selected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltip that displays when no Git repositories are available for selection

* **Style**
  * Updated checkbox component styling for improved visual alignment and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->