### PR TITLE
EDM-3395: Ensure paddings are defined for main components

### DIFF
--- a/apps/ocp-plugin/src/components/common/WithPageLayout.tsx
+++ b/apps/ocp-plugin/src/components/common/WithPageLayout.tsx
@@ -7,6 +7,17 @@ import PageNavigation from '@flightctl/ui-components/src/components/common/PageN
 import { SystemRestoreProvider } from '@flightctl/ui-components/src/hooks/useSystemRestoreContext';
 import { PermissionsContextProvider } from '@flightctl/ui-components/src/components/common/PermissionsContext';
 
+// The OCP console uses "calc" to calculate padding values for page containers and breadcrumbs.
+// But some CSS variables it uses are undefined, so the "calc" values are invalid.
+const ocpPageRootStyles: React.CSSProperties = {
+  // Ensure page containers have inline padding
+  ['--pf-v6-c-page__main-container--BorderInlineEndWidth' as string]: '0px',
+  ['--pf-v6-c-page__main-container--BorderInlineStartWidth' as string]: '0px',
+  // Ensure page breadcrumbs have inline padding
+  ['--pf-v6-c-page__main-breadcrumb--PaddingInlineStart' as string]: '1rem',
+  ['--pf-v6-c-page__main-breadcrumb--PaddingInlineEnd' as string]: '1rem',
+};
+
 const WithPageLayoutContent = ({ children }: React.PropsWithChildren) => {
   const { mustShowOrganizationSelector } = useOrganizationGuardContext();
 
@@ -15,10 +26,10 @@ const WithPageLayoutContent = ({ children }: React.PropsWithChildren) => {
   }
 
   return (
-    <>
+    <div style={ocpPageRootStyles}>
       <PageNavigation showSettings={false} />
       {children}
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
In OCP 4.19 and 4.20, some expressions that apply padding to main components are not evaluating properly because some Patternfly CSS variables are undefined.

Until the fixes are done in the OCP console, we provide a workaround for our application.
<img width="3901" height="1503" alt="ocp-4 20-fixed" src="https://github.com/user-attachments/assets/99783fad-0c88-4f1c-99ad-043afddc9f6e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined page layout styling with adjusted padding for improved visual presentation and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->