### PR TITLE
EDM-3540: Remove column for count of image exports

### DIFF
--- a/libs/ui-components/src/components/ImageBuilds/CreateImageBuildWizard/utils.ts
+++ b/libs/ui-components/src/components/ImageBuilds/CreateImageBuildWizard/utils.ts
@@ -175,9 +175,7 @@ export const getValidationSchema = (t: TFunction) => {
 
 // Returns an array with one item per format (VMDK, QCOW2, ISO), where each item is either
 // undefined or the latest ImageExport for that format.
-const getImageExportsByFormat = (
-  imageExports?: ImageExport[],
-): { imageExports: (ImageExport | undefined)[]; exportsCount: number } => {
+const getImageExportsByFormat = (imageExports?: ImageExport[]): { imageExports: (ImageExport | undefined)[] } => {
   const formatMap: Partial<Record<ExportFormatType, ImageExport>> = {};
 
   imageExports?.forEach((ie) => {
@@ -208,7 +206,6 @@ const getImageExportsByFormat = (
       formatMap[ExportFormatType.ExportFormatTypeQCOW2],
       formatMap[ExportFormatType.ExportFormatTypeVMDK],
     ],
-    exportsCount: imageExports?.length || 0,
   };
 };
 
@@ -223,7 +220,6 @@ export const toImageBuildWithExports = (imageBuild: ImageBuild): ImageBuildWithE
   return {
     ...imageBuildWithoutExports,
     imageExports: latestExports,
-    exportsCount: allExports.length,
   };
 };
 

--- a/libs/ui-components/src/components/ImageBuilds/ImageBuildDetails/ImageBuildDetailsTab.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/ImageBuildDetails/ImageBuildDetailsTab.tsx
@@ -37,8 +37,8 @@ const ImageBuildDetailsTab = ({ imageBuild }: { imageBuild: ImageBuildWithExport
   const { ociRegistries } = useOciRegistriesContext();
   const isEarlyBinding = imageBuild.spec.binding.type === BindingType.BindingTypeEarly;
 
-  const hasExports = imageBuild.exportsCount > 0;
   const existingImageExports = imageBuild.imageExports.filter((imageExport) => imageExport !== undefined);
+  const hasExports = existingImageExports.length > 0;
 
   const srcImageReference = React.useMemo(() => {
     return getImageReference(ociRegistries, imageBuild.spec.source) || '';

--- a/libs/ui-components/src/components/ImageBuilds/ImageBuildDetails/ImageBuildYaml.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/ImageBuildDetails/ImageBuildYaml.tsx
@@ -9,7 +9,7 @@ import { ImageBuildWithExports } from '../../../types/extraTypes';
 // For that reason, we must remove the fields we add to "ImageBuildWithExports"
 const ImageBuildYaml = ({ imageBuild, refetch }: { imageBuild: ImageBuildWithExports; refetch: VoidFunction }) => {
   const { t } = useTranslation();
-  const rawImageBuild = { ...imageBuild, imageExports: undefined, exportsCount: undefined } as ImageBuild;
+  const rawImageBuild = { ...imageBuild, imageExports: undefined } as ImageBuild;
   return (
     <YamlEditor
       apiObj={rawImageBuild}

--- a/libs/ui-components/src/components/ImageBuilds/ImageBuildRow.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/ImageBuildRow.tsx
@@ -103,7 +103,6 @@ const ImageBuildRow = ({
         <Td dataLabel={t('Status')}>
           <ImageBuildStatusDisplay buildStatus={imageBuild.status} />
         </Td>
-        <Td dataLabel={t('Export images')}>{`${imageBuild.exportsCount || 0}`}</Td>
         <Td dataLabel={t('Date')}>{getDateDisplay(imageBuild.metadata.creationTimestamp)}</Td>
         <Td isActionCell>
           <ActionsColumn items={actions} />

--- a/libs/ui-components/src/components/ImageBuilds/ImageBuildsPage.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/ImageBuildsPage.tsx
@@ -47,9 +47,6 @@ const getColumns = (t: TFunction): ApiSortTableColumn[] => [
     name: t('Status'),
   },
   {
-    name: t('Export images'),
-  },
-  {
     name: t('Date'),
   },
 ];

--- a/libs/ui-components/src/types/extraTypes.ts
+++ b/libs/ui-components/src/types/extraTypes.ts
@@ -87,7 +87,6 @@ export type AlertManagerAlert = {
 // ImageBuild with the latest exports for each format
 export type ImageBuildWithExports = Omit<ImageBuild, 'imageexports'> & {
   imageExports: (ImageExport | undefined)[];
-  exportsCount: number;
 };
 
 // AuthProviders that can be added dynamically to the system can only be OAuth2 or OIDC.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the "Export images" column from the Image Builds table and row.
* **Bug Fixes**
  * "Export formats" display now reflects the actual available exports (shows formats or "None" consistently).
  * YAML view no longer clears export-related info unexpectedly, preserving displayed export details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->