### PR TITLE
EDM-3617: Do not show decomissioned devices as target

### DIFF
--- a/libs/ui-components/src/components/Device/DevicesPage/useDevices.ts
+++ b/libs/ui-components/src/components/Device/DevicesPage/useDevices.ts
@@ -66,7 +66,7 @@ const getDevicesEndpoint = ({
 
   if (onlyDecommissioned) {
     queryUtils.addQueryConditions(fieldSelectors, 'status.lifecycle.status', decommissionedStatuses);
-  } else if (summaryOnly) {
+  } else {
     queryUtils.addQueryConditions(fieldSelectors, 'status.lifecycle.status', enrolledStatuses);
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where device filtering behavior was inconsistent when viewing non-decommissioned devices, ensuring more reliable and predictable results across all views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->