### PR TITLE
EDM-3577: Apply correct validations to targetRevision

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -1443,6 +1443,7 @@
   "HTTP service": "HTTP service",
   "OCI registry": "OCI registry",
   "Git repository": "Git repository",
+  "Target revision must start with a letter or number and may only contain letters, numbers, dots (.), hyphens (-), underscores (_), and forward slashes (/).": "Target revision must start with a letter or number and may only contain letters, numbers, dots (.), hyphens (-), underscores (_), and forward slashes (/).",
   "Target revision is required.": "Target revision is required.",
   "Must be an absolute path.": "Must be an absolute path.",
   "Value must not exceed {{ maxSize }} MiB when encoded.": "Value must not exceed {{ maxSize }} MiB when encoded.",

--- a/libs/ui-components/src/components/Repository/CreateRepository/utils.ts
+++ b/libs/ui-components/src/components/Repository/CreateRepository/utils.ts
@@ -20,7 +20,12 @@ import {
 import { RepositoryFormValues, ResourceSyncFormValue } from './types';
 import { getErrorMessage } from '../../../utils/error';
 import { appendJSONPatch } from '../../../utils/patch';
-import { MAX_TARGET_REVISION_LENGTH, maxLengthString, validKubernetesDnsSubdomain } from '../../form/validations';
+import {
+  GIT_TARGET_REVISION_REGEX,
+  MAX_TARGET_REVISION_LENGTH,
+  maxLengthString,
+  validKubernetesDnsSubdomain,
+} from '../../form/validations';
 
 const MAX_PATH_LENGTH = 2048;
 const gitRepoUrlRegex = new RegExp(
@@ -656,7 +661,14 @@ export const repoSyncSchema = (t: TFunction, values: ResourceSyncFormValue[]) =>
         targetRevision: maxLengthString(t, {
           maxLength: MAX_TARGET_REVISION_LENGTH,
           fieldName: t('Target revision'),
-        }).defined(t('Target revision is required.')),
+        })
+          .matches(
+            GIT_TARGET_REVISION_REGEX,
+            t(
+              'Target revision must start with a letter or number and may only contain letters, numbers, dots (.), hyphens (-), underscores (_), and forward slashes (/).',
+            ),
+          )
+          .defined(t('Target revision is required.')),
         path: maxLengthString(t, { maxLength: MAX_PATH_LENGTH, fieldName: t('Path') })
           .matches(pathRegex, t('Must be an absolute path.'))
           .defined(t('Path is required.')),

--- a/libs/ui-components/src/components/form/validations.ts
+++ b/libs/ui-components/src/components/form/validations.ts
@@ -55,8 +55,9 @@ const OCI_IMAGE_FULL_REGEXP = /^(?![./_])[a-zA-Z0-9.\-\/:@_+]*$/;
 // Accepts all characters from the above regex, but it rejects leading dot, slash, or underscore
 const OCI_IMAGE_ALLOWED_CHARS_REGEXP = /^[a-zA-Z0-9.\-\/:@_+]*$/;
 const GENERIC_NAME_REGEXP = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
-
 const APPLICATION_VAR_NAME_REGEXP = /^[a-zA-Z_]+[a-zA-Z0-9_]*$/;
+
+export const GIT_TARGET_REVISION_REGEX = /^[a-zA-Z0-9]([a-zA-Z0-9.\/_-])*$/;
 
 const TEMPLATE_VARIABLES_REGEXP = /{{.+?}}/g;
 // Special characters allowed: "dot", "pipe", "spaces" "quote", "backward slash", "underscore", "forward slash", "hyphen"


### PR DESCRIPTION
Validation of `targetRevision` for resource syncs was missing the format check.

<img width="2358" height="1347" alt="target-revision-validation" src="https://github.com/user-attachments/assets/6b924de7-6ee1-4374-b797-8985fb5945a2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened target revision validation: values must start with a letter or number and may only include letters, numbers, dots (.), hyphens (-), underscores (_), and forward slashes (/).
* **Documentation**
  * Added an English validation message for the updated target revision rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->