### PR TITLE
EDM-3372: Disable mass delete button after delete success

### DIFF
--- a/libs/ui-components/src/components/Device/DevicesPage/DecommissionedDevicesTable.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/DecommissionedDevicesTable.tsx
@@ -151,6 +151,7 @@ const DecommissionedDevicesTable = ({
           resources={devices.filter(isRowSelected)}
           onDeleteSuccess={() => {
             setIsMassDeleteModalOpen(false);
+            setAllSelected(false);
             refetch();
           }}
         />

--- a/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestList.tsx
+++ b/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestList.tsx
@@ -153,6 +153,7 @@ const EnrollmentRequestList = ({ refetchDevices, isStandalone }: EnrollmentReque
             resources={pendingEnrollments.filter(isRowSelected)}
             onDeleteSuccess={() => {
               setIsMassDeleteModalOpen(false);
+              setAllSelected(false);
               refetch();
             }}
           />

--- a/libs/ui-components/src/components/Fleet/FleetsPage.tsx
+++ b/libs/ui-components/src/components/Fleet/FleetsPage.tsx
@@ -197,6 +197,7 @@ const FleetTable = () => {
           fleets={fleets.filter(isRowSelected)}
           onDeleteSuccess={() => {
             setIsMassDeleteModalOpen(false);
+            setAllSelected(false);
             refetch();
           }}
         />

--- a/libs/ui-components/src/components/ImageBuilds/ImageBuildsPage.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/ImageBuildsPage.tsx
@@ -185,6 +185,7 @@ const ImageBuildTable = () => {
           imageBuilds={imageBuilds.filter(isRowSelected)}
           onDeleteSuccess={() => {
             setIsMassDeleteModalOpen(false);
+            setAllSelected(false);
             refetch();
           }}
         />

--- a/libs/ui-components/src/components/Repository/RepositoryList.tsx
+++ b/libs/ui-components/src/components/Repository/RepositoryList.tsx
@@ -244,6 +244,7 @@ const RepositoryTable = () => {
           onClose={() => setIsMassDeleteModalOpen(false)}
           onDeleteSuccess={() => {
             setIsMassDeleteModalOpen(false);
+            setAllSelected(false);
             refetch();
           }}
           repositories={filteredData.filter(isRowSelected)}

--- a/libs/ui-components/src/components/ResourceSync/RepositoryResourceSyncList.tsx
+++ b/libs/ui-components/src/components/ResourceSync/RepositoryResourceSyncList.tsx
@@ -295,6 +295,7 @@ const RepositoryResourceSyncList = ({ repositoryId }: { repositoryId: string }) 
           resources={filteredData.filter(isRowSelected)}
           onDeleteSuccess={() => {
             setIsMassDeleteModalOpen(false);
+            setAllSelected(false);
             refetch();
           }}
         />


### PR DESCRIPTION
After successfully deleting all elements in a table, remove the current selection so the "Delete all" button becomes disabled.

Affected tables:
- Decommissioned devices
- Enrolled devices
- Fleets
- Image builds
- Repositories
- Resource syncs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table selection state not clearing after successful mass delete operations. Selected items are now properly deselected when bulk deletion completes across device, enrollment request, fleet, image build, repository, and resource sync lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->