### PR TITLE
EDM-3455: Add data-testid attributes for Cypress device E2E tests

### DIFF
--- a/apps/standalone/src/app/components/AppLayout/AppLayout.tsx
+++ b/apps/standalone/src/app/components/AppLayout/AppLayout.tsx
@@ -50,6 +50,7 @@ const AppLayoutContent = () => {
             isSidebarOpen={isSidebarOpen}
             onSidebarToggle={onSidebarToggle}
             id="page-toggle-button"
+            data-testid="nav-toggle"
           />
         </MastheadToggle>
         <MastheadBrand>

--- a/libs/ui-components/src/components/DetailsPage/DetailsPage.tsx
+++ b/libs/ui-components/src/components/DetailsPage/DetailsPage.tsx
@@ -38,6 +38,8 @@ export type DetailsPageProps = {
   actions?: React.ReactNode;
   nav?: React.ReactNode;
   banner?: React.ReactNode;
+  /** Optional data-testid for the title (e.g. "device-details-title") */
+  titleDataTestId?: string;
 };
 
 const DetailsPage = ({
@@ -53,6 +55,7 @@ const DetailsPage = ({
   actions,
   nav,
   banner,
+  titleDataTestId,
 }: DetailsPageProps) => {
   const { t } = useTranslation();
   let content = children;
@@ -87,7 +90,12 @@ const DetailsPage = ({
       <PageSection hasBodyWrapper={false}>
         <Split hasGutter>
           <SplitItem isFilled>
-            <Title headingLevel="h1" size="3xl" role="heading">
+            <Title
+              headingLevel="h1"
+              size="3xl"
+              role="heading"
+              {...(titleDataTestId && { 'data-testid': titleDataTestId })}
+            >
               {title || id}
             </Title>
           </SplitItem>

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsPage.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsPage.tsx
@@ -121,6 +121,7 @@ const DeviceDetailsPage = ({ children, hideTerminal }: DeviceDetailsPageProps) =
       error={error}
       id={deviceId}
       breadcrumbTitle={deviceAlias}
+      titleDataTestId="device-details-title"
       title={
         canEdit ? (
           /* key={deviceAlias} is needed for the input field to be initialized with the alias as its value */

--- a/libs/ui-components/src/components/Device/DevicesPage/DecommissionedDeviceTableRow.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/DecommissionedDeviceTableRow.tsx
@@ -34,7 +34,7 @@ const DecommissionedDeviceTableRow = ({
   const deviceAlias = device.metadata.labels?.alias;
 
   return (
-    <Tr>
+    <Tr data-testid={`decommissioned-device-row-${rowIndex}`}>
       <Td
         select={{
           rowIndex,
@@ -43,13 +43,17 @@ const DecommissionedDeviceTableRow = ({
         }}
       />
       <Td dataLabel={t('Name')}>
-        <ResourceLink id={deviceName} routeLink={ROUTE.DEVICE_DETAILS} />
+        <ResourceLink
+          id={deviceName}
+          routeLink={ROUTE.DEVICE_DETAILS}
+          data-testid={`decommissioned-device-name-link-${rowIndex}`}
+        />
       </Td>
       <Td dataLabel={t('Device status')}>
         <DeviceLifecycleStatus device={device} />
       </Td>
       {canDelete && (
-        <Td isActionCell>
+        <Td isActionCell data-testid={`decommissioned-device-row-actions-${rowIndex}`}>
           <ActionsColumn
             items={[
               ...(canEdit

--- a/libs/ui-components/src/components/Device/DevicesPage/DecommissionedDevicesTable.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/DecommissionedDevicesTable.tsx
@@ -94,6 +94,7 @@ const DecommissionedDevicesTable = ({
                   isDisabled={!hasSelectedRows}
                   onClick={() => setIsMassDeleteModalOpen(true)}
                   variant="secondary"
+                  data-testid="toolbar-delete-forever"
                 >
                   {t('Delete forever')}
                 </Button>
@@ -108,6 +109,7 @@ const DecommissionedDevicesTable = ({
                   setOnlyDecommissioned(false);
                 }}
                 ouiaId={t('Show decommissioned devices')}
+                data-testid="show-decommissioned-devices-switch"
               />
             </ToolbarItem>
           </ToolbarGroup>

--- a/libs/ui-components/src/components/Device/DevicesPage/EnrolledDeviceTableRow.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/EnrolledDeviceTableRow.tsx
@@ -54,7 +54,7 @@ const EnrolledDeviceTableRow = ({
   const columnIds = React.useMemo(() => deviceColumns.map(({ id }) => id), [deviceColumns]);
 
   return (
-    <Tr>
+    <Tr data-testid={`enrolled-device-row-${rowIndex}`}>
       <Td
         select={{
           rowIndex,
@@ -65,12 +65,17 @@ const EnrolledDeviceTableRow = ({
       />
       {columnIds.includes('alias') && (
         <Td dataLabel={t('Alias')}>
-          <ResourceLink id={deviceName} name={deviceAlias || t('Untitled')} routeLink={ROUTE.DEVICE_DETAILS} />
+          <ResourceLink
+            id={deviceName}
+            name={deviceAlias || t('Untitled')}
+            routeLink={ROUTE.DEVICE_DETAILS}
+            data-testid={`device-name-link-${rowIndex}`}
+          />
         </Td>
       )}
       {columnIds.includes('name') && (
         <Td dataLabel={t('Name')}>
-          <ResourceLink id={deviceName} />
+          <ResourceLink id={deviceName} data-testid={`device-internal-name-link-${rowIndex}`} />
         </Td>
       )}
       {columnIds.includes('fleet') && (
@@ -94,7 +99,7 @@ const EnrolledDeviceTableRow = ({
         </Td>
       )}
       {!hideActions && (
-        <Td isActionCell>
+        <Td isActionCell data-testid={`device-row-actions-${rowIndex}`}>
           <ActionsColumn
             items={[
               ...(canEdit

--- a/libs/ui-components/src/components/Device/DevicesPage/EnrolledDevicesTable.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/EnrolledDevicesTable.tsx
@@ -162,6 +162,7 @@ const EnrolledDevicesTable = ({
               isDisabled={!hasSelectedRows}
               onClick={() => setIsMassDecommissionModalOpen(true)}
               variant="secondary"
+              data-testid="toolbar-decommission-devices"
             >
               {t('Decommission devices')}
             </Button>
@@ -177,6 +178,7 @@ const EnrolledDevicesTable = ({
               setOnlyDecommissioned(true);
             }}
             ouiaId={t('Show decommissioned devices')}
+            data-testid="show-decommissioned-devices-switch"
           />
         </ToolbarItem>
       </DeviceTableToolbar>
@@ -189,6 +191,7 @@ const EnrolledDevicesTable = ({
         emptyData={devices.length === 0}
         isAllSelected={isAllSelected}
         onSelectAll={setAllSelected}
+        data-testid="enrolled-devices-table"
       >
         <Tbody>
           {devices.map((device, index) => (

--- a/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestTableRow.tsx
+++ b/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestTableRow.tsx
@@ -67,13 +67,17 @@ const EnrollmentRequestTableRow: React.FC<EnrollmentRequestTableRow> = ({
       <Td dataLabel={t('Created')}>{timeSinceText(t, er.metadata.creationTimestamp)}</Td>
       {canApprove && (
         <Td dataLabel={t('Approve')}>
-          <Button variant="link" onClick={approveEnrollment}>
+          <Button
+            variant="link"
+            onClick={approveEnrollment}
+            data-testid={`enrollment-request-approve-button-${rowIndex}`}
+          >
             {t('Approve')}
           </Button>
         </Td>
       )}
       {!!actionItems.length && (
-        <Td isActionCell>
+        <Td isActionCell data-testid={`enrollment-request-row-actions-${rowIndex}`}>
           <ActionsColumn items={actionItems} />
         </Td>
       )}

--- a/libs/ui-components/src/components/ListPage/ListPage.tsx
+++ b/libs/ui-components/src/components/ListPage/ListPage.tsx
@@ -13,7 +13,7 @@ const ListPage: React.FC<ListPageProps> = ({ title, headingLevel = 'h1', childre
     <PageSection hasBodyWrapper={false}>
       <Flex gap={{ default: 'gapMd' }} alignItems={{ default: 'alignItemsCenter' }}>
         <FlexItem>
-          <Title headingLevel={headingLevel} size="3xl">
+          <Title headingLevel={headingLevel} size="3xl" data-testid="list-page-title">
             {title}
           </Title>
         </FlexItem>

--- a/libs/ui-components/src/components/Table/Table.tsx
+++ b/libs/ui-components/src/components/Table/Table.tsx
@@ -38,6 +38,7 @@ type TableProps<D> = Pick<PFTableProps, 'variant'> & {
   onSelectAll?: (isSelected: boolean) => void;
   isAllSelected?: boolean;
   isExpandable?: boolean;
+  'data-testid'?: string;
   singleSelect?: boolean;
 };
 

--- a/libs/ui-components/src/components/common/FlightCtlWizardFooter.tsx
+++ b/libs/ui-components/src/components/common/FlightCtlWizardFooter.tsx
@@ -50,20 +50,32 @@ const FlightCtlWizardFooter = <T extends Record<string, unknown>>({
   let primaryBtn: React.ReactNode;
   if (isSubmitStep && !isReadOnly) {
     primaryBtn = (
-      <Button variant="primary" onClick={submitForm} isDisabled={isSubmitting} isLoading={isSubmitting}>
+      <Button
+        variant="primary"
+        onClick={submitForm}
+        isDisabled={isSubmitting}
+        isLoading={isSubmitting}
+        data-testid="wizard-save-button"
+      >
         {saveButtonText || t('Save')}
       </Button>
     );
   } else if (isSubmitStep) {
     // Read-only "Review" step
     primaryBtn = (
-      <Button variant="primary" onClick={() => navigate(-1)}>
+      <Button variant="primary" onClick={() => navigate(-1)} data-testid="wizard-close-button">
         {t('Close')}
       </Button>
     );
   } else {
     primaryBtn = (
-      <Button variant="primary" onClick={onMoveNext} isDisabled={!isReadOnly && !stepValid} ref={buttonRef}>
+      <Button
+        variant="primary"
+        onClick={onMoveNext}
+        isDisabled={!isReadOnly && !stepValid}
+        ref={buttonRef}
+        data-testid="wizard-next-button"
+      >
         {t('Next')}
       </Button>
     );
@@ -77,6 +89,7 @@ const FlightCtlWizardFooter = <T extends Record<string, unknown>>({
               variant="secondary"
               onClick={goToPrevStep}
               isDisabled={String(activeStep.id) === firstStepId || isSubmitting}
+              data-testid="wizard-back-button"
             >
               {t('Back')}
             </Button>
@@ -85,7 +98,12 @@ const FlightCtlWizardFooter = <T extends Record<string, unknown>>({
         </ActionListGroup>
         <ActionListGroup>
           <ActionListItem>
-            <Button variant="link" onClick={onCancel ?? (() => navigate(-1))} isDisabled={isSubmitting}>
+            <Button
+              variant="link"
+              onClick={onCancel ?? (() => navigate(-1))}
+              isDisabled={isSubmitting}
+              data-testid="wizard-cancel-button"
+            >
               {t('Cancel')}
             </Button>
           </ActionListItem>

--- a/libs/ui-components/src/components/common/ResourceLink.tsx
+++ b/libs/ui-components/src/components/common/ResourceLink.tsx
@@ -12,6 +12,7 @@ type ResourceDisplayLinkProps = {
   name?: string;
   variant?: 'shortened' | 'full';
   routeLink?: RouteWithPostfix;
+  'data-testid'?: string;
 };
 
 export const getDisplayText = (name: string | undefined) => {
@@ -24,7 +25,13 @@ export const getDisplayText = (name: string | undefined) => {
   return `${name.substring(0, 6)}...${name.substring(name.length - 7)}`;
 };
 
-const ResourceLink = ({ id, name, variant = 'shortened', routeLink }: ResourceDisplayLinkProps) => {
+const ResourceLink = ({
+  id,
+  name,
+  variant = 'shortened',
+  routeLink,
+  'data-testid': dataTestId,
+}: ResourceDisplayLinkProps) => {
   const nameOrId = name || id;
   const displayText = getDisplayText(nameOrId);
   const showCopy = nameOrId !== displayText;
@@ -33,7 +40,13 @@ const ResourceLink = ({ id, name, variant = 'shortened', routeLink }: ResourceDi
 
   return (
     <span className={`fctl-resource-link fctl-resource-link__${variant}`}>
-      {routeLink ? <Link to={{ route: routeLink, postfix: id }}>{textEl}</Link> : <>{textEl}</>}
+      {routeLink ? (
+        <Link to={{ route: routeLink, postfix: id }} data-testid={dataTestId}>
+          {textEl}
+        </Link>
+      ) : (
+        <span data-testid={dataTestId}>{textEl}</span>
+      )}
       {showCopy && nameOrId && <CopyButton text={nameOrId} />}
     </span>
   );

--- a/libs/ui-components/src/components/modals/ApproveDeviceModal/ApproveDeviceForm.tsx
+++ b/libs/ui-components/src/components/modals/ApproveDeviceModal/ApproveDeviceForm.tsx
@@ -59,6 +59,7 @@ const ApproveDeviceForm: React.FC<ApproveDeviceFormProps> = ({ enrollmentRequest
           onClick={submitForm}
           isDisabled={disableSubmit || isSubmitting}
           isLoading={isSubmitting}
+          data-testid="approve-device-form-submit"
         >
           {t('Approve')}
         </Button>

--- a/libs/ui-components/src/components/modals/massModals/MassDecommissionDeviceModal/MassDecommissionDeviceModal.tsx
+++ b/libs/ui-components/src/components/modals/massModals/MassDecommissionDeviceModal/MassDecommissionDeviceModal.tsx
@@ -124,6 +124,7 @@ const MassDecommissionDeviceModal = ({ onClose, devices, onSuccess }: MassDecomm
           onClick={decommissionDevices}
           isLoading={isSubmitting}
           isDisabled={isSubmitting}
+          data-testid="modal-decommission-confirm"
         >
           {t('Decommission')}
         </Button>

--- a/libs/ui-components/src/components/modals/massModals/MassDeleteDeviceModal/MassDeleteDeviceModal.tsx
+++ b/libs/ui-components/src/components/modals/massModals/MassDeleteDeviceModal/MassDeleteDeviceModal.tsx
@@ -112,7 +112,14 @@ const MassDeleteDeviceModal: React.FC<MassDeleteDeviceModalProps> = ({ onClose, 
         </Stack>
       </ModalBody>
       <ModalFooter>
-        <Button key="delete" variant="danger" onClick={deleteResources} isLoading={isDeleting} isDisabled={isDeleting}>
+        <Button
+          key="delete"
+          variant="danger"
+          onClick={deleteResources}
+          isLoading={isDeleting}
+          isDisabled={isDeleting}
+          data-testid="modal-delete-devices-confirm"
+        >
           {t('Delete devices')}
         </Button>
         <Button key="cancel" variant="link" onClick={onClose} isDisabled={isDeleting}>


### PR DESCRIPTION
- AppLayout: nav-toggle on sidebar toggle
- ListPage: list-page-title on page title
- EnrollmentRequestTableRow: enrollment-request-approve-button
- ApproveDeviceForm: approve-device-form-submit
- EnrolledDevicesTable: enrolled-devices-table, toolbar-decommission-devices, show-decommissioned-devices-switch
- EnrolledDeviceTableRow: enrolled-device-row, device-name-link, device-row-actions
- ResourceLink: optional data-testid prop
- FlightCtlWizardFooter: wizard-next-button, wizard-save-button, wizard-back-button
- DetailsPage: optional titleDataTestId (device-details-title from DeviceDetailsPage)
- MassDecommissionDeviceModal: modal-decommission-confirm
- MassDeleteDeviceModal: modal-delete-devices-confirm
- DecommissionedDevicesTable: toolbar-delete-forever, show-decommissioned-devices-switch
- Table: data-testid prop support

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added data-testids across the UI (navigation toggle, page/list titles, tables, rows/links, action buttons, switches, wizard controls, approve/delete/decommission modals) to improve end-to-end and UI testing.
* **New Features**
  * Introduced optional test-id props on several UI components (titles, tables, resource links, details pages) to enable precise test targeting without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->