### PR TITLE
Reapply "EDM-3466: Do not combine several prompt values"

### DIFF
--- a/proxy/auth/common.go
+++ b/proxy/auth/common.go
@@ -129,9 +129,9 @@ func loginRedirect(client *osincli.Client, state string, codeChallenge string) s
 	query.Set("code_challenge_method", "S256")
 
 	// Force that when a new auth flow starts, the user is prompted to select
-	// their account and enter credentials, even if they're already logged in
-	// Does not work for all providers (eg. OpenShift)
-	query.Set("prompt", "login select_account")
+	// their account, even if they're already logged in
+	// Some providers ignore this parameter (eg. OpenShift)
+	query.Set("prompt", "select_account")
 
 	parsedURL.RawQuery = query.Encode()
 


### PR DESCRIPTION
Previous PRs (#561) (#568) (#581)

This reverts commit dfd8779d135676280b7e999294d8755d5645d70f.