### PR TITLE
EDM-3383: Refresh device before displaying YAML

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -504,6 +504,7 @@
   "The current YAML is invalid. Fix the errors, or click ʼReloadʼ to discard your changes.": "The current YAML is invalid. Fix the errors, or click ʼReloadʼ to discard your changes.",
   "This object has been updated.": "This object has been updated.",
   "Click reload to see the new version.": "Click reload to see the new version.",
+  "Refreshing details": "Refreshing details",
   "Copy to clipboard": "Copy to clipboard",
   "Content copied to clipboard": "Content copied to clipboard",
   "Download yaml": "Download yaml",

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsPage.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsPage.tsx
@@ -23,7 +23,12 @@ import { ROUTE, useNavigate } from '../../../hooks/useNavigate';
 import { useAppContext } from '../../../hooks/useAppContext';
 import DeviceDetailsTab from './DeviceDetailsTab';
 import TerminalTab from './TerminalTab';
-import { getEditDisabledReason, getResumeDisabledReason, isDeviceEnrolled } from '../../../utils/devices';
+import {
+  getEditDisabledReason,
+  getResumeDisabledReason,
+  hasActiveConsoleSessions,
+  isDeviceEnrolled,
+} from '../../../utils/devices';
 import TabsNav from '../../TabsNav/TabsNav';
 import { RESOURCE, VERB } from '../../../types/rbac';
 import { usePermissionsContext } from '../../common/PermissionsContext';
@@ -211,6 +216,7 @@ const DeviceDetailsPage = ({ children, hideTerminal }: DeviceDetailsPageProps) =
                 refetch={refetch}
                 disabledEditReason={editDisabledReason}
                 canEdit={hasEditPermissions}
+                shouldFetchInitially={hasActiveConsoleSessions(device)}
               />
             }
           />

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsPage.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsPage.tsx
@@ -29,7 +29,7 @@ import { RESOURCE, VERB } from '../../../types/rbac';
 import { usePermissionsContext } from '../../common/PermissionsContext';
 import EventsCard from '../../Events/EventsCard';
 import PageWithPermissions from '../../common/PageWithPermissions';
-import YamlEditor from '../../common/CodeEditor/YamlEditor';
+import { YamlEditorLoader } from '../../common/CodeEditor/YamlEditor';
 import DeviceAliasEdit from './DeviceAliasEdit';
 import { SystemRestoreBanners } from '../../SystemRestore/SystemRestoreBanners';
 import DeviceDetailsCatalog from './DeviceDetailsCatalog';
@@ -206,7 +206,7 @@ const DeviceDetailsPage = ({ children, hideTerminal }: DeviceDetailsPageProps) =
           <Route
             path="yaml"
             element={
-              <YamlEditor
+              <YamlEditorLoader
                 apiObj={device}
                 refetch={refetch}
                 disabledEditReason={editDisabledReason}

--- a/libs/ui-components/src/components/common/CodeEditor/YamlEditor.css
+++ b/libs/ui-components/src/components/common/CodeEditor/YamlEditor.css
@@ -1,5 +1,5 @@
 .fctl-yaml-editor .monaco-editor {
-  min-height: 70vh;
+  min-height: 50vh;
 }
 
 /* Style of the bar with the line numbers for light and dark themes */

--- a/libs/ui-components/src/components/common/CodeEditor/YamlEditor.tsx
+++ b/libs/ui-components/src/components/common/CodeEditor/YamlEditor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Alert, AlertActionCloseButton, Stack, StackItem } from '@patternfly/react-core';
+import { Alert, AlertActionCloseButton, Bullseye, Spinner, Stack, StackItem } from '@patternfly/react-core';
 import { CodeEditorProps as PfCodeEditorProps } from '@patternfly/react-code-editor';
 import { dump, load } from 'js-yaml';
 import { compare } from 'fast-json-patch';
@@ -7,6 +7,7 @@ import type * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 
 import { AuthProvider, Device, Fleet, PatchRequest, Repository, ResourceKind } from '@flightctl/types';
 import { ImageBuild } from '@flightctl/types/imagebuilder';
+import { showSpinnerBriefly } from '../../../utils/time';
 import { fromAPILabel } from '../../../utils/labels';
 import { getLabelPatches } from '../../../utils/patch';
 import { getErrorMessage, isResourceVersionTestFailure } from '../../../utils/error';
@@ -107,6 +108,8 @@ const createPatchList = (original: FlightCtlYamlResource, updated: FlightCtlYaml
   // To prevent that, we'll use a fallback that patches the top-level mutable fields that were modified.
   return getFallbackPatches(original, updated);
 };
+
+const YAML_TAB_REFETCH_DELAY_MS = 500;
 
 const YamlEditor = <R extends FlightCtlYamlResource>({
   apiObj,
@@ -257,6 +260,39 @@ const YamlEditor = <R extends FlightCtlYamlResource>({
       )}
     </div>
   );
+};
+
+/**
+ * Use YamlEditorLoader instead of the default YamlEditor component to trigger a refetch of the resource before rendering the editor.
+ *
+ * @param props - YamlEditor component props.
+ * @returns A spinner while the resource is being refetched, then the YamlEditor component.
+ */
+export const YamlEditorLoader = <R extends FlightCtlYamlResource>(props: YamlEditorProps<R>) => {
+  const { t } = useTranslation();
+  const [initialLoad, setInitialLoad] = React.useState(false);
+  const { refetch } = props;
+
+  React.useEffect(() => {
+    const forceRefresh = async () => {
+      setInitialLoad(false);
+      // Wait before triggering the refetch to give time for the resource to be updated.
+      await showSpinnerBriefly(YAML_TAB_REFETCH_DELAY_MS);
+      refetch();
+      setInitialLoad(true);
+    };
+    void forceRefresh();
+  }, [refetch]);
+
+  if (!initialLoad) {
+    return (
+      <Bullseye>
+        <Spinner size="lg" aria-label={t('Refreshing details')} />
+      </Bullseye>
+    );
+  }
+
+  return <YamlEditor {...props} />;
 };
 
 export default YamlEditor;

--- a/libs/ui-components/src/components/common/CodeEditor/YamlEditor.tsx
+++ b/libs/ui-components/src/components/common/CodeEditor/YamlEditor.tsx
@@ -109,7 +109,8 @@ const createPatchList = (original: FlightCtlYamlResource, updated: FlightCtlYaml
   return getFallbackPatches(original, updated);
 };
 
-const YAML_TAB_REFETCH_DELAY_MS = 500;
+const YAML_TAB_REFETCH_DELAY_BEFORE_MS = 400;
+const YAML_TAB_REFETCH_DELAY_AFTER_MS = 150;
 
 const YamlEditor = <R extends FlightCtlYamlResource>({
   apiObj,
@@ -263,28 +264,53 @@ const YamlEditor = <R extends FlightCtlYamlResource>({
 };
 
 /**
- * Use YamlEditorLoader instead of the default YamlEditor component to trigger a refetch of the resource before rendering the editor.
+ * Use YamlEditorLoader instead of the default YamlEditor component to trigger a conditional fetch of the resource before rendering the editor.
+ * The refetch is performed only if `shouldFetchInitially` returns true.
  *
- * @param props - YamlEditor component props.
+ * @param props - YamlEditor component props plus `shouldFetchInitially`.
  * @returns A spinner while the resource is being refetched, then the YamlEditor component.
  */
-export const YamlEditorLoader = <R extends FlightCtlYamlResource>(props: YamlEditorProps<R>) => {
+export const YamlEditorLoader = <R extends FlightCtlYamlResource>(
+  props: YamlEditorProps<R> & {
+    shouldFetchInitially: boolean;
+  },
+) => {
   const { t } = useTranslation();
-  const [initialLoad, setInitialLoad] = React.useState(false);
-  const { refetch } = props;
+  const { refetch, shouldFetchInitially, ...yamlEditorProps } = props;
+
+  const shouldFetchInitiallyRef = React.useRef(shouldFetchInitially);
+  shouldFetchInitiallyRef.current = shouldFetchInitially;
+
+  const [isLoaded, setIsLoaded] = React.useState(() => !props.shouldFetchInitially);
 
   React.useEffect(() => {
-    const forceRefresh = async () => {
-      setInitialLoad(false);
-      // Wait before triggering the refetch to give time for the resource to be updated.
-      await showSpinnerBriefly(YAML_TAB_REFETCH_DELAY_MS);
-      refetch();
-      setInitialLoad(true);
-    };
-    void forceRefresh();
-  }, [refetch]);
+    let cancelled = false;
 
-  if (!initialLoad) {
+    const shouldFetch = shouldFetchInitiallyRef.current;
+    if (shouldFetch) {
+      const doRefetch = async () => {
+        setIsLoaded(false);
+        await showSpinnerBriefly(YAML_TAB_REFETCH_DELAY_BEFORE_MS);
+        if (cancelled) {
+          return;
+        }
+        refetch();
+        // Give some time for refetch to complete before marking the editor as loaded
+        await showSpinnerBriefly(YAML_TAB_REFETCH_DELAY_AFTER_MS);
+        setIsLoaded(true);
+      };
+      void doRefetch();
+    } else {
+      setIsLoaded(true);
+    }
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (!isLoaded) {
     return (
       <Bullseye>
         <Spinner size="lg" aria-label={t('Refreshing details')} />
@@ -292,7 +318,7 @@ export const YamlEditorLoader = <R extends FlightCtlYamlResource>(props: YamlEdi
     );
   }
 
-  return <YamlEditor {...props} />;
+  return <YamlEditor {...yamlEditorProps} refetch={refetch} />;
 };
 
 export default YamlEditor;

--- a/libs/ui-components/src/components/common/CodeEditor/YamlEditorBase.tsx
+++ b/libs/ui-components/src/components/common/CodeEditor/YamlEditorBase.tsx
@@ -127,6 +127,7 @@ const YamlEditorBase = ({
               theme: `console-${resolvedTheme}`,
               readOnly: readOnly || !!disabledEditReason,
             }}
+            height="60vh"
             onChange={(val) => onChange?.(val)}
           />
         </StackItem>

--- a/libs/ui-components/src/utils/devices.ts
+++ b/libs/ui-components/src/utils/devices.ts
@@ -1,6 +1,8 @@
 import { Device, DeviceSummaryStatusType, ObjectMeta } from '@flightctl/types';
 import { TFunction } from 'react-i18next';
 
+const DEVICE_CONSOLE_ANNOTATION = 'device-controller/console';
+
 const deviceFleetRegExp = /^Fleet\/(?<fleetName>.*)$/;
 
 export const getDeviceFleet = (metadata: ObjectMeta) => {
@@ -35,4 +37,13 @@ export const getResumeDisabledReason = (device: Device, t: TFunction) => {
     return t('Device is not suspended.');
   }
   return undefined;
+};
+
+export const hasActiveConsoleSessions = (device: Device): boolean => {
+  const consoleAnnotation = device.metadata?.annotations?.[DEVICE_CONSOLE_ANNOTATION]?.trim();
+  if (!consoleAnnotation || consoleAnnotation === '[]') {
+    return false;
+  }
+  // Content is a JSON array including the sessionID and sessionMetadata
+  return true;
 };


### PR DESCRIPTION
When the YAML editor opens, we now refresh the device details so that the editor shows the most updated version.

This helps for example when quickly switching from the Terminal tab to the YAML tab, as the device annotations are updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a brief loading state and delayed refresh when opening the YAML editor on device details pages for smoother loading.
  * YAML editor now conditionally performs an initial refresh when a device has active console sessions.

* **Style / Layout**
  * Reduced the YAML editor minimum height and adjusted default editor and terminal tab heights for improved fit.

* **Localization**
  * Added an English translation for "Refreshing details".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->