### PR TITLE
EDM-3408: Use exec form for CMD primitives

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -30,4 +30,4 @@ LABEL \
   name="flightctl-ui" \
   summary="Flight Control User Interface Service"
 EXPOSE 8080
-CMD ./flightctl-ui
+CMD ["./flightctl-ui"]

--- a/Containerfile.ocp
+++ b/Containerfile.ocp
@@ -30,4 +30,4 @@ LABEL \
   name="flightctl-ui-ocp" \
   summary="Flight Control User Interface Service for OCP Integration"
 EXPOSE 8080
-CMD ./flightctl-ui
+CMD ["./flightctl-ui"]


### PR DESCRIPTION
This PR fixes the problem that the Containerfiles run the application using the Shell Form of the CMD primitive (e.g. `CMD ./application`) instead of the Exec Form (`CMD ["./application"]`).

With Shell Form, `/bin/sh` runs as PID 1, not the application. This breaks graceful shutdown as it's the shell receiving the SIGTERM signal and not the application itself, which may thus be forcibly killed (SIGKILL) and only after the timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container command execution format in Containerfile and Containerfile.ocp from shell form to exec form, affecting signal handling and command processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->