### PR TITLE
EDM-3426: Correctly place message and disable steps after device is bound

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -644,6 +644,7 @@
   "Device is non-editable": "Device is non-editable",
   "Device template": "Device template",
   "The device will be bound to a fleet. As a result, its configurations cannot be edited directly.": "The device will be bound to a fleet. As a result, its configurations cannot be edited directly.",
+  "Why this step is disabled": "Why this step is disabled",
   "This port mapping already exists": "This port mapping already exists",
   "Port mapping must be in format \"hostPort:containerPort\"": "Port mapping must be in format \"hostPort:containerPort\"",
   "Invalid port values": "Invalid port values",

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/EditDeviceWizard.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/EditDeviceWizard.tsx
@@ -113,16 +113,16 @@ const EditDeviceWizard = () => {
           const templateStepValid = isDeviceTemplateStepValid(formikErrors);
           const updateStepValid = isUpdatePolicyStepValid(formikErrors);
 
-          const canEditTemplate = !values.fleetMatch;
-          const isTemplateStepDisabled = !(generalStepValid && canEditTemplate);
-          const isUpdateStepDisabled = !templateStepValid;
+          const isFleetless = !values.fleetMatch;
+          const isTemplateStepDisabled = !(generalStepValid && isFleetless);
+          const isUpdateStepDisabled = !(generalStepValid && templateStepValid && isFleetless);
 
           return (
             <>
               <LeaveFormConfirmation />
               <Wizard
                 footer={<EditDeviceWizardFooter />}
-                nav={<EditDeviceWizardNav />}
+                nav={<EditDeviceWizardNav isFleetless={isFleetless} />}
                 onStepChange={() => {
                   if (submitError) {
                     setSubmitError(undefined);

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/EditDeviceWizardNav.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/EditDeviceWizardNav.tsx
@@ -1,19 +1,46 @@
 import * as React from 'react';
-import { Icon, Tooltip, WizardNav, WizardNavItem, useWizardContext } from '@patternfly/react-core';
+import { Flex, FlexItem, Icon, Tooltip, WizardNav, WizardNavItem, useWizardContext } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
 
 import { useTranslation } from '../../../hooks/useTranslation';
-import { TFunction } from 'react-i18next';
 
 const generalInfoStepIndex = 0;
 const deviceTemplateStepIndex = 1;
 const deviceUpdatesStepIndex = 2;
 const reviewDeviceStepIndex = 3;
 
-const disabledTemplateReason = (t: TFunction) =>
-  t('The device will be bound to a fleet. As a result, its configurations cannot be edited directly.');
+const StepNavContent = ({
+  stepName,
+  isDisabled,
+  isFleetless,
+}: {
+  stepName: string;
+  isDisabled?: boolean;
+  isFleetless?: boolean;
+}) => {
+  const { t } = useTranslation();
+  if (!isDisabled || isFleetless) {
+    return stepName;
+  }
+  return (
+    <Flex>
+      <FlexItem>{stepName}</FlexItem>
+      <FlexItem>
+        <Tooltip
+          content={t('The device will be bound to a fleet. As a result, its configurations cannot be edited directly.')}
+        >
+          <span tabIndex={0} aria-label={t('Why this step is disabled')}>
+            <Icon status="info" size="sm">
+              <InfoCircleIcon />
+            </Icon>
+          </span>
+        </Tooltip>
+      </FlexItem>
+    </Flex>
+  );
+};
 
-const EditDeviceWizardNav = () => {
+const EditDeviceWizardNav = ({ isFleetless }: { isFleetless: boolean }) => {
   const { t } = useTranslation();
   const { activeStep, steps, goToStepByIndex } = useWizardContext();
 
@@ -33,9 +60,15 @@ const EditDeviceWizardNav = () => {
       />
       <WizardNavItem
         stepIndex={deviceTemplateStepIndex}
-        content={t('Device template')}
+        content={
+          <StepNavContent
+            stepName={t('Device template')}
+            isDisabled={isEditTemplateDisabled}
+            isFleetless={isFleetless}
+          />
+        }
         isCurrent={activeStep?.index === deviceTemplateStepIndex + 1}
-        isDisabled={isEditTemplateDisabled}
+        aria-disabled={isEditTemplateDisabled}
         onClick={() => {
           if (!isEditTemplateDisabled) {
             goToStepByIndex(deviceTemplateStepIndex + 1);
@@ -44,23 +77,17 @@ const EditDeviceWizardNav = () => {
       />
       <WizardNavItem
         stepIndex={deviceUpdatesStepIndex}
-        content={t('Updates')}
+        content={
+          <StepNavContent stepName={t('Updates')} isDisabled={isDeviceUpdatesDisabled} isFleetless={isFleetless} />
+        }
         isCurrent={activeStep?.index === deviceUpdatesStepIndex + 1}
-        isDisabled={isDeviceUpdatesDisabled}
+        aria-disabled={isDeviceUpdatesDisabled}
         onClick={() => {
           if (!isDeviceUpdatesDisabled) {
             goToStepByIndex(deviceUpdatesStepIndex + 1);
           }
         }}
-      >
-        {isDeviceUpdatesDisabled && (
-          <Tooltip content={disabledTemplateReason(t)}>
-            <Icon status="info" size="sm">
-              <InfoCircleIcon />
-            </Icon>
-          </Tooltip>
-        )}
-      </WizardNavItem>
+      />
       <WizardNavItem
         stepIndex={reviewDeviceStepIndex}
         content={t('Review and save')}


### PR DESCRIPTION
The tooltip that should have been displayed when by editing a device it becomes bound to a fleet, was being displayed wrongly positioned and when device was not becoming bound to a fleet.

<img width="1517" height="545" alt="icons-fixed" src="https://github.com/user-attachments/assets/8f2fb929-fc62-44d8-b703-76fc2c8d8957" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wizard now respects a "fleetless" state to enable/disable template and update steps and adjust navigation behavior.
  * Step labels use a unified renderer that shows contextual icons and tooltips only when appropriate.

* **Accessibility**
  * Improved disabled-step handling for better screen reader semantics and keyboard navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->