### PR TITLE
EDM-3329: Pre-select log entity from URL

### DIFF
--- a/libs/ui-components/src/components/ImageBuilds/ImageBuildDetails/ImageBuildExportsGallery.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/ImageBuildDetails/ImageBuildExportsGallery.tsx
@@ -16,6 +16,7 @@ import { showSpinnerBriefly } from '../../../utils/time';
 import { getAllExportFormats, getExportDownloadResult, getImageReference } from '../../../utils/imageBuilds';
 import { useAppContext } from '../../../hooks/useAppContext';
 import { ROUTE } from '../../../hooks/useNavigate';
+import { IMAGE_EXPORT_ID_PARAM } from './ImageBuildLogsTab';
 
 type ImageBuildExportsGalleryProps = {
   imageBuild: ImageBuildWithExports;
@@ -102,11 +103,6 @@ const ImageBuildExportsGallery = ({ imageBuild, refetch }: ImageBuildExportsGall
   >();
   const imageBuildId = imageBuild.metadata.name as string;
 
-  const handleViewLogs = () => {
-    const baseRoute = appRoutes[ROUTE.IMAGE_BUILD_DETAILS];
-    routerNavigate(`${baseRoute}/${imageBuildId}/logs`);
-  };
-
   const handleCreateNewExport = async (format: ExportFormatType) => {
     try {
       const imageExport = getImageExportResource(imageBuildId, format);
@@ -178,7 +174,9 @@ const ImageBuildExportsGallery = ({ imageBuild, refetch }: ImageBuildExportsGall
           await handleDelete(ieName);
           break;
         case 'viewLogs':
-          handleViewLogs();
+          routerNavigate(
+            `${appRoutes[ROUTE.IMAGE_BUILD_DETAILS]}/${imageBuildId}/logs?${IMAGE_EXPORT_ID_PARAM}=${ieName}`,
+          );
           break;
       }
     } catch (error) {

--- a/libs/ui-components/src/components/ImageBuilds/ImageBuildDetails/ImageBuildExportsGallery.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/ImageBuildDetails/ImageBuildExportsGallery.tsx
@@ -14,8 +14,7 @@ import { ImageExportAction, ViewImageBuildExportCard } from '../ImageExportCards
 import { useOciRegistriesContext } from '../OciRegistriesContext';
 import { showSpinnerBriefly } from '../../../utils/time';
 import { getAllExportFormats, getExportDownloadResult, getImageReference } from '../../../utils/imageBuilds';
-import { useAppContext } from '../../../hooks/useAppContext';
-import { ROUTE } from '../../../hooks/useNavigate';
+import { ROUTE, useNavigate } from '../../../hooks/useNavigate';
 import { IMAGE_EXPORT_ID_PARAM } from './ImageBuildLogsTab';
 
 type ImageBuildExportsGalleryProps = {
@@ -87,10 +86,7 @@ const ImageBuildExportsGallery = ({ imageBuild, refetch }: ImageBuildExportsGall
     return actions;
   }, [buildReason, canCreateExport, canDelete, canViewLogs, canDownload, canCancel]);
 
-  const {
-    router: { useNavigate: useRouterNavigate, appRoutes },
-  } = useAppContext();
-  const routerNavigate = useRouterNavigate();
+  const navigate = useNavigate();
   const [error, setError] = React.useState<{
     format: ExportFormatType;
     action: ImageExportAction;
@@ -173,11 +169,13 @@ const ImageBuildExportsGallery = ({ imageBuild, refetch }: ImageBuildExportsGall
         case 'delete':
           await handleDelete(ieName);
           break;
-        case 'viewLogs':
-          routerNavigate(
-            `${appRoutes[ROUTE.IMAGE_BUILD_DETAILS]}/${imageBuildId}/logs?${IMAGE_EXPORT_ID_PARAM}=${ieName}`,
-          );
+        case 'viewLogs': {
+          const searchParams = new URLSearchParams({
+            [IMAGE_EXPORT_ID_PARAM]: ieName,
+          });
+          navigate({ route: ROUTE.IMAGE_BUILD_DETAILS, postfix: `${imageBuildId}/logs?${searchParams.toString()}` });
           break;
+        }
       }
     } catch (error) {
       setError({ format, message: getErrorMessage(error), action });


### PR DESCRIPTION
Now, when clicking on "view logs" for an image export, the UI will select to view the logs of that entity without the user having to select it manually first.

https://github.com/user-attachments/assets/0af1dc86-6ebe-4ec5-aaba-0db2d9d5aacc



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-select image export logs via URL parameters for direct linking/bookmarking of specific exports.
  * Viewing logs preserves the selected export in the URL for reliable sharing and navigation.
  * "View logs" from the gallery opens the details view with the corresponding export pre-selected (falls back to the build name when needed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->