### PR TITLE
EDM-3394: Fix footer button - overwrite styling from OCP console

### DIFF
--- a/libs/ui-components/src/components/common/FlightCtlWizardFooter.tsx
+++ b/libs/ui-components/src/components/common/FlightCtlWizardFooter.tsx
@@ -82,7 +82,8 @@ const FlightCtlWizardFooter = <T extends Record<string, unknown>>({
   }
   return (
     <WizardFooterWrapper>
-      <ActionList>
+      {/* Overwrite the justifyContent: 'space-between' set incorrectly by the OCP console */}
+      <ActionList style={{ justifyContent: 'normal' }}>
         <ActionListGroup>
           <ActionListItem>
             <Button


### PR DESCRIPTION
The OpenShift console has the following CSS
```
.co-quick-start-drawer {
  .pf-v6-c-action-list {
    justify-content: space-between;
  }
}
```
Since the QuickStartDrawer sits on the top of the DOM, it affects the `FlightCtlWizardFooter`,  because it's an ActionList with more than 1 ActionListGroup.

Until there's a fix in Console, we must overwrite the style to keep our desired display.

<img width="3008" height="2098" alt="action-group-styling" src="https://github.com/user-attachments/assets/b6806b0c-1ebe-4273-b4d9-4d070a0a93f2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout alignment in the wizard footer so action buttons no longer inherit unintended spacing; buttons are now consistently grouped and aligned, improving form navigation and overall visual polish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->