### PR TITLE
EDM-3580: Fix error 404 in device catalog for managed devices

### DIFF
--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsCatalog.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsCatalog.tsx
@@ -1,5 +1,5 @@
-import { Device, Fleet, PatchRequest } from '@flightctl/types';
 import * as React from 'react';
+import { Device, Fleet, PatchRequest, ResourceKind } from '@flightctl/types';
 import { Alert, Spinner } from '@patternfly/react-core';
 
 import { useFetch } from '../../../hooks/useFetch';
@@ -8,7 +8,7 @@ import { ROUTE, useNavigate } from '../../../hooks/useNavigate';
 import { useFetchPeriodically } from '../../../hooks/useFetchPeriodically';
 import { getErrorMessage } from '../../..//utils/error';
 import { useTranslation } from '../../../hooks/useTranslation';
-import { getOwnerName } from '../../Fleet/FleetDetails/FleetOwnerLink';
+import { getOwnerName } from '../../../utils/resource';
 
 type DeviceDetailsCatalogProps = {
   device: Device;
@@ -28,8 +28,9 @@ const DeviceDetailsCatalog = ({ device, refetch, canEdit }: DeviceDetailsCatalog
     [refetch, patch, device.metadata.name],
   );
 
+  const fleetOwnerName = getOwnerName(ResourceKind.FLEET, device.metadata.owner);
   const [ownerFleet, loading, error] = useFetchPeriodically<Fleet>({
-    endpoint: device.metadata.owner ? `fleets/${getOwnerName(device.metadata.owner)}` : '',
+    endpoint: fleetOwnerName ? `fleets/${fleetOwnerName}` : '',
   });
 
   if (loading) {
@@ -43,7 +44,7 @@ const DeviceDetailsCatalog = ({ device, refetch, canEdit }: DeviceDetailsCatalog
     );
   }
 
-  return device.metadata.owner ? (
+  return fleetOwnerName ? (
     <ResourceCatalogPage
       canEdit={false}
       hasOwner

--- a/libs/ui-components/src/components/Fleet/FleetDetails/FleetOwnerLink.tsx
+++ b/libs/ui-components/src/components/Fleet/FleetDetails/FleetOwnerLink.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { CodeBranchIcon } from '@patternfly/react-icons/dist/js/icons/code-branch-icon';
+
+import { ResourceKind } from '@flightctl/types';
 import { Link, ROUTE } from '../../../hooks/useNavigate';
-import WithTooltip from '../../common/WithTooltip';
 import { useTranslation } from '../../../hooks/useTranslation';
-
-const rsOwnerRegex = /^ResourceSync\/(?<rsName>.*)$/;
-
-export const getOwnerName = (owner: string | undefined) => rsOwnerRegex.exec(owner || '')?.groups?.rsName;
+import WithTooltip from '../../common/WithTooltip';
+import { getOwnerName } from '../../../utils/resource';
 
 export const RSLink = ({ rsName }: { rsName: string }) => (
   <div>
@@ -15,7 +14,7 @@ export const RSLink = ({ rsName }: { rsName: string }) => (
 );
 
 const FleetOwnerLink = ({ owner }: { owner: string | undefined }) => {
-  const ownerRsName = getOwnerName(owner);
+  const ownerRsName = getOwnerName(ResourceKind.RESOURCE_SYNC, owner);
   if (!ownerRsName) {
     return '-';
   }

--- a/libs/ui-components/src/components/Fleet/FleetRow.tsx
+++ b/libs/ui-components/src/components/Fleet/FleetRow.tsx
@@ -1,15 +1,16 @@
 import * as React from 'react';
 import { ActionsColumn, IAction, OnSelect, Td, Tr } from '@patternfly/react-table';
 
-import { Fleet } from '@flightctl/types';
+import { Fleet, ResourceKind } from '@flightctl/types';
 import { useTranslation } from '../../hooks/useTranslation';
 import { ROUTE, useNavigate } from '../../hooks/useNavigate';
 import { getFleetRolloutStatusWarning } from '../../utils/status/fleet';
+import { getOwnerName } from '../../utils/resource';
 
-import { FleetOwnerLinkIcon, getOwnerName } from './FleetDetails/FleetOwnerLink';
-import FleetStatus from './FleetStatus';
 import ResourceLink from '../common/ResourceLink';
 import FleetDevicesCount from './FleetDetails/FleetDevicesCount';
+import { FleetOwnerLinkIcon } from './FleetDetails/FleetOwnerLink';
+import FleetStatus from './FleetStatus';
 
 type FleetRowProps = {
   fleet: Fleet;
@@ -88,7 +89,7 @@ const FleetRow: React.FC<FleetRowProps> = ({
         }}
       />
       <Td dataLabel={t('Name')}>
-        <FleetOwnerLinkIcon ownerName={getOwnerName(fleet.metadata.owner)}>
+        <FleetOwnerLinkIcon ownerName={getOwnerName(ResourceKind.RESOURCE_SYNC, fleet.metadata.owner)}>
           <ResourceLink id={fleetName} routeLink={ROUTE.FLEET_DETAILS} />
         </FleetOwnerLinkIcon>
       </Td>

--- a/libs/ui-components/src/utils/resource.ts
+++ b/libs/ui-components/src/utils/resource.ts
@@ -1,4 +1,16 @@
-import { ObjectMeta } from '@flightctl/types';
+import { ObjectMeta, ResourceKind } from '@flightctl/types';
+
+export const getOwnerName = (ownerKind: ResourceKind, owner: string | undefined): string | undefined => {
+  if (!owner) {
+    return undefined;
+  }
+  const prefix = `${ownerKind}/`;
+  if (!owner.startsWith(prefix)) {
+    return undefined;
+  }
+  const name = owner.slice(prefix.length);
+  return name.length > 0 ? name : undefined;
+};
 
 export const getResourceId = <R extends { kind: string; metadata: ObjectMeta }>(resource: R) =>
   `${resource.kind}/${resource.metadata.name || ''}`;


### PR DESCRIPTION
To retrieve for the devices's owner fleet, we were attempting to match to a ResourceSync.

After the fix
<img width="2072" height="1347" alt="device-catalog" src="https://github.com/user-attachments/assets/090c0d2b-0d84-477b-a762-b0c039c6a809" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated owner-parsing into a shared utility and updated components to use it. Internal code reorganization only; no changes to visible UI or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->