### PR TITLE
EDM-3295: Fix imagebuilder in OCP plugin

### DIFF
--- a/apps/ocp-plugin/src/utils/apiCalls.ts
+++ b/apps/ocp-plugin/src/utils/apiCalls.ts
@@ -60,7 +60,7 @@ const getFullApiUrl = (path: string): { api: Api; url: string } => {
     return { api: 'alerts', url: `${alertsAPI}/api/v2/${path}` };
   }
   if (imageBuilderPathRegex.test(path)) {
-    return { api: 'imagebuilder', url: `${uiProxy}/imagebuilder/api/v1/${path}` };
+    return { api: 'imagebuilder', url: `${uiProxy}/api/imagebuilder/api/v1/${path}` };
   }
   return { api: 'flightctl', url: `${flightCtlAPI}/api/v1/${path}` };
 };


### PR DESCRIPTION
The API path for imagebuilder was wrong in the OCP plugin and the UI failed to load.

<img width="2337" height="860" alt="fix-ocp-ib" src="https://github.com/user-attachments/assets/2c1a1f5a-8a41-44fd-9b1c-05f777d00bdd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated routing for image builder requests sent through the UI proxy to ensure they reach the correct API endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->