### PR TITLE
EDM-3361/EDM-3370: Do not show download for qcow2 container exports

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -830,7 +830,7 @@
   "Failed to cancel image build": "Failed to cancel image build",
   "Cancel image build": "Cancel image build",
   "Cancel image export?": "Cancel image export?",
-  "This will immediately stop the current process. As a result, no images will be exported.": "This will immediately stop the current process. As a result, no images will be exported.",
+  "This will immediately stop the current process. As a result, the image will not be exported in this format.": "This will immediately stop the current process. As a result, the image will not be exported in this format.",
   "Cancel image export": "Cancel image export",
   "Delete image export?": "Delete image export?",
   "This image export will be permanently removed. The actual image files in your storage will not be deleted.": "This image export will be permanently removed. The actual image files in your storage will not be deleted.",

--- a/libs/ui-components/src/components/ImageBuilds/ConfirmImageExportModal/ConfirmImageExportModal.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/ConfirmImageExportModal/ConfirmImageExportModal.tsx
@@ -21,7 +21,9 @@ const ConfirmImageExportActionModal = ({
   switch (action) {
     case 'cancel':
       title = t('Cancel image export?');
-      message = t('This will immediately stop the current process. As a result, no images will be exported.');
+      message = t(
+        'This will immediately stop the current process. As a result, the image will not be exported in this format.',
+      );
       confirmButtonTitle = t('Cancel image export');
       break;
     case 'delete':

--- a/libs/ui-components/src/components/ImageBuilds/ImageExportCards.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/ImageExportCards.tsx
@@ -43,6 +43,7 @@ import './ImageExportCards.css';
 export type ImageExportAction = 'cancel' | 'delete' | 'viewLogs' | 'download' | 'retry' | 'rebuild' | 'createExport';
 
 const getActionsForStatus = (
+  format: ExportFormatType,
   exportReason: ImageExportConditionReason | undefined,
   actionPermissions: ImageExportAction[],
 ): ImageExportAction[] => {
@@ -56,7 +57,10 @@ const getActionsForStatus = (
       actions.push('cancel', 'viewLogs');
       break;
     case ImageExportConditionReason.ImageExportConditionReasonCompleted:
-      actions.push('download', 'viewLogs', 'delete', 'rebuild');
+      if (format !== ExportFormatType.ExportFormatTypeQCOW2DiskContainer) {
+        actions.push('download');
+      }
+      actions.push('viewLogs', 'delete', 'rebuild');
       break;
     case ImageExportConditionReason.ImageExportConditionReasonFailed:
     case ImageExportConditionReason.ImageExportConditionReasonCanceled:
@@ -197,11 +201,11 @@ export const ViewImageBuildExportCard = ({
   };
 
   const { primaryAction, remainingActions } = React.useMemo(() => {
-    const allActions = getActionsForStatus(exportReason, actionPermissions);
+    const allActions = getActionsForStatus(format, exportReason, actionPermissions);
     const primaryAction = allActions.length > 0 ? allActions[0] : undefined;
     const remainingActions = allActions.length > 1 ? allActions.slice(1) : [];
     return { primaryAction, remainingActions };
-  }, [exportReason, actionPermissions]);
+  }, [format, exportReason, actionPermissions]);
 
   const renderActionButton = (exportAction: ImageExportAction, variant: 'primary' | 'secondary' = 'secondary') => {
     const isDisabled = activeAction !== undefined;


### PR DESCRIPTION
Restrict actions for image exports
- Qcow2 container: can't download (OCI artifact is used from OpenShift virtualization / KubeVirt)
- Image exports of failed/canceled/canceling image builds: can only delete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined messaging when canceling image exports to clarify format-specific behavior
  * Limited available actions based on image build status (failed, canceled, or canceling states now restrict to delete-only operations)
  * Adjusted download availability for certain export formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->