### PR TITLE
EDM-3291: Use new constants for API versions

### DIFF
--- a/libs/cypress/support/constants.ts
+++ b/libs/cypress/support/constants.ts
@@ -1,1 +1,3 @@
-export const API_VERSION = 'v1beta1';
+import { ApiVersion } from '@flightctl/types';
+
+export const API_VERSION = ApiVersion.ApiVersionV1beta1;

--- a/libs/types/imagebuilder/index.ts
+++ b/libs/types/imagebuilder/index.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
+export { ApiVersion } from './models/ApiVersion';
 export { BindingType } from './models/BindingType';
 export type { EarlyBinding } from './models/EarlyBinding';
 export { ExportFormatType } from './models/ExportFormatType';

--- a/libs/types/imagebuilder/models/ApiVersion.ts
+++ b/libs/types/imagebuilder/models/ApiVersion.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
+ */
+export enum ApiVersion {
+  ApiVersionV1alpha1 = 'v1alpha1',
+  ApiVersionFlightctlIoV1alpha1 = 'flightctl.io/v1alpha1',
+}

--- a/libs/types/imagebuilder/models/ImageBuild.ts
+++ b/libs/types/imagebuilder/models/ImageBuild.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { ObjectMeta } from '../../models/ObjectMeta';
 import type { ImageBuildSpec } from './ImageBuildSpec';
 import type { ImageBuildStatus } from './ImageBuildStatus';
@@ -10,10 +11,7 @@ import type { ImageExport } from './ImageExport';
  * ImageBuild represents a build request for a container image.
  */
 export type ImageBuild = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/imagebuilder/models/ImageBuildList.ts
+++ b/libs/types/imagebuilder/models/ImageBuildList.ts
@@ -2,16 +2,14 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { ListMeta } from '../../models/ListMeta';
 import type { ImageBuild } from './ImageBuild';
 /**
  * ImageBuildList is a list of ImageBuild resources.
  */
 export type ImageBuildList = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/imagebuilder/models/ImageExport.ts
+++ b/libs/types/imagebuilder/models/ImageExport.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { ObjectMeta } from '../../models/ObjectMeta';
 import type { ImageExportSpec } from './ImageExportSpec';
 import type { ImageExportStatus } from './ImageExportStatus';
@@ -9,10 +10,7 @@ import type { ImageExportStatus } from './ImageExportStatus';
  * ImageExport represents an export request to convert and push images to different formats.
  */
 export type ImageExport = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/imagebuilder/models/ImageExportList.ts
+++ b/libs/types/imagebuilder/models/ImageExportList.ts
@@ -2,16 +2,14 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { ListMeta } from '../../models/ListMeta';
 import type { ImageExport } from './ImageExport';
 /**
  * ImageExportList is a list of ImageExport resources.
  */
 export type ImageExportList = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/imagebuilder/models/Status.ts
+++ b/libs/types/imagebuilder/models/Status.ts
@@ -2,14 +2,12 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 /**
  * Status is a return value for calls that don't return other objects.
  */
 export type Status = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/index.ts
+++ b/libs/types/index.ts
@@ -5,6 +5,7 @@
 
 export type { AapProviderSpec } from './models/AapProviderSpec';
 export type { AbsolutePath } from './models/AbsolutePath';
+export { ApiVersion } from './models/ApiVersion';
 export type { ApplicationContent } from './models/ApplicationContent';
 export type { ApplicationEnvVars } from './models/ApplicationEnvVars';
 export type { ApplicationPort } from './models/ApplicationPort';

--- a/libs/types/models/ApiVersion.ts
+++ b/libs/types/models/ApiVersion.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
+ */
+export enum ApiVersion {
+  ApiVersionV1beta1 = 'v1beta1',
+  ApiVersionFlightctlIoV1beta1 = 'flightctl.io/v1beta1',
+  ApiVersionEmpty = '',
+}

--- a/libs/types/models/AuthConfig.ts
+++ b/libs/types/models/AuthConfig.ts
@@ -2,12 +2,10 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { AuthProvider } from './AuthProvider';
 export type AuthConfig = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * List of all available authentication providers.
    */

--- a/libs/types/models/AuthProvider.ts
+++ b/libs/types/models/AuthProvider.ts
@@ -2,16 +2,14 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { AuthProviderSpec } from './AuthProviderSpec';
 import type { ObjectMeta } from './ObjectMeta';
 /**
  * AuthProvider represents an authentication provider configuration supporting both OIDC and OAuth2.
  */
 export type AuthProvider = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/AuthProviderList.ts
+++ b/libs/types/models/AuthProviderList.ts
@@ -2,16 +2,14 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { AuthProvider } from './AuthProvider';
 import type { ListMeta } from './ListMeta';
 /**
  * AuthProviderList is a list of auth providers.
  */
 export type AuthProviderList = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/CertificateSigningRequest.ts
+++ b/libs/types/models/CertificateSigningRequest.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { CertificateSigningRequestSpec } from './CertificateSigningRequestSpec';
 import type { CertificateSigningRequestStatus } from './CertificateSigningRequestStatus';
 import type { ObjectMeta } from './ObjectMeta';
@@ -9,10 +10,7 @@ import type { ObjectMeta } from './ObjectMeta';
  * CertificateSigningRequest represents a request for a signed certificate from the CA.
  */
 export type CertificateSigningRequest = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/CertificateSigningRequestList.ts
+++ b/libs/types/models/CertificateSigningRequestList.ts
@@ -2,16 +2,14 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { CertificateSigningRequest } from './CertificateSigningRequest';
 import type { ListMeta } from './ListMeta';
 /**
  * CertificateSigningRequestList is a list of CertificateSigningRequest.
  */
 export type CertificateSigningRequestList = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/Device.ts
+++ b/libs/types/models/Device.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { DeviceSpec } from './DeviceSpec';
 import type { DeviceStatus } from './DeviceStatus';
 import type { ObjectMeta } from './ObjectMeta';
@@ -9,10 +10,7 @@ import type { ObjectMeta } from './ObjectMeta';
  * Device represents a physical device.
  */
 export type Device = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/DeviceList.ts
+++ b/libs/types/models/DeviceList.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { Device } from './Device';
 import type { DevicesSummary } from './DevicesSummary';
 import type { ListMeta } from './ListMeta';
@@ -9,10 +10,7 @@ import type { ListMeta } from './ListMeta';
  * DeviceList is a list of Devices.
  */
 export type DeviceList = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/EnrollmentRequest.ts
+++ b/libs/types/models/EnrollmentRequest.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { EnrollmentRequestSpec } from './EnrollmentRequestSpec';
 import type { EnrollmentRequestStatus } from './EnrollmentRequestStatus';
 import type { ObjectMeta } from './ObjectMeta';
@@ -9,10 +10,7 @@ import type { ObjectMeta } from './ObjectMeta';
  * EnrollmentRequest represents a request for approval to enroll a device.
  */
 export type EnrollmentRequest = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/EnrollmentRequestList.ts
+++ b/libs/types/models/EnrollmentRequestList.ts
@@ -2,16 +2,14 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { EnrollmentRequest } from './EnrollmentRequest';
 import type { ListMeta } from './ListMeta';
 /**
  * EnrollmentRequestList is a list of EnrollmentRequest.
  */
 export type EnrollmentRequestList = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/Event.ts
+++ b/libs/types/models/Event.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { EventDetails } from './EventDetails';
 import type { EventSource } from './EventSource';
 import type { ObjectMeta } from './ObjectMeta';
@@ -10,10 +11,7 @@ import type { ObjectReference } from './ObjectReference';
  * Event represents a single event that occurred in the system.
  */
 export type Event = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/EventList.ts
+++ b/libs/types/models/EventList.ts
@@ -2,16 +2,14 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { Event } from './Event';
 import type { ListMeta } from './ListMeta';
 /**
  * EventList is a list of Events.
  */
 export type EventList = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/Fleet.ts
+++ b/libs/types/models/Fleet.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { FleetSpec } from './FleetSpec';
 import type { FleetStatus } from './FleetStatus';
 import type { ObjectMeta } from './ObjectMeta';
@@ -9,10 +10,7 @@ import type { ObjectMeta } from './ObjectMeta';
  * Fleet represents a set of devices.
  */
 export type Fleet = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/FleetList.ts
+++ b/libs/types/models/FleetList.ts
@@ -2,16 +2,14 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { Fleet } from './Fleet';
 import type { ListMeta } from './ListMeta';
 /**
  * FleetList is a list of Fleets.
  */
 export type FleetList = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/Organization.ts
+++ b/libs/types/models/Organization.ts
@@ -2,13 +2,11 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { ObjectMeta } from './ObjectMeta';
 import type { OrganizationSpec } from './OrganizationSpec';
 export type Organization = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/OrganizationList.ts
+++ b/libs/types/models/OrganizationList.ts
@@ -2,16 +2,14 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { ListMeta } from './ListMeta';
 import type { Organization } from './Organization';
 /**
  * OrganizationList is a list of Organizations.
  */
 export type OrganizationList = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/Repository.ts
+++ b/libs/types/models/Repository.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { ObjectMeta } from './ObjectMeta';
 import type { RepositorySpec } from './RepositorySpec';
 import type { RepositoryStatus } from './RepositoryStatus';
@@ -9,10 +10,7 @@ import type { RepositoryStatus } from './RepositoryStatus';
  * Repository represents a Git repository or an HTTP endpoint.
  */
 export type Repository = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/RepositoryList.ts
+++ b/libs/types/models/RepositoryList.ts
@@ -2,16 +2,14 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { ListMeta } from './ListMeta';
 import type { Repository } from './Repository';
 /**
  * RepositoryList is a list of Repositories.
  */
 export type RepositoryList = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/ResourceSync.ts
+++ b/libs/types/models/ResourceSync.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { ObjectMeta } from './ObjectMeta';
 import type { ResourceSyncSpec } from './ResourceSyncSpec';
 import type { ResourceSyncStatus } from './ResourceSyncStatus';
@@ -9,10 +10,7 @@ import type { ResourceSyncStatus } from './ResourceSyncStatus';
  * ResourceSync represents a reference to one or more files in a repository to sync to resource definitions.
  */
 export type ResourceSync = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/ResourceSyncList.ts
+++ b/libs/types/models/ResourceSyncList.ts
@@ -2,13 +2,11 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { ListMeta } from './ListMeta';
 import type { ResourceSync } from './ResourceSync';
 export type ResourceSyncList = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/Status.ts
+++ b/libs/types/models/Status.ts
@@ -2,14 +2,12 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 /**
  * Status is a return value for calls that don't return other objects.
  */
 export type Status = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/TemplateVersion.ts
+++ b/libs/types/models/TemplateVersion.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { ObjectMeta } from './ObjectMeta';
 import type { TemplateVersionSpec } from './TemplateVersionSpec';
 import type { TemplateVersionStatus } from './TemplateVersionStatus';
@@ -9,10 +10,7 @@ import type { TemplateVersionStatus } from './TemplateVersionStatus';
  * TemplateVersion represents a version of a template.
  */
 export type TemplateVersion = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/types/models/TemplateVersionList.ts
+++ b/libs/types/models/TemplateVersionList.ts
@@ -2,16 +2,14 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { ApiVersion } from './ApiVersion';
 import type { ListMeta } from './ListMeta';
 import type { TemplateVersion } from './TemplateVersion';
 /**
  * TemplateVersionList is a list of TemplateVersions.
  */
 export type TemplateVersionList = {
-  /**
-   * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources.
-   */
-  apiVersion: string;
+  apiVersion: ApiVersion;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds.
    */

--- a/libs/ui-components/src/components/AuthProvider/CreateAuthProvider/utils.ts
+++ b/libs/ui-components/src/components/AuthProvider/CreateAuthProvider/utils.ts
@@ -1,6 +1,7 @@
 import * as Yup from 'yup';
 import { TFunction } from 'i18next';
 import {
+  ApiVersion,
   AuthDynamicRoleAssignment,
   AuthOrganizationAssignment,
   AuthProvider,
@@ -25,7 +26,6 @@ import {
 } from './types';
 import { validKubernetesDnsSubdomain } from '../../form/validations';
 import { DynamicAuthProviderSpec, ProviderType } from '../../../types/extraTypes';
-import { CORE_API_VERSION } from '../../../constants';
 
 export const getAssignmentTypeLabel = (
   type: AuthOrganizationAssignment['type'] | AuthRoleAssignment['type'] | undefined,
@@ -317,7 +317,7 @@ export const getAuthProvider = (values: AuthProviderFormValues): AuthProvider =>
   }
 
   return {
-    apiVersion: CORE_API_VERSION,
+    apiVersion: ApiVersion.ApiVersionV1beta1,
     kind: 'AuthProvider',
     metadata: {
       name: values.name,

--- a/libs/ui-components/src/components/Fleet/CreateFleet/utils.ts
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/utils.ts
@@ -1,7 +1,6 @@
-import { Fleet, PatchRequest } from '@flightctl/types';
 import { TFunction } from 'i18next';
 import * as Yup from 'yup';
-import { CORE_API_VERSION } from '../../../constants';
+import { ApiVersion, Fleet, PatchRequest } from '@flightctl/types';
 import { toAPILabel } from '../../../utils/labels';
 import {
   systemdUnitListValidationSchema,
@@ -178,7 +177,7 @@ export const getFleetResource = (values: FleetFormValues): Fleet => {
           },
         };
   const fleet: Fleet = {
-    apiVersion: CORE_API_VERSION,
+    apiVersion: ApiVersion.ApiVersionV1beta1,
     kind: 'Fleet',
     metadata: {
       name: values.name,

--- a/libs/ui-components/src/components/ImageBuilds/CreateImageBuildWizard/utils.ts
+++ b/libs/ui-components/src/components/ImageBuilds/CreateImageBuildWizard/utils.ts
@@ -2,6 +2,7 @@ import { TFunction } from 'i18next';
 import * as Yup from 'yup';
 
 import {
+  ApiVersion,
   BindingType,
   ExportFormatType,
   ImageBuild,
@@ -10,7 +11,6 @@ import {
   ImageExport,
   ResourceKind,
 } from '@flightctl/types/imagebuilder';
-import { IMAGEBUILDER_API_VERSION } from '../../../constants';
 import { ImageBuildFormValues } from './types';
 import { ImageBuildWithExports } from '../../../types/extraTypes';
 
@@ -162,7 +162,7 @@ export const getImageBuildResource = (values: ImageBuildFormValues): ImageBuild 
   }
 
   return {
-    apiVersion: IMAGEBUILDER_API_VERSION,
+    apiVersion: ApiVersion.ApiVersionV1alpha1,
     kind: ResourceKind.IMAGE_BUILD,
     metadata: {
       name,
@@ -175,7 +175,7 @@ export const getImageExportResource = (imageBuildName: string, format: ExportFor
   const exportName = generateExportName(imageBuildName, format);
 
   return {
-    apiVersion: IMAGEBUILDER_API_VERSION,
+    apiVersion: ApiVersion.ApiVersionV1alpha1,
     kind: ResourceKind.IMAGE_EXPORT,
     metadata: {
       name: exportName,

--- a/libs/ui-components/src/components/Repository/CreateRepository/utils.ts
+++ b/libs/ui-components/src/components/Repository/CreateRepository/utils.ts
@@ -1,6 +1,7 @@
 import * as Yup from 'yup';
 import { TFunction } from 'i18next';
 import {
+  ApiVersion,
   DockerAuth,
   GitRepoSpec,
   HttpConfig,
@@ -16,7 +17,6 @@ import {
 } from '@flightctl/types';
 
 import { RepositoryFormValues, ResourceSyncFormValue } from './types';
-import { CORE_API_VERSION } from '../../../constants';
 import { getErrorMessage } from '../../../utils/error';
 import { appendJSONPatch } from '../../../utils/patch';
 import { MAX_TARGET_REVISION_LENGTH, maxLengthString, validKubernetesDnsSubdomain } from '../../form/validations';
@@ -779,7 +779,7 @@ export const getRepository = (values: Omit<RepositoryFormValues, 'useResourceSyn
     }
 
     return {
-      apiVersion: CORE_API_VERSION,
+      apiVersion: ApiVersion.ApiVersionV1beta1,
       kind: 'Repository',
       metadata: {
         name: values.name,
@@ -877,7 +877,7 @@ export const getRepository = (values: Omit<RepositoryFormValues, 'useResourceSyn
   }
 
   return {
-    apiVersion: CORE_API_VERSION,
+    apiVersion: ApiVersion.ApiVersionV1beta1,
     kind: 'Repository',
     metadata: {
       name: values.name,
@@ -888,7 +888,7 @@ export const getRepository = (values: Omit<RepositoryFormValues, 'useResourceSyn
 
 export const getResourceSync = (repositoryId: string, values: ResourceSyncFormValue): ResourceSync => {
   return {
-    apiVersion: CORE_API_VERSION,
+    apiVersion: ApiVersion.ApiVersionV1beta1,
     kind: 'ResourceSync',
     metadata: {
       name: values.name,

--- a/libs/ui-components/src/constants.ts
+++ b/libs/ui-components/src/constants.ts
@@ -1,7 +1,7 @@
-export const APP_TITLE = 'Edge Manager';
-export const CORE_API_VERSION = 'v1beta1';
-export const IMAGEBUILDER_API_VERSION = 'v1alpha1';
+import { ApiVersion } from '@flightctl/types';
+import { ApiVersion as ImageBuilderApiVersion } from '@flightctl/types/imagebuilder';
 
+export const APP_TITLE = 'Edge Manager';
 export const PAGE_SIZE = 15;
 export const EVENT_PAGE_SIZE = 200; // It's 500 in OCP console
 
@@ -10,9 +10,9 @@ export const CERTIFICATE_VALIDITY_IN_YEARS = 1;
 export const getApiVersion = (api: 'flightctl' | 'imagebuilder' | 'alerts'): string | undefined => {
   switch (api) {
     case 'flightctl':
-      return CORE_API_VERSION;
+      return ApiVersion.ApiVersionV1beta1;
     case 'imagebuilder':
-      return IMAGEBUILDER_API_VERSION;
+      return ImageBuilderApiVersion.ApiVersionV1alpha1;
     case 'alerts':
     default:
       return undefined;

--- a/libs/ui-components/src/utils/search.ts
+++ b/libs/ui-components/src/utils/search.ts
@@ -1,5 +1,5 @@
 import fuzzy from 'fuzzysearch';
-import { CORE_API_VERSION } from '../constants';
+import { ApiVersion } from '@flightctl/types';
 
 // Must be an even number for "getSearchResultsCount" to work
 export const MAX_TOTAL_SEARCH_RESULTS = 10;
@@ -26,7 +26,7 @@ export const getSearchResultsCount = (labelCount: number, fleetCount: number) =>
 };
 
 export const getEmptyFleetSearch = () => ({
-  apiVersion: CORE_API_VERSION,
+  apiVersion: ApiVersion.ApiVersionV1beta1,
   kind: 'Fleet',
   metadata: {},
   items: [],


### PR DESCRIPTION
`npm run gen-types` is now broken due to there being an empty ApiVersion without a name.

I created https://github.com/flightctl/flightctl/pull/2492 that adds names to each version, and now the UI can reference the types versions rather than having them hardcoded.

Backend PR was already merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for API version handling by standardizing version management throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->