### PR TITLE
EDM-3332: Prevent copy button border from being cut

### DIFF
--- a/libs/ui-components/src/components/modals/LoginCommandModal/LoginCommandModal.css
+++ b/libs/ui-components/src/components/modals/LoginCommandModal/LoginCommandModal.css
@@ -1,0 +1,4 @@
+.fctl-login-command-modal__clipboard-copy .pf-v6-c-button {
+  --pf-v6-c-button--ScaleX: 0.95;
+  --pf-v6-c-button--ScaleY: 0.95;
+}

--- a/libs/ui-components/src/components/modals/LoginCommandModal/LoginCommandModal.tsx
+++ b/libs/ui-components/src/components/modals/LoginCommandModal/LoginCommandModal.tsx
@@ -16,6 +16,8 @@ import { useTranslation } from '../../../hooks/useTranslation';
 import { useFetch } from '../../../hooks/useFetch';
 import { getErrorMessage } from '../../../utils/error';
 
+import './LoginCommandModal.css';
+
 type LoginCommand = {
   providerName: string;
   displayName: string;
@@ -117,7 +119,12 @@ const LoginCommandModal = ({ onClose }: LoginCommandModalProps) => {
                       </strong>
                     </Content>
                   )}
-                  <ClipboardCopy isReadOnly hoverTip={t('Copy to clipboard')} clickTip={t('Copied!')}>
+                  <ClipboardCopy
+                    isReadOnly
+                    hoverTip={t('Copy to clipboard')}
+                    clickTip={t('Copied!')}
+                    className="fctl-login-command-modal__clipboard-copy"
+                  >
                     {cmd.command}
                   </ClipboardCopy>
                 </StackItem>


### PR DESCRIPTION
Fixes a visual issue that was happening only in Firefox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Brought modal-specific styling into the component to ensure consistent visual behavior.
  * Adjusted the login command copy control: added a targeted class and slightly reduced the copy button scale for improved visual alignment and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->