### PR TITLE
EDM-3315: Fix wrong request to download ImageBuilder API after redirect

### DIFF
--- a/libs/ui-components/src/components/ImageBuilds/ImageBuildDetails/ImageBuildExportsGallery.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/ImageBuildDetails/ImageBuildExportsGallery.tsx
@@ -107,25 +107,21 @@ const ImageBuildExportsGallery = ({ imageBuild, refetch }: ImageBuildExportsGall
     }
   };
   const handleDownload = async (ieName: string, format: ExportFormatType) => {
-    try {
-      const response = await proxyFetch(`imagebuilder/api/v1/imageexports/${ieName}/download`, {
-        method: 'GET',
-        credentials: 'include',
-      });
-      const downloadResult = await getExportDownloadResult(response);
-      if (downloadResult === null) {
-        await showSpinnerBriefly(DOWNLOAD_REDIRECT_DELAY);
-        throw new Error(`Download failed: ${response.status} ${response.statusText}`);
-      }
-      if (downloadResult.type === 'redirect') {
-        createDownloadLink(downloadResult.url);
-        await showSpinnerBriefly(DOWNLOAD_REDIRECT_DELAY);
-      } else {
-        const defaultFilename = `image-export-${ieName}.${format}`;
-        saveAs(downloadResult.blob, downloadResult.filename || defaultFilename);
-      }
-    } catch (err) {
-      throw err;
+    const response = await proxyFetch(`imagebuilder/api/v1/imageexports/${ieName}/download`, {
+      method: 'GET',
+      credentials: 'include',
+    });
+    const downloadResult = await getExportDownloadResult(response);
+    if (downloadResult === null) {
+      await showSpinnerBriefly(DOWNLOAD_REDIRECT_DELAY);
+      throw new Error(`Download failed: ${response.status} ${response.statusText}`);
+    }
+    if (downloadResult.type === 'redirect') {
+      createDownloadLink(downloadResult.url);
+      await showSpinnerBriefly(DOWNLOAD_REDIRECT_DELAY);
+    } else {
+      const defaultFilename = `image-export-${ieName}.${format}`;
+      saveAs(downloadResult.blob, downloadResult.filename || defaultFilename);
     }
   };
 

--- a/libs/ui-components/src/components/ImageBuilds/ImageBuildDetails/ImageBuildExportsGallery.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/ImageBuildDetails/ImageBuildExportsGallery.tsx
@@ -107,22 +107,25 @@ const ImageBuildExportsGallery = ({ imageBuild, refetch }: ImageBuildExportsGall
     }
   };
   const handleDownload = async (ieName: string, format: ExportFormatType) => {
-    const response = await proxyFetch(`imagebuilder/api/v1/imageexports/${ieName}/download`, {
-      method: 'GET',
-      credentials: 'include',
-      redirect: 'manual', // Prevent automatic redirect following to avoid CORS issues
-    });
-
-    const downloadResult = await getExportDownloadResult(response);
-    if (downloadResult === null) {
-      await showSpinnerBriefly(DOWNLOAD_REDIRECT_DELAY);
-      throw new Error(`Download failed: ${response.status} ${response.statusText}`);
-    } else if (downloadResult.type === 'redirect') {
-      createDownloadLink(downloadResult.url);
-      await showSpinnerBriefly(DOWNLOAD_REDIRECT_DELAY);
-    } else {
-      const defaultFilename = `image-export-${ieName}.${format}`;
-      saveAs(downloadResult.blob, downloadResult.filename || defaultFilename);
+    try {
+      const response = await proxyFetch(`imagebuilder/api/v1/imageexports/${ieName}/download`, {
+        method: 'GET',
+        credentials: 'include',
+      });
+      const downloadResult = await getExportDownloadResult(response);
+      if (downloadResult === null) {
+        await showSpinnerBriefly(DOWNLOAD_REDIRECT_DELAY);
+        throw new Error(`Download failed: ${response.status} ${response.statusText}`);
+      }
+      if (downloadResult.type === 'redirect') {
+        createDownloadLink(downloadResult.url);
+        await showSpinnerBriefly(DOWNLOAD_REDIRECT_DELAY);
+      } else {
+        const defaultFilename = `image-export-${ieName}.${format}`;
+        saveAs(downloadResult.blob, downloadResult.filename || defaultFilename);
+      }
+    } catch (err) {
+      throw err;
     }
   };
 

--- a/proxy/bridge/handler.go
+++ b/proxy/bridge/handler.go
@@ -152,6 +152,8 @@ func (t *imagebuilderDownloadRewriteTransport) RoundTrip(req *http.Request) (*ht
 	resp.Status = "200 OK"
 	resp.Header = http.Header{}
 	resp.Header.Set("Content-Type", "application/json")
+	// Prevent caching the redirect URL which may include a time-limited signed URL
+	resp.Header.Set("Cache-Control", "no-store")
 	resp.ContentLength = int64(len(body))
 	resp.Body = io.NopCloser(bytes.NewReader(body))
 	return resp, nil


### PR DESCRIPTION
The flow for downloading an image export image was the following:
1. Request to ImageBuilder API "download" endpoint with "manual" redirect to prevent CORS issues.
2. The response included the "Location" header, but the UI was not able to read it.
3. As a result, it triggered a second request to the same "download" endpoint, but this time it didn't include the `X-FlightCtl-Organization-ID` header, triggering error 428 in the UI proxy.


To fix this, now we use the UI proxy to read the Location header and return the response as a statusCode 200 with the redirect URL in the response body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined download and redirect handling for image build exports to simplify control flow while preserving user-visible behavior.
  * Centralized detection of redirect responses so the UI reliably receives redirect links or blob downloads.

* **Bug Fixes**
  * Improved robustness for edge cases (invalid responses, opaque redirects, missing filenames) to reduce download errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->