### PR TITLE
EDM-3368: Force creating writable repository

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -1131,6 +1131,7 @@
   "Read only": "Read only",
   "Read and write": "Read and write",
   "Use advanced configurations": "Use advanced configurations",
+  "Access mode must be set to read and write for this repository type": "Access mode must be set to read and write for this repository type",
   "Use resource syncs": "Use resource syncs",
   "Repository could not be saved": "Repository could not be saved",
   "Resource sync name": "Resource sync name",

--- a/libs/ui-components/src/components/ImageBuilds/CreateImageBuildWizard/steps/OutputImageStep.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/CreateImageBuildWizard/steps/OutputImageStep.tsx
@@ -77,6 +77,9 @@ const OutputImageStep = () => {
             repoRefetch={refetch}
             label={t('Target repository')}
             isRequired
+            options={{
+              writeAccessOnly: true,
+            }}
             validateRepoSelection={writableRepoValidation}
             helperText={t('Storage repository for your completed image.')}
           />

--- a/libs/ui-components/src/components/Repository/CreateRepository/CreateRepositoryForm.tsx
+++ b/libs/ui-components/src/components/Repository/CreateRepository/CreateRepositoryForm.tsx
@@ -5,6 +5,8 @@ import {
   Button,
   ButtonVariant,
   Checkbox,
+  Flex,
+  FlexItem,
   FormGroup,
   FormSection,
   Grid,
@@ -46,6 +48,7 @@ import TextField from '../../form/TextField';
 import FlightCtlForm from '../../form/FlightCtlForm';
 import { getDnsSubdomainValidations } from '../../form/validations';
 import { DEMO_REPOSITORY_URL } from '../../../hooks/useAppLinks';
+import WithTooltip from '../../common/WithTooltip';
 import { usePermissionsContext } from '../../common/PermissionsContext';
 import { RESOURCE, VERB } from '../../../types/rbac';
 
@@ -296,10 +299,17 @@ const RepositoryType = ({ isEdit }: { isEdit?: boolean }) => {
   );
 };
 
-export const RepositoryForm = ({ isEdit }: { isEdit?: boolean }) => {
+export const RepositoryForm = ({
+  isEdit,
+  accessModeDisabledReason,
+}: {
+  isEdit?: boolean;
+  accessModeDisabledReason?: string;
+}) => {
   const { t } = useTranslation();
   const { values } = useFormikContext<RepositoryFormValues>();
   const isOciRepo = values.repoType === RepoSpecType.RepoSpecTypeOci;
+  const isAccessModeDisabled = Boolean(accessModeDisabledReason);
 
   return (
     <>
@@ -353,24 +363,28 @@ export const RepositoryForm = ({ isEdit }: { isEdit?: boolean }) => {
             </Split>
           </FormGroup>
           <FormGroup label={t('Access mode')}>
-            <Split hasGutter>
-              <SplitItem>
-                <RadioField
-                  id="oci-access-read"
-                  name="ociConfig.accessMode"
-                  label={t('Read only')}
-                  checkedValue={OciRepoSpec.accessMode.READ}
-                />
-              </SplitItem>
-              <SplitItem>
-                <RadioField
-                  id="oci-access-readwrite"
-                  name="ociConfig.accessMode"
-                  label={t('Read and write')}
-                  checkedValue={OciRepoSpec.accessMode.READ_WRITE}
-                />
-              </SplitItem>
-            </Split>
+            <WithTooltip showTooltip={isAccessModeDisabled} content={accessModeDisabledReason}>
+              <Flex>
+                <FlexItem>
+                  <RadioField
+                    id="oci-access-read"
+                    name="ociConfig.accessMode"
+                    label={t('Read only')}
+                    checkedValue={OciRepoSpec.accessMode.READ}
+                    isDisabled={isAccessModeDisabled}
+                  />
+                </FlexItem>
+                <FlexItem>
+                  <RadioField
+                    id="oci-access-readwrite"
+                    name="ociConfig.accessMode"
+                    label={t('Read and write')}
+                    checkedValue={OciRepoSpec.accessMode.READ_WRITE}
+                    isDisabled={isAccessModeDisabled}
+                  />
+                </FlexItem>
+              </Flex>
+            </WithTooltip>
           </FormGroup>
         </FormSection>
       )}
@@ -380,12 +394,11 @@ export const RepositoryForm = ({ isEdit }: { isEdit?: boolean }) => {
 };
 
 type CreateRepositoryFormContentProps = React.PropsWithChildren &
-  Pick<CreateRepositoryFormProps, 'onClose'> & {
+  Pick<CreateRepositoryFormProps, 'onClose' | 'options'> & {
     isEdit: boolean;
-    isReadOnly: boolean;
   };
 
-const CreateRepositoryFormContent = ({ isEdit, isReadOnly, onClose, children }: CreateRepositoryFormContentProps) => {
+const CreateRepositoryFormContent = ({ isEdit, onClose, options, children }: CreateRepositoryFormContentProps) => {
   const { t } = useTranslation();
   const { values, setFieldValue, isValid, dirty, submitForm, isSubmitting } = useFormikContext<RepositoryFormValues>();
   const isSubmitDisabled = isSubmitting || !dirty || !isValid;
@@ -396,9 +409,16 @@ const CreateRepositoryFormContent = ({ isEdit, isReadOnly, onClose, children }: 
   const showResourceSyncs = values.canUseResourceSyncs && values.repoType === RepoSpecType.RepoSpecTypeGit;
   return (
     <FlightCtlForm className="fctl-create-repo">
-      <fieldset disabled={isReadOnly}>
+      <fieldset disabled={options?.isReadOnly ?? false}>
         <Grid hasGutter span={8}>
-          <RepositoryForm isEdit={isEdit} />
+          <RepositoryForm
+            isEdit={isEdit}
+            accessModeDisabledReason={
+              options?.writeAccessOnly
+                ? t('Access mode must be set to read and write for this repository type')
+                : undefined
+            }
+          />
           {showResourceSyncs && canCreateRS && (
             <Checkbox
               id="use-resource-syncs"
@@ -439,20 +459,18 @@ export type CreateRepositoryFormProps = {
   onSuccess: (repository: Repository) => void;
   repository?: Repository;
   resourceSyncs?: ResourceSync[];
-  // If provided, the repository submission will be blocked if the validation fails
-  validateBefore?: (repo: Repository) => string | undefined;
   options?: {
     isReadOnly?: boolean;
     canUseResourceSyncs?: boolean;
     showRepoTypes?: boolean;
     allowedRepoTypes?: RepoSpecType[];
+    writeAccessOnly?: boolean;
   };
 };
 
 const CreateRepositoryForm = ({
   repository,
   resourceSyncs,
-  validateBefore,
   options,
   onClose,
   onSuccess,
@@ -517,11 +535,6 @@ const CreateRepositoryForm = ({
           }
         } else {
           const repoToCreate = getRepository(values);
-          const validationError = validateBefore?.(repoToCreate);
-          if (validationError) {
-            setErrors([validationError]);
-            return;
-          }
           try {
             const repo = await post<Repository>('repositories', repoToCreate);
             if (values.useResourceSyncs) {
@@ -541,7 +554,7 @@ const CreateRepositoryForm = ({
         }
       }}
     >
-      <CreateRepositoryFormContent isEdit={!!repository} onClose={onClose} isReadOnly={!!options?.isReadOnly}>
+      <CreateRepositoryFormContent isEdit={!!repository} onClose={onClose} options={options}>
         {errors?.length && (
           <Alert isInline variant="danger" title={t('Repository could not be saved')}>
             {errors.map((e, index) => (

--- a/libs/ui-components/src/components/Repository/CreateRepository/utils.ts
+++ b/libs/ui-components/src/components/Repository/CreateRepository/utils.ts
@@ -468,6 +468,7 @@ export const getInitValues = ({
     canUseResourceSyncs?: boolean;
     allowedRepoTypes?: RepoSpecType[];
     showRepoTypes?: boolean;
+    writeAccessOnly?: boolean;
   };
 }): RepositoryFormValues => {
   const configAllowsResourceSyncs = options?.canUseResourceSyncs ?? true;
@@ -501,7 +502,7 @@ export const getInitValues = ({
       initValues.ociConfig = {
         registry: '',
         scheme: OciRepoSpec.scheme.HTTPS,
-        accessMode: OciRepoSpec.accessMode.READ,
+        accessMode: options?.writeAccessOnly ? OciRepoSpec.accessMode.READ_WRITE : OciRepoSpec.accessMode.READ,
       };
     }
 

--- a/libs/ui-components/src/components/form/RepositorySelect.tsx
+++ b/libs/ui-components/src/components/form/RepositorySelect.tsx
@@ -116,6 +116,9 @@ type RepositorySelectProps = {
   canCreateRepo: boolean;
   isReadOnly?: boolean;
   repoRefetch?: VoidFunction;
+  options?: {
+    writeAccessOnly?: boolean;
+  };
   isRequired?: boolean;
   validateRepoSelection?: (repo: Repository) => string | undefined;
 };
@@ -148,6 +151,7 @@ const RepositorySelect = ({
   repoRefetch,
   label,
   helperText,
+  options,
   isRequired,
   validateRepoSelection,
 }: RepositorySelectProps) => {
@@ -214,7 +218,7 @@ const RepositorySelect = ({
           type={repoType}
           onClose={() => setCreateRepoModalOpen(false)}
           onSuccess={handleCreateRepository}
-          validateBeforeCreate={validateRepoSelection}
+          options={options}
         />
       )}
     </>

--- a/libs/ui-components/src/components/modals/CreateRepositoryModal/CreateRepositoryModal.tsx
+++ b/libs/ui-components/src/components/modals/CreateRepositoryModal/CreateRepositoryModal.tsx
@@ -9,10 +9,12 @@ type CreateRepositoryModalProps = {
   type: RepoSpecType;
   onClose: VoidFunction;
   onSuccess: (repository: Repository) => void;
-  validateBeforeCreate?: (repo: Repository) => string | undefined;
+  options?: {
+    writeAccessOnly?: boolean;
+  };
 };
 
-const CreateRepositoryModal = ({ type, onClose, onSuccess, validateBeforeCreate }: CreateRepositoryModalProps) => {
+const CreateRepositoryModal = ({ type, onClose, onSuccess, options }: CreateRepositoryModalProps) => {
   const { t } = useTranslation();
   return (
     <Modal variant="medium" isOpen>
@@ -21,10 +23,10 @@ const CreateRepositoryModal = ({ type, onClose, onSuccess, validateBeforeCreate 
         <CreateRepositoryForm
           onClose={onClose}
           onSuccess={onSuccess}
-          validateBefore={validateBeforeCreate}
           options={{
             canUseResourceSyncs: false,
             allowedRepoTypes: [type],
+            writeAccessOnly: options?.writeAccessOnly,
           }}
         />
       </ModalBody>


### PR DESCRIPTION
The solution in https://github.com/flightctl/flightctl-ui/pull/511 was not accepted, so we need to actually disable the option to create repositories in access mode other than read-and-write for the output image step of Image builds.


<img width="1185" height="866" alt="msg" src="https://github.com/user-attachments/assets/1fc76119-254b-4d74-b3ff-52d3c9ac2792" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repository selection for image build destinations is now restricted to write-access repositories, improving deployment guidance.
  * Repository creation forms now display explanatory tooltips when access mode selection is unavailable, clarifying access requirements.
  * Enhanced messaging around read and write access mode validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->