### PR TITLE
EDM-3371: Skip repositories that no longer exist

### DIFF
--- a/libs/ui-components/src/components/ImageBuilds/CreateImageBuildWizard/CreateImageBuildWizard.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/CreateImageBuildWizard/CreateImageBuildWizard.tsx
@@ -70,10 +70,15 @@ const CreateImageBuildWizard = () => {
   const [error, setError] = React.useState<ImageBuildWizardError>();
   const [currentStep, setCurrentStep] = React.useState<WizardStepType>();
   const [imageBuildId, imageBuild, imageBuildLoading, editError] = useEditImageBuild();
-  const { isLoading: registriesLoading, error: registriesError } = useOciRegistriesContext();
+  const { ociRegistries, isLoading: registriesLoading, error: registriesError } = useOciRegistriesContext();
 
   const isEdit = !!imageBuildId;
   const buildReason = imageBuild ? getImageBuildStatusReason(imageBuild) : undefined;
+
+  const availableRepositoryIds = React.useMemo(
+    () => new Set(ociRegistries.map((r) => r.metadata?.name as string)),
+    [ociRegistries],
+  );
 
   let title: string;
   if (isEdit) {
@@ -117,7 +122,7 @@ const CreateImageBuildWizard = () => {
             </Alert>
           ) : (
             <Formik<ImageBuildFormValues>
-              initialValues={getInitialValues(imageBuild)}
+              initialValues={getInitialValues(imageBuild, availableRepositoryIds)}
               validationSchema={getValidationSchema(t)}
               validateOnMount
               onSubmit={async (values) => {


### PR DESCRIPTION
When copying/retrying an image build, if either repository has been removed since the original Image Build was created, we must ignore it. This forces the user to having to select them from the list of available repositories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repository selections in the image build wizard are now validated against available registries; unavailable selections are auto-cleared to prevent invalid submissions.
  * Form initialization better preserves user configuration and includes sensible default configuration fields when starting a new build, ensuring settings are retained or properly reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->