### PR TITLE
EDM-3079: Single container apps name is optional

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -770,7 +770,6 @@
   "Image reference is required for this volume type": "Image reference is required for this volume type",
   "Definition source must be image for this type of applications": "Definition source must be image for this type of applications",
   "Application type is required": "Application type is required",
-  "Name is required for single container applications.": "Name is required for single container applications.",
   "Image is required.": "Image is required.",
   "Application image includes invalid characters.": "Application image includes invalid characters.",
   "Host port is required": "Host port is required",

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/deviceSpecUtils.ts
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/deviceSpecUtils.ts
@@ -459,13 +459,15 @@ const toApiHelmApp = (app: HelmAppForm): HelmApplication => {
 
 const toApiContainerApp = (app: SingleContainerAppForm): ContainerApplication => {
   const containerApp: ContainerApplication = {
-    name: app.name,
     image: app.image,
     appType: app.appType,
     runAs: app.runAs || RUN_AS_ROOT_USER,
     envVars: variablesToEnvVars(app.variables || []),
     volumes: formVolumesToApi(app.volumes || [], AppType.AppTypeContainer),
   };
+  if (app.name) {
+    containerApp.name = app.name;
+  }
   if (app.ports.length > 0) {
     containerApp.ports = app.ports.map((p) => `${p.hostPort}:${p.containerPort}`);
   }
@@ -488,11 +490,13 @@ const toApiContainerApp = (app: SingleContainerAppForm): ContainerApplication =>
 
 const toApiComposeApp = (app: ComposeAppForm): ComposeApplication => {
   const formApp: Partial<ComposeApplication> = {
-    name: app.name,
     appType: app.appType,
     envVars: variablesToEnvVars(app.variables || []),
     volumes: formVolumesToApi(app.volumes || [], app.appType),
   };
+  if (app.name) {
+    formApp.name = app.name;
+  }
   if (app.specType === AppSpecType.OCI_IMAGE) {
     (formApp as ImageApplicationProviderSpec).image = app.image;
   } else {

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ApplicationContainerForm.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/steps/ApplicationContainerForm.tsx
@@ -157,7 +157,6 @@ const ApplicationContainerForm = ({ index, isReadOnly }: { index: number; isRead
       <FormGroupWithHelperText
         label={t('Application name')}
         content={t('If not specified, the image name will be used. Application name must be unique.')}
-        isRequired
       >
         <TextField aria-label={t('Application name')} name={`${appFieldName}.name`} isDisabled={isReadOnly} />
       </FormGroupWithHelperText>

--- a/libs/ui-components/src/components/form/validations.ts
+++ b/libs/ui-components/src/components/form/validations.ts
@@ -664,7 +664,7 @@ export const validApplicationsSchema = (t: TFunction) => {
               .oneOf([AppSpecType.OCI_IMAGE])
               .required(t('Definition source must be image for this type of applications')),
             appType: Yup.string().oneOf([AppType.AppTypeContainer]).required(t('Application type is required')),
-            name: validApplicationAndVolumeName(t).required(t('Name is required for single container applications.')),
+            name: validApplicationAndVolumeName(t),
             image: Yup.string()
               .required(t('Image is required.'))
               .matches(APPLICATION_IMAGE_REGEXP, t('Application image includes invalid characters.')),


### PR DESCRIPTION
For Single Container apps, there is an "image" field, and if application name is not specified, the image name is used.


```
bash-5.1# pwd
/etc/containers/systemd/quay.io/flightctl-tests/alpine:v1
bash-5.1# ls -la
total 12
drwxr-xr-x. 3 root root 4096 Feb  9 13:43 .
drwxr-xr-x. 3 root root   23 Feb  9 13:43 ..
drwxr-xr-x. 2 root root   31 Feb  9 13:43 quay_io_flightctl-tests_alpine_v1-260823-.container.d
-rw-r--r--. 1 root root  149 Feb  9 13:43 quay_io_flightctl-tests_alpine_v1-260823-app.container
-rw-r--r--. 1 root root  125 Feb  9 13:43 quay_io_flightctl-tests_alpine_v1-260823-flightctl-quadlet-app.target
```

and

```
bash-5.1# systemctl list-units | grep flightctl
  flightctl-agent.service                                                                  loaded active running   Flight Control management agent
  flightctl-configure-greenboot.service                                                    loaded active exited    Configure greenboot for flightctl-managed rollback
  quay_io_flightctl-tests_alpine_v1-260823-flightctl-quadlet-app.target                    loaded active active    quay_io_flightctl-tests_alpine_v1-260823-flightctl-quadlet-app.target
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * The application name field in the device configuration wizard is no longer marked as required and now displays with simplified formatting.
* **Bug Fixes**
  * Validation updated so single-container apps can be saved without an explicit name; when left empty, the name is omitted from outgoing requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->