### PR TITLE
EDM-3535: Use RHEMs own documentation for upstream

### DIFF
--- a/libs/ui-components/src/components/common/LeaveFormConfirmation.tsx
+++ b/libs/ui-components/src/components/common/LeaveFormConfirmation.tsx
@@ -5,7 +5,7 @@ import { Blocker, BlockerFunction } from 'react-router-dom';
 import { useFormikContext } from 'formik';
 
 import { useTranslation } from '../../hooks/useTranslation';
-import { FlightCtlApp, useAppContext } from '../../hooks/useAppContext';
+import { useAppContext } from '../../hooks/useAppContext';
 
 const ConfirmNavigationDialog = ({ blocker }: { blocker: Blocker }) => {
   const { t } = useTranslation();
@@ -74,15 +74,10 @@ const BrowserBlocker = ({ lock }: { lock: boolean }) => {
 const LeaveFormConfirmation = () => {
   const { dirty, isSubmitting } = useFormikContext();
   const {
-    appType,
     router: { useBlocker },
   } = useAppContext();
 
   const lock = !isSubmitting && dirty;
-
-  if (appType === FlightCtlApp.AAP) {
-    return null;
-  }
 
   // workaround for OCP plugin where useBlocker is not yet available due to older react-router-dom version
   return useBlocker ? <RouterBlocker lock={lock} /> : <BrowserBlocker lock={lock} />;

--- a/libs/ui-components/src/hooks/useAppContext.tsx
+++ b/libs/ui-components/src/hooks/useAppContext.tsx
@@ -55,7 +55,6 @@ export type PromptFC = React.FC<{ message: string }>;
 export enum FlightCtlApp {
   STANDALONE = 'standalone',
   OCP = 'ocp',
-  AAP = 'aap',
 }
 
 export type AppContextProps = {

--- a/libs/ui-components/src/hooks/useAppContext.tsx
+++ b/libs/ui-components/src/hooks/useAppContext.tsx
@@ -56,7 +56,6 @@ export type PromptFC = React.FC<{ message: string }>;
 export enum FlightCtlApp {
   STANDALONE = 'standalone',
   OCP = 'ocp',
-  AAP = 'aap',
 }
 
 export type AppContextProps = {

--- a/libs/ui-components/src/hooks/useAppLinks.ts
+++ b/libs/ui-components/src/hooks/useAppLinks.ts
@@ -1,55 +1,35 @@
-import { FlightCtlApp, useAppContext } from './useAppContext';
+import { useAppContext } from './useAppContext';
 
 // Links to other flightctl upstream resources
 export const DEMO_REPOSITORY_URL = 'https://github.com/flightctl/flightctl-demos';
 
-const ACM_VERSION = '2.14';
-const AAP_VERSION = '2.5';
+export const RHEM_VERSION = '1.1';
 
-const upstreamDocsBase = 'https://github.com/flightctl/flightctl/blob/main/docs';
-const acmDownstreamDocsBase = `https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/${ACM_VERSION}/html-single/edge_manager/index`;
-const aapDownstreamDocsBase = `https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/${AAP_VERSION}/html/managing_device_fleets_with_the_red_hat_edge_manager`;
+const baseUpstreamDocs = 'https://github.com/flightctl/flightctl/blob/main/docs';
+const baseDownstreamDocs = 'https://docs.redhat.com/en/documentation/red_hat_edge_manager/${RHEM_VERSION}/html';
 
-const links: Record<'fc' | 'acm' | 'aap', Record<AppLink, string>> = {
-  fc: {
-    createApp: `${upstreamDocsBase}/user/using/managing-devices.md#creating-applications`,
-    useTemplateVars: `${upstreamDocsBase}/user/using/managing-fleets.md#defining-device-templates`,
-    addNewDevice: `${upstreamDocsBase}/user/building/building-images.md#choosing-an-enrollment-method`,
-    createAcmRepo: `${upstreamDocsBase}/user/using/registering-microshift-devices-acm.md#auto-registering-devices-with-microshift-into-acm`,
-    provisionDevice: `${upstreamDocsBase}/user/using/provisioning-devices.md#provisioning-physical-devices`,
-    catalog: `${upstreamDocsBase}/user/using/managing-catalogs.md`,
-  },
-  acm: {
-    createApp: `${acmDownstreamDocsBase}#build-app-packages`,
-    useTemplateVars: `${acmDownstreamDocsBase}#device-templates`,
-    addNewDevice: `${acmDownstreamDocsBase}#edge-mgr-build`,
-    createAcmRepo: `${acmDownstreamDocsBase}#device-config-git-cli`,
-    provisionDevice: `${acmDownstreamDocsBase}#provision-devices-intro`,
-    catalog: '',
-  },
-  aap: {
-    createApp: `${aapDownstreamDocsBase}/edge-manager-manage-apps#edge-manager-build-app-packages`,
-    useTemplateVars: `${aapDownstreamDocsBase}/assembly-edge-manager-device-fleets#edge-manager-device-templates`,
-    addNewDevice: `${aapDownstreamDocsBase}/assembly-edge-manager-images#edge-manager-build-bootc`,
-    createAcmRepo: '',
-    provisionDevice: `${aapDownstreamDocsBase}/edge-manager-provisioning-devices`,
-    catalog: '',
-  },
+const upstreamLinks = {
+  createApp: `${baseUpstreamDocs}/user/using/managing-devices.md#creating-applications`,
+  useTemplateVars: `${baseUpstreamDocs}/user/using/managing-fleets.md#defining-device-templates`,
+  addNewDevice: `${baseUpstreamDocs}/user/building/building-images.md#choosing-an-enrollment-method`,
+  createAcmRepo: `${baseUpstreamDocs}/user/using/registering-microshift-devices-acm.md#auto-registering-devices-with-microshift-into-acm`,
+  provisionDevice: `${baseUpstreamDocs}/user/using/provisioning-devices.md#provisioning-physical-devices`,
+  catalog: `https://github.com/flightctl/flightctl/blob/main/docs/user/using/managing-catalogs.md`,
+};
+
+const downstreamLinks = {
+  createApp: `${baseDownstreamDocs}/managing_applications_on_an_edge_device/rhem-manage-apps#build-app-packages`,
+  useTemplateVars: `${baseDownstreamDocs}/managing_device_fleets/device-fleets#device-templates`,
+  addNewDevice: `${baseDownstreamDocs}/operating_system_images_for_the_red_hat_edge_manager/edge-mgr-images#build-images-consider`,
+  createAcmRepo: `${baseDownstreamDocs}/managing_devices/manage-devices-intro#manage-git-repository`,
+  provisionDevice: `${baseDownstreamDocs}/provisioning_devices/provision-devices-intro`,
+  catalog: '',
 };
 
 type AppLink = 'createApp' | 'useTemplateVars' | 'addNewDevice' | 'createAcmRepo' | 'provisionDevice' | 'catalog';
 
-const getLinkSource = (appType: FlightCtlApp, isRHEM?: boolean) => {
-  // Default doc links are AAP's and apply when using RHEM branding
-  if (isRHEM || appType === FlightCtlApp.AAP) {
-    return links.aap;
-  }
-  return appType === FlightCtlApp.STANDALONE ? links.fc : links.acm;
-};
-
 export const useAppLinks = (link: AppLink) => {
-  const { appType, settings } = useAppContext();
+  const { settings } = useAppContext();
 
-  const links = getLinkSource(appType, settings.isRHEM);
-  return links[link];
+  return settings.isRHEM ? downstreamLinks[link] : upstreamLinks[link];
 };

--- a/libs/ui-components/src/hooks/useAppLinks.ts
+++ b/libs/ui-components/src/hooks/useAppLinks.ts
@@ -18,7 +18,7 @@ const upstreamLinks = {
 };
 
 const downstreamLinks = {
-  createApp: `${baseDownstreamDocs}/managing_applications_on_an_edge_device/rhem-manage-apps#build-app-packages`,
+  createApp: `${baseDownstreamDocs}/managing_applications_on_an_edge_device/build-app-packages`,
   useTemplateVars: `${baseDownstreamDocs}/managing_device_fleets/device-fleets#device-templates`,
   addNewDevice: `${baseDownstreamDocs}/operating_system_images_for_the_red_hat_edge_manager/edge-mgr-images#build-images-consider`,
   createAcmRepo: `${baseDownstreamDocs}/managing_devices/manage-devices-intro#manage-git-repository`,

--- a/libs/ui-components/src/hooks/useAppLinks.ts
+++ b/libs/ui-components/src/hooks/useAppLinks.ts
@@ -6,7 +6,7 @@ export const DEMO_REPOSITORY_URL = 'https://github.com/flightctl/flightctl-demos
 export const RHEM_VERSION = '1.1';
 
 const baseUpstreamDocs = 'https://github.com/flightctl/flightctl/blob/main/docs';
-const baseDownstreamDocs = 'https://docs.redhat.com/en/documentation/red_hat_edge_manager/${RHEM_VERSION}/html';
+const baseDownstreamDocs = `https://docs.redhat.com/en/documentation/red_hat_edge_manager/${RHEM_VERSION}/html`;
 
 const upstreamLinks = {
   createApp: `${baseUpstreamDocs}/user/using/managing-devices.md#creating-applications`,
@@ -23,7 +23,7 @@ const downstreamLinks = {
   addNewDevice: `${baseDownstreamDocs}/operating_system_images_for_the_red_hat_edge_manager/edge-mgr-images#build-images-consider`,
   createAcmRepo: `${baseDownstreamDocs}/managing_devices/manage-devices-intro#manage-git-repository`,
   provisionDevice: `${baseDownstreamDocs}/provisioning_devices/provision-devices-intro`,
-  catalog: '',
+  catalog: `${baseDownstreamDocs}/managing_devices/manage-devices-intro#software-catalog`,
 };
 
 type AppLink = 'createApp' | 'useTemplateVars' | 'addNewDevice' | 'createAcmRepo' | 'provisionDevice' | 'catalog';


### PR DESCRIPTION
Updates the links used for downstream to the Official RHEM documentation.
- Latest version would be 1.1
- Removed AAP application type.

