### PR TITLE
Remove unnecessary client-side filters

### DIFF
--- a/libs/ui-components/src/components/Device/DevicesPage/DevicesPage.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/DevicesPage.tsx
@@ -6,7 +6,6 @@ import ListPage from '../../ListPage/ListPage';
 import ListPageBody from '../../ListPage/ListPageBody';
 import { useTranslation } from '../../../hooks/useTranslation';
 import { useTablePagination } from '../../../hooks/useTablePagination';
-import { isDeviceEnrolled } from '../../../utils/devices';
 import { useDevices } from './useDevices';
 import { useDeviceBackendFilters } from './useDeviceBackendFilters';
 
@@ -16,10 +15,6 @@ import { RESOURCE, VERB } from '../../../types/rbac';
 import { usePermissionsContext } from '../../common/PermissionsContext';
 import EnrolledDevicesTable from './EnrolledDevicesTable';
 import DecommissionedDevicesTable from './DecommissionedDevicesTable';
-
-const removeDecommissionedDevices = (data: DeviceList) => {
-  data.items = data.items.filter(isDeviceEnrolled);
-};
 
 const DevicesPage = ({ canListER }: { canListER: boolean }) => {
   const { t } = useTranslation();
@@ -37,9 +32,7 @@ const DevicesPage = ({ canListER }: { canListER: boolean }) => {
   } = useDeviceBackendFilters();
   const [onlyDecommissioned, setOnlyDecommissioned] = React.useState<boolean>(false);
 
-  const { currentPage, setCurrentPage, onPageFetched, nextContinue, itemCount } = useTablePagination<DeviceList>(
-    onlyDecommissioned ? undefined : removeDecommissionedDevices,
-  );
+  const { currentPage, setCurrentPage, onPageFetched, nextContinue, itemCount } = useTablePagination<DeviceList>();
 
   const {
     devices: data,

--- a/libs/ui-components/src/hooks/useTablePagination.ts
+++ b/libs/ui-components/src/hooks/useTablePagination.ts
@@ -11,9 +11,7 @@ export type PaginationDetails<T extends ApiList> = {
   itemCount: number;
 };
 
-type ProcessData<T> = (data: T) => void;
-
-export const useTablePagination = <T extends ApiList>(processor?: ProcessData<T>): PaginationDetails<T> => {
+export const useTablePagination = <T extends ApiList>(): PaginationDetails<T> => {
   const [currentPage, setCurrentPage] = React.useState<number>(1);
   const [continueTokens, setContinueTokens] = React.useState<string[]>([]);
   const [itemCount, setItemCount] = React.useState<number>(0);
@@ -22,10 +20,6 @@ export const useTablePagination = <T extends ApiList>(processor?: ProcessData<T>
 
   const onPageFetched = React.useCallback(
     (data: T) => {
-      if (processor) {
-        // Can mutate the data
-        processor(data);
-      }
       const prevItems = (currentPage - 1) * PAGE_SIZE;
       setItemCount(prevItems + (data?.items.length || 0) + (data.metadata.remainingItemCount || 0));
 
@@ -43,7 +37,7 @@ export const useTablePagination = <T extends ApiList>(processor?: ProcessData<T>
         );
       }
     },
-    [setContinueTokens, continueTokens, setItemCount, currentPage, processor],
+    [setContinueTokens, continueTokens, setItemCount, currentPage],
   );
 
   return { onPageFetched, currentPage, setCurrentPage, nextContinue, itemCount };


### PR DESCRIPTION
After https://github.com/flightctl/flightctl-ui/pull/605, the UI does not need to filter out decommissioned devices client side since this is done via the API call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed client-side data filtering from the pagination system, streamlining pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->