### PR TITLE
Fix order of nav items

### DIFF
--- a/apps/ocp-plugin/console-extensions.json
+++ b/apps/ocp-plugin/console-extensions.json
@@ -48,9 +48,9 @@
   {
     "type": "console.navigation/href",
     "properties": {
-      "id": "fctl-repositories",
-      "name": "%plugin__flightctl-plugin~Repositories%",
-      "href": "/edge/repositories",
+      "id": "fctl-imagebuilds",
+      "name": "%plugin__flightctl-plugin~Image builds%",
+      "href": "/edge/imagebuilds",
       "perspective": "acm",
       "section": "fctl"
     }
@@ -58,9 +58,9 @@
   {
     "type": "console.navigation/href",
     "properties": {
-      "id": "fctl-imagebuilds",
-      "name": "%plugin__flightctl-plugin~Image builds%",
-      "href": "/edge/imagebuilds",
+      "id": "fctl-repositories",
+      "name": "%plugin__flightctl-plugin~Repositories%",
+      "href": "/edge/repositories",
       "perspective": "acm",
       "section": "fctl"
     }


### PR DESCRIPTION
For OCP Plugin, the Repositories and Image Build nav items had swapped placed.
<img width="389" height="336" alt="swap" src="https://github.com/user-attachments/assets/2bf2abe9-2468-4bce-8701-27410293152b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized navigation menu items for Repositories and Image builds sections in the console interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->