### PR TITLE
EDM-3320: Fix alignment in table with HelperTextIcon

### DIFF
--- a/libs/ui-components/src/components/Table/Table.css
+++ b/libs/ui-components/src/components/Table/Table.css
@@ -1,0 +1,4 @@
+.fctl-tableth__helper-text .pf-v6-c-button {
+  --pf-v6-c-button--PaddingBlockEnd: 0;
+  --pf-v6-c-button--PaddingBlockStart: 0;
+}

--- a/libs/ui-components/src/components/Table/Table.tsx
+++ b/libs/ui-components/src/components/Table/Table.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { Button, EmptyState, EmptyStateActions, EmptyStateBody, Spinner } from '@patternfly/react-core';
 import { Table as PFTable, TableProps as PFTableProps, Td, Th, ThProps, Thead, Tr } from '@patternfly/react-table';
+import { SearchIcon } from '@patternfly/react-icons/dist/js/icons';
+
 import { useTranslation } from '../../hooks/useTranslation';
 import LabelWithHelperText from '../common/WithHelperText';
-import { SearchIcon } from '@patternfly/react-icons/dist/js/icons';
+import './Table.css';
 
 export type ApiSortTableColumn = {
   id?: string;
@@ -91,7 +93,7 @@ const Table: TableFC = ({
           {!emptyData && singleSelect && <Th screenReaderText={t('Row select')} />}
           {isExpandable && !emptyData && <Th screenReaderText={t('Expand row')} />}
           {columns.map((c) => (
-            <Th key={c.name} {...c.thProps} aria-label={c.name}>
+            <Th key={c.name} {...c.thProps} aria-label={c.name} className="fctl-tableth__helper-text">
               {c.helperText ? (
                 <LabelWithHelperText label={c.name} content={c.helperText} triggerAction="hover" />
               ) : (


### PR DESCRIPTION
Fixes the alignment of the table headers due to the extra padding of the helper text icon.

(Lime line added for alignment comparison)

Before:
<img width="1963" height="488" alt="alignment-before" src="https://github.com/user-attachments/assets/50a5b248-f024-434a-91d8-cf89606dbd14" />

After:
<img width="1963" height="488" alt="alignment-after" src="https://github.com/user-attachments/assets/a80cc2ba-0fa9-4888-b811-2ca504f1ce36" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced table header styling with refined button padding and improved visual consistency in header cell appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->