### PR TITLE
EDM-3402: Use control variant for RichTextFIeld

### DIFF
--- a/libs/ui-components/src/components/form/RichValidationTextField.tsx
+++ b/libs/ui-components/src/components/form/RichValidationTextField.tsx
@@ -141,7 +141,7 @@ const RichValidationTextField = React.forwardRef(
                     <CheckCircleIcon color={successColor.value} />
                   )
                 }
-                variant="plain"
+                variant="control"
                 aria-label="Validation"
               />
             </Popover>


### PR DESCRIPTION
Using the control variant makes it visually clearer that the field has the same size as the rest of the fields.

<img width="1758" height="1156" alt="control-added" src="https://github.com/user-attachments/assets/6e2f9e6c-f218-4655-9c0b-2c9393ce1188" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the button styling used in form validation popovers, changing its visual appearance for improved consistency and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->