### PR TITLE
EDM-3073: Use ResourceLink to display fleet names

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -970,7 +970,7 @@
   "Use different update schedules for downloading and installing updates": "Use different update schedules for downloading and installing updates",
   "Deletion of fleet {{fleetId}} failed.": "Deletion of fleet {{fleetId}} failed.",
   "Delete fleet?": "Delete fleet?",
-  "<0>{fleetId}</0> will be deleted permanently. If the device selector of a remaining fleet matches a device in <2>{fleetId}</2>, the device will be moved to the new fleet. If there&apos;s no matching fleet for a device, it will be unlinked from any fleet.": "<0>{fleetId}</0> will be deleted permanently. If the device selector of a remaining fleet matches a device in <2>{fleetId}</2>, the device will be moved to the new fleet. If there&apos;s no matching fleet for a device, it will be unlinked from any fleet.",
+  "<0>{fleetId}</0> will be deleted permanently. If the device selector of a remaining fleet matches a device currently linked to this fleet, the device will be moved to the new fleet. If there&apos;s no matching fleet for a device, it will be unlinked from any fleet.": "<0>{fleetId}</0> will be deleted permanently. If the device selector of a remaining fleet matches a device currently linked to this fleet, the device will be moved to the new fleet. If there&apos;s no matching fleet for a device, it will be unlinked from any fleet.",
   "Are you sure you want to delete?": "Are you sure you want to delete?",
   "Details: {{errorDetails}}": "Details: {{errorDetails}}",
   "Delete fleet": "Delete fleet",

--- a/libs/ui-components/src/components/DetailsPage/DetailsPage.tsx
+++ b/libs/ui-components/src/components/DetailsPage/DetailsPage.tsx
@@ -16,6 +16,7 @@ import DetailsNotFound from './DetailsNotFound';
 import { useTranslation } from '../../hooks/useTranslation';
 import { Link, Route } from '../../hooks/useNavigate';
 import ErrorBoundary from '../common/ErrorBoundary';
+import ResourceLink from '../common/ResourceLink';
 
 import './DetailsPage.css';
 
@@ -84,7 +85,9 @@ const DetailsPage = ({
           <BreadcrumbItem>
             <Link to={resourceLink}>{resourceTypeLabel}</Link>
           </BreadcrumbItem>
-          <BreadcrumbItem isActive>{breadcrumbTitle || id}</BreadcrumbItem>
+          <BreadcrumbItem isActive>
+            <ResourceLink id={breadcrumbTitle || id} />
+          </BreadcrumbItem>
         </Breadcrumb>
       </PageSection>
       <PageSection hasBodyWrapper={false}>
@@ -96,7 +99,7 @@ const DetailsPage = ({
               role="heading"
               {...(titleDataTestId && { 'data-testid': titleDataTestId })}
             >
-              {title || id}
+              {title || <ResourceLink id={id} />}
             </Title>
           </SplitItem>
           <SplitItem>{actions}</SplitItem>

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceFleet.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceFleet.tsx
@@ -9,6 +9,7 @@ import { getDeviceFleet } from '../../../utils/devices';
 import { getCondition } from '../../../utils/api';
 import { useTranslation } from '../../../hooks/useTranslation';
 import { Link, ROUTE } from '../../../hooks/useNavigate';
+import ResourceLink from '../../common/ResourceLink';
 
 import './DeviceFleet.css';
 
@@ -82,7 +83,7 @@ const DeviceFleet = ({ device }: { device?: Device }) => {
   let fleetNameEl: React.ReactNode = null;
   const fleetName = getDeviceFleet(device.metadata);
   if (fleetName) {
-    fleetNameEl = <Link to={{ route: ROUTE.FLEET_DETAILS, postfix: fleetName }}>{fleetName}</Link>;
+    fleetNameEl = <ResourceLink id={fleetName} routeLink={ROUTE.FLEET_DETAILS} />;
   } else if (multipleOwnersCondition) {
     // Device has no owner set, but with the multiple owners condition. The warning icon should be displayed
     fleetNameEl = t('None');

--- a/libs/ui-components/src/components/Fleet/CreateFleet/CreateFleetWizard.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/CreateFleetWizard.tsx
@@ -35,6 +35,7 @@ import ErrorBoundary from '../../common/ErrorBoundary';
 import { usePermissionsContext } from '../../common/PermissionsContext';
 import PageWithPermissions from '../../common/PageWithPermissions';
 import { useAppContext } from '../../../hooks/useAppContext';
+import ResourceLink from '../../common/ResourceLink';
 
 const orderedIds = [generalInfoStepId, deviceTemplateStepId, updatePolicyStepId, reviewStepId];
 
@@ -190,7 +191,7 @@ const CreateFleetWizard = () => {
           </BreadcrumbItem>
           {fleetId && (
             <BreadcrumbItem>
-              <Link to={{ route: ROUTE.FLEET_DETAILS, postfix: fleetId }}>{fleetId}</Link>
+              <ResourceLink id={fleetId} routeLink={ROUTE.FLEET_DETAILS} />
             </BreadcrumbItem>
           )}
           <BreadcrumbItem isActive>{title}</BreadcrumbItem>

--- a/libs/ui-components/src/components/Fleet/DeleteFleetModal/DeleteFleetModal.tsx
+++ b/libs/ui-components/src/components/Fleet/DeleteFleetModal/DeleteFleetModal.tsx
@@ -35,8 +35,8 @@ const DeleteFleetModal = ({ fleetId, onClose }: { fleetId: string; onClose: (has
           <StackItem>
             <Trans t={t}>
               <strong>{fleetId}</strong> will be deleted permanently. If the device selector of a remaining fleet
-              matches a device in <strong>{fleetId}</strong>, the device will be moved to the new fleet. If there&apos;s
-              no matching fleet for a device, it will be unlinked from any fleet.
+              matches a device currently linked to this fleet, the device will be moved to the new fleet. If
+              there&apos;s no matching fleet for a device, it will be unlinked from any fleet.
             </Trans>
           </StackItem>
           <StackItem>{t('Are you sure you want to delete?')}</StackItem>


### PR DESCRIPTION
Use ResourceLink to display the fleet name in the following places:

- Fleet details page (breadcrumb and title)
- Edit fleet (breadcrumb)
- Device list (fleet name column)
- Device details page (fleet name column)

<img width="2811" height="1520" alt="fleet-name" src="https://github.com/user-attachments/assets/bdd8b79c-3384-44b6-a6e2-82e459a95e71" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified fleet-deletion confirmation text: device migration now triggers only when a remaining fleet’s selector matches devices currently linked to the fleet being deleted; other clauses about permanent deletion and unlinking remain intact.

* **Refactor**
  * Unified how fleet and device identifiers are displayed by replacing raw text with a consistent resource link presentation across relevant UI pages and breadcrumbs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->