### PR TITLE
EDM-2851: Preserve OpenShift login

### DIFF
--- a/proxy/auth/common.go
+++ b/proxy/auth/common.go
@@ -319,8 +319,6 @@ func clearSessionCookie(w http.ResponseWriter, r *http.Request) {
 		SameSite: http.SameSiteLaxMode,
 	}
 	http.SetCookie(w, &cookie)
-
-	w.Header().Set("Clear-Site-Data", `"cookies"`)
 }
 
 // validateAndExtractProviderFromState validates the state parameter and extracts the provider name


### PR DESCRIPTION
- Do not remove all session cookies when user logs out

By not removing the cookies, we won't clear the OpenShift cookies. Therefore if the user was logged in to the OpenShift console, they'll stay logged in.

However, the behaviour now is a bit weird if the user is logged in as the `kubeadmin` user:
- If they are logged in first in OCP then login to Flight Control, they get logged in to FC as `kubeadmin` directly.
- If they are logged in in both apps as `kubeadmin` and there's only one auth provider (OpenShift), a new login flow is triggered and the user is logged back again as `kubeadmin`. Users need to log out of OpenShift for the logout to take effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session logout reliability by streamlining the session clearing mechanism to use cookie deletion exclusively, removing an unnecessary browser directive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->