### PR TITLE
EDM-3448: Allow ConsolePlugin to report desired version

### DIFF
--- a/Containerfile.ocp
+++ b/Containerfile.ocp
@@ -10,6 +10,8 @@ COPY libs /app/libs
 COPY apps /app/apps
 ENV NODE_OPTIONS='--max-old-space-size=8192'
 RUN npm ci
+ARG PLUGIN_VERSION=""
+ENV PLUGIN_VERSION=$PLUGIN_VERSION
 RUN npm run build:ocp
 
 FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as proxy-build

--- a/apps/ocp-plugin/webpack.config.ts
+++ b/apps/ocp-plugin/webpack.config.ts
@@ -8,7 +8,15 @@ import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
 import TerserJSPlugin from 'terser-webpack-plugin';
 import { ConsoleRemotePlugin } from '@openshift-console/dynamic-plugin-sdk-webpack';
 
+const packageJson = require('./package.json');
+
 const NODE_ENV: Configuration['mode'] = process.env.NODE_ENV === 'production' ? 'production' : 'development';
+
+const pluginMetadata = {
+  ...packageJson.consolePlugin,
+  // Use PLUGIN_VERSION to set the ConsolePlugin's version at build time.
+  version: process.env.PLUGIN_VERSION || packageJson.consolePlugin.version,
+};
 
 const config: Configuration & {
   devServer?: WebpackDevServerConfiguration;
@@ -78,7 +86,7 @@ const config: Configuration & {
     // Plugin uses react-router-dom 5.3.x and Console provides 5.3.x at runtime.
     // When building the app, the ConsoleRemotePlugin sees the package from root node_modules that has v6.x
     // We disable validation to avoid build errors.
-    new ConsoleRemotePlugin({ validateSharedModules: false }),
+    new ConsoleRemotePlugin({ validateSharedModules: false, pluginMetadata }),
   ] as unknown as WebpackPluginInstance[],
   resolve: {
     plugins: [


### PR DESCRIPTION
When building the OCP UI image with the desired `PLUGIN_VERSION` build argument, the ConsolePlugin will report that version in the OpenShift Console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build now embeds plugin version metadata into packaged plugins so distributed artifacts include explicit version info.
  * Supports a build-time override for the plugin version via a PLUGIN_VERSION build argument/environment variable, ensuring the metadata can be set during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->