### PR TITLE
EDM-3687: Allow user to go back to step to fix problems

### DIFF
--- a/libs/cypress/e2e/fleets/createFleet.cy.ts
+++ b/libs/cypress/e2e/fleets/createFleet.cy.ts
@@ -58,6 +58,21 @@ describe('Create fleet form', () => {
     fleetDetailsPage.title.should('have.text', 'sample-fleet');
   });
 
+  it('allows navigating between previous and current step when there are validation errors', () => {
+    fleetsPage.openCreateFleetFormButton.click();
+    createFleetWizardPage = new CreateFleetWizardPage();
+
+    createFleetWizardPage.newFleetNameField.type('another-fleet');
+    createFleetWizardPage.nextFleetWizardButton.should('be.enabled').click();
+
+    createFleetWizardPage.newFleetSystemImageField.type('invalid!oci').blur();
+    createFleetWizardPage.nextFleetWizardButton.should('be.disabled');
+    createFleetWizardPage.backFleetWizardButton.click();
+    createFleetWizardPage.nextFleetWizardButton.should('be.enabled').click();
+
+    createFleetWizardPage.newFleetSystemImageField.should('be.visible').should('have.value', 'invalid!oci');
+  });
+
   it('disables the create fleet button if a fleet with the same name exists', () => {
     const existingFleetName = 'eu-west-prod-001';
     fleetsPage.fleetRow(existingFleetName).should('exist');

--- a/libs/cypress/pages/CreateFleetWizardPage.ts
+++ b/libs/cypress/pages/CreateFleetWizardPage.ts
@@ -59,6 +59,10 @@ export class CreateFleetWizardPage {
     return cy.contains('button', 'Next');
   }
 
+  get backFleetWizardButton() {
+    return cy.contains('button', 'Back');
+  }
+
   get addConfigurationButton() {
     return cy.contains('button', 'Add configuration');
   }

--- a/libs/ui-components/src/components/Catalog/AddCatalogItemWizard/AddCatalogItemWizard.tsx
+++ b/libs/ui-components/src/components/Catalog/AddCatalogItemWizard/AddCatalogItemWizard.tsx
@@ -29,6 +29,7 @@ import {
   getInitialValuesFromItem,
   getValidationSchema,
 } from './utils';
+import { isWizardStepDisabled } from '../../../utils/wizards';
 import { AddCatalogItemFormValues } from './types';
 import FlightCtlWizardFooter from '../../common/FlightCtlWizardFooter';
 import LeaveFormConfirmation from '../../common/LeaveFormConfirmation';
@@ -55,11 +56,6 @@ const getValidStepIds = (formikErrors: FormikErrors<AddCatalogItemFormValues>): 
     validStepIds.push(reviewStepId);
   }
   return validStepIds;
-};
-
-const isDisabledStep = (stepId: string, validStepIds: string[]) => {
-  const validIndex = validStepIds.indexOf(stepId);
-  return validIndex === -1 || validIndex !== orderedIds.indexOf(stepId);
 };
 
 const validateStep = (activeStepId: string, errors: FormikErrors<AddCatalogItemFormValues>) => {
@@ -178,27 +174,21 @@ const AddCatalogItemWizard = () => {
                   <WizardStep
                     name={t('Type and configuration')}
                     id={typeConfigStepId}
-                    isDisabled={isDisabledStep(generalInfoStepId, validStepIds)}
+                    isDisabled={isWizardStepDisabled(typeConfigStepId, orderedIds, validStepIds)}
                   >
                     {currentStep?.id === typeConfigStepId && <TypeConfigStep isEdit={isEdit} isReadOnly={isReadOnly} />}
                   </WizardStep>
                   <WizardStep
                     name={t('Versions')}
                     id={versionStepId}
-                    isDisabled={
-                      isDisabledStep(typeConfigStepId, validStepIds) || isDisabledStep(generalInfoStepId, validStepIds)
-                    }
+                    isDisabled={isWizardStepDisabled(versionStepId, orderedIds, validStepIds)}
                   >
                     {currentStep?.id === versionStepId && <VersionStep isReadOnly={isReadOnly} isEdit={isEdit} />}
                   </WizardStep>
                   <WizardStep
                     name={isReadOnly ? t('Review') : isEdit ? t('Review and save') : t('Review and create')}
                     id={reviewStepId}
-                    isDisabled={
-                      isDisabledStep(versionStepId, validStepIds) ||
-                      isDisabledStep(typeConfigStepId, validStepIds) ||
-                      isDisabledStep(generalInfoStepId, validStepIds)
-                    }
+                    isDisabled={isWizardStepDisabled(reviewStepId, orderedIds, validStepIds)}
                   >
                     {currentStep?.id === reviewStepId && (
                       <ReviewStep error={error} isEdit={isEdit} isReadOnly={isReadOnly} />

--- a/libs/ui-components/src/components/Catalog/EditWizard/EditAppWizard.tsx
+++ b/libs/ui-components/src/components/Catalog/EditWizard/EditAppWizard.tsx
@@ -18,10 +18,27 @@ import UpdateStep, { isUpdateStepValid } from './steps/UpdateStep';
 import ReviewStep from './steps/ReviewStep';
 import LeaveFormConfirmation from '../../common/LeaveFormConfirmation';
 import { validApplicationAndVolumeName } from '../../form/validations';
+import { isWizardStepDisabled } from '../../../utils/wizards';
 
 const versionStepId = 'version-step';
 const configStepId = 'config-step';
 const reviewStepId = 'review-step';
+
+const orderedIds = [versionStepId, configStepId, reviewStepId];
+
+const getValidStepIds = (errors: FormikErrors<AppUpdateFormik>, values: AppUpdateFormik): string[] => {
+  const validStepIds: string[] = [];
+  if (isUpdateStepValid(errors)) {
+    validStepIds.push(versionStepId);
+  }
+  if (isAppConfigStepValid(values, errors)) {
+    validStepIds.push(configStepId);
+  }
+  if (validStepIds.length === orderedIds.length - 1) {
+    validStepIds.push(reviewStepId);
+  }
+  return validStepIds;
+};
 
 const validateUpdateWizardStep = (
   activeStepId: string,
@@ -55,8 +72,7 @@ const WizardContent: React.FC<WizardContentProps> = ({
 
   const { values, errors } = useFormikContext<AppUpdateFormik>();
 
-  const isVersionStepValid = !!values.version;
-  const isConfigStepValid = isAppConfigStepValid(values, errors);
+  const validStepIds = getValidStepIds(errors, values);
 
   return (
     <>
@@ -82,13 +98,17 @@ const WizardContent: React.FC<WizardContentProps> = ({
             <UpdateStep catalogItem={catalogItem} currentVersion={currentVersion} isEdit={!!appSpec} />
           )}
         </WizardStep>
-        <WizardStep name={t('Configuration')} id={configStepId} isDisabled={!isVersionStepValid}>
+        <WizardStep
+          name={t('Configuration')}
+          id={configStepId}
+          isDisabled={isWizardStepDisabled(configStepId, orderedIds, validStepIds)}
+        >
           {currentStep?.id === configStepId && <AppConfigStep isEdit={!!appSpec} />}
         </WizardStep>
         <WizardStep
           name={t('Review and deploy')}
           id={reviewStepId}
-          isDisabled={!isVersionStepValid || !isConfigStepValid}
+          isDisabled={isWizardStepDisabled(reviewStepId, orderedIds, validStepIds)}
         >
           {currentStep?.id === reviewStepId && (
             <ReviewStep error={error} schemaErrors={schemaErrors} isEdit={!!appSpec} />

--- a/libs/ui-components/src/components/Catalog/EditWizard/EditOsWizard.tsx
+++ b/libs/ui-components/src/components/Catalog/EditWizard/EditOsWizard.tsx
@@ -13,9 +13,23 @@ import UpdateStep, { isUpdateStepValid } from './steps/UpdateStep';
 import { getErrorMessage } from '../../../utils/error';
 import ReviewStep from './steps/ReviewStep';
 import LeaveFormConfirmation from '../../common/LeaveFormConfirmation';
+import { isWizardStepDisabled } from '../../../utils/wizards';
 
 const versionStepId = 'version-step';
 const reviewStepId = 'review-step';
+
+const orderedIds = [versionStepId, reviewStepId];
+
+const getValidStepIds = (errors: FormikErrors<InstallSpecFormik>): string[] => {
+  const validStepIds: string[] = [];
+  if (isUpdateStepValid(errors)) {
+    validStepIds.push(versionStepId);
+  }
+  if (validStepIds.length === orderedIds.length - 1) {
+    validStepIds.push(reviewStepId);
+  }
+  return validStepIds;
+};
 
 const validateUpdateWizardStep = (activeStepId: string, errors: FormikErrors<InstallSpecFormik>) => {
   if (activeStepId === versionStepId) return isUpdateStepValid(errors);
@@ -34,9 +48,9 @@ const WizardContent: React.FC<WizardContentProps> = ({ currentVersion, catalogIt
   const { t } = useTranslation();
   const [currentStep, setCurrentStep] = React.useState<WizardStepType>();
 
-  const { values } = useFormikContext<InstallSpecFormik>();
+  const { errors } = useFormikContext<InstallSpecFormik>();
 
-  const isVersionStepValid = !!values.version;
+  const validStepIds = getValidStepIds(errors);
 
   return (
     <>
@@ -62,7 +76,11 @@ const WizardContent: React.FC<WizardContentProps> = ({ currentVersion, catalogIt
             <UpdateStep catalogItem={catalogItem} currentVersion={currentVersion} isEdit={isEdit} />
           )}
         </WizardStep>
-        <WizardStep name={t('Review and deploy')} id={reviewStepId} isDisabled={!isVersionStepValid}>
+        <WizardStep
+          name={t('Review and deploy')}
+          id={reviewStepId}
+          isDisabled={isWizardStepDisabled(reviewStepId, orderedIds, validStepIds)}
+        >
           {currentStep?.id === reviewStepId && <ReviewStep error={error} isEdit={isEdit} />}
         </WizardStep>
       </Wizard>

--- a/libs/ui-components/src/components/Catalog/InstallWizard/InstallAppWizard.tsx
+++ b/libs/ui-components/src/components/Catalog/InstallWizard/InstallAppWizard.tsx
@@ -1,6 +1,6 @@
 import { CatalogItem } from '@flightctl/types/alpha';
 import { Wizard, WizardStep, WizardStepType } from '@patternfly/react-core';
-import { Formik, useFormikContext } from 'formik';
+import { Formik, FormikErrors, useFormikContext } from 'formik';
 import * as React from 'react';
 import * as Yup from 'yup';
 import { load } from 'js-yaml';
@@ -22,6 +22,26 @@ import { useAppContext } from '../../../hooks/useAppContext';
 import { getInitialAppConfig } from './utils';
 import { useSubmitCatalogForm } from '../useSubmitCatalogForm';
 import { validApplicationAndVolumeName } from '../../form/validations';
+import { isWizardStepDisabled } from '../../../utils/wizards';
+
+const orderedIds = [specificationsStepId, selectTargetStepId, appConfigStepId, reviewStepId];
+
+const getValidStepIds = (errors: FormikErrors<InstallAppFormik>, values: InstallAppFormik): string[] => {
+  const validStepIds: string[] = [];
+  if (isSpecsStepValid(errors)) {
+    validStepIds.push(specificationsStepId);
+  }
+  if (isSelectTargetStepValid(errors)) {
+    validStepIds.push(selectTargetStepId);
+  }
+  if (isAppConfigStepValid(values, errors)) {
+    validStepIds.push(appConfigStepId);
+  }
+  if (validStepIds.length === orderedIds.length - 1) {
+    validStepIds.push(reviewStepId);
+  }
+  return validStepIds;
+};
 
 export const validateAppWizardStep: FlightCtlWizardFooterProps<InstallAppFormik>['validateStep'] = (
   activeStepId,
@@ -55,6 +75,7 @@ const InstallAppWizardContent = ({
 }: InstallAppWizardContentProps) => {
   const { t } = useTranslation();
   const { values, errors } = useFormikContext<InstallAppFormik>();
+  const validStepIds = getValidStepIds(errors, values);
   return isSuccessful ? (
     <UpdateSuccessPage />
   ) : (
@@ -81,22 +102,24 @@ const InstallAppWizardContent = ({
             <SpecificationsStep catalogItem={catalogItem} />
           )}
         </WizardStep>
-        <WizardStep name={t('Select target')} id={selectTargetStepId} isDisabled={!isSpecsStepValid(errors)}>
+        <WizardStep
+          name={t('Select target')}
+          id={selectTargetStepId}
+          isDisabled={isWizardStepDisabled(selectTargetStepId, orderedIds, validStepIds)}
+        >
           {currentStep?.id === selectTargetStepId && <SelectTargetStep catalogItem={catalogItem} />}
         </WizardStep>
         <WizardStep
           name={t('Application configuration')}
           id={appConfigStepId}
-          isDisabled={!isSelectTargetStepValid(errors) || !isSpecsStepValid(errors)}
+          isDisabled={isWizardStepDisabled(appConfigStepId, orderedIds, validStepIds)}
         >
           {currentStep?.id === appConfigStepId && <AppConfigStep schemaErrors={schemaErrors} />}
         </WizardStep>
         <WizardStep
           name={t('Review and deploy')}
           id={reviewStepId}
-          isDisabled={
-            !isAppConfigStepValid(values, errors) || !isSpecsStepValid(errors) || !isSelectTargetStepValid(errors)
-          }
+          isDisabled={isWizardStepDisabled(reviewStepId, orderedIds, validStepIds)}
         >
           {currentStep?.id === reviewStepId && <ReviewStep error={error} catalogItem={catalogItem} />}
         </WizardStep>

--- a/libs/ui-components/src/components/Catalog/InstallWizard/InstallOsWizard.tsx
+++ b/libs/ui-components/src/components/Catalog/InstallWizard/InstallOsWizard.tsx
@@ -1,6 +1,6 @@
 import { CatalogItem } from '@flightctl/types/alpha';
 import { Wizard, WizardStep, WizardStepType } from '@patternfly/react-core';
-import { Formik, useFormikContext } from 'formik';
+import { Formik, FormikErrors, useFormikContext } from 'formik';
 import * as React from 'react';
 import * as Yup from 'yup';
 import { Device, Fleet } from '@flightctl/types';
@@ -18,6 +18,26 @@ import UpdateSuccessPage from './UpdateSuccessPage';
 import FlightCtlWizardFooter, { FlightCtlWizardFooterProps } from '../../common/FlightCtlWizardFooter';
 import { useAppContext } from '../../../hooks/useAppContext';
 import { useNavigate } from '../../../hooks/useNavigate';
+import { isWizardStepDisabled } from '../../../utils/wizards';
+
+const getOrderedStepIds = (target: InstallOsFormik['target']) =>
+  target === 'new-device'
+    ? [specificationsStepId, selectTargetStepId]
+    : [specificationsStepId, selectTargetStepId, reviewStepId];
+
+const getValidStepIds = (errors: FormikErrors<InstallOsFormik>, orderedStepIds: string[]): string[] => {
+  const validStepIds: string[] = [];
+  if (isSpecsStepValid(errors)) {
+    validStepIds.push(specificationsStepId);
+  }
+  if (isSelectTargetStepValid(errors)) {
+    validStepIds.push(selectTargetStepId);
+  }
+  if (orderedStepIds.includes(reviewStepId) && validStepIds.length === orderedStepIds.length - 1) {
+    validStepIds.push(reviewStepId);
+  }
+  return validStepIds;
+};
 
 export const validateOsWizardStep: FlightCtlWizardFooterProps<InstallOsFormik>['validateStep'] = (
   activeStepId,
@@ -47,6 +67,8 @@ const InstallOsWizardContent = ({
 }: InstallOsWizardContentProps) => {
   const { t } = useTranslation();
   const { values, errors } = useFormikContext<InstallOsFormik>();
+  const orderedStepIds = getOrderedStepIds(values.target);
+  const validStepIds = getValidStepIds(errors, orderedStepIds);
   const showLeaveConfirmation = !(values.target === 'new-device' && currentStep?.id === selectTargetStepId);
 
   return isSuccessful ? (
@@ -75,14 +97,18 @@ const InstallOsWizardContent = ({
             <SpecificationsStep catalogItem={catalogItem} showNewDevice />
           )}
         </WizardStep>
-        <WizardStep name={t('Select target')} id={selectTargetStepId} isDisabled={!isSpecsStepValid(errors)}>
+        <WizardStep
+          name={t('Select target')}
+          id={selectTargetStepId}
+          isDisabled={isWizardStepDisabled(selectTargetStepId, orderedStepIds, validStepIds)}
+        >
           {currentStep?.id === selectTargetStepId && <SelectTargetStep catalogItem={catalogItem} />}
         </WizardStep>
         {values.target !== 'new-device' && (
           <WizardStep
             name={t('Review and deploy')}
             id={reviewStepId}
-            isDisabled={!isSpecsStepValid(errors) || !isSelectTargetStepValid(errors)}
+            isDisabled={isWizardStepDisabled(reviewStepId, orderedStepIds, validStepIds)}
           >
             {currentStep?.id === reviewStepId && <ReviewStep error={error} catalogItem={catalogItem} />}
           </WizardStep>

--- a/libs/ui-components/src/components/Device/EditDeviceWizard/EditDeviceWizard.tsx
+++ b/libs/ui-components/src/components/Device/EditDeviceWizard/EditDeviceWizard.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Formik } from 'formik';
+import { Formik, FormikErrors } from 'formik';
 import {
   Alert,
   Breadcrumb,
@@ -40,6 +40,26 @@ import EditDeviceWizardFooter from './EditDeviceWizardFooter';
 import PageWithPermissions from '../../common/PageWithPermissions';
 import { usePermissionsContext } from '../../common/PermissionsContext';
 import { RESOURCE, VERB } from '../../../types/rbac';
+import { isWizardStepDisabled } from '../../../utils/wizards';
+
+const orderedIds = [generalInfoStepId, deviceTemplateStepId, deviceUpdatePolicyStepId, reviewDeviceStepId];
+
+const getValidStepIds = (formikErrors: FormikErrors<EditDeviceFormValues>): string[] => {
+  const validStepIds: string[] = [];
+  if (isGeneralInfoStepValid(formikErrors)) {
+    validStepIds.push(generalInfoStepId);
+  }
+  if (isDeviceTemplateStepValid(formikErrors)) {
+    validStepIds.push(deviceTemplateStepId);
+  }
+  if (isUpdatePolicyStepValid(formikErrors)) {
+    validStepIds.push(deviceUpdatePolicyStepId);
+  }
+  if (validStepIds.length === orderedIds.length - 1) {
+    validStepIds.push(reviewDeviceStepId);
+  }
+  return validStepIds;
+};
 
 const EditDeviceWizard = () => {
   const { t } = useTranslation();
@@ -109,13 +129,9 @@ const EditDeviceWizard = () => {
         }}
       >
         {({ values, errors: formikErrors }) => {
-          const generalStepValid = isGeneralInfoStepValid(formikErrors);
-          const templateStepValid = isDeviceTemplateStepValid(formikErrors);
-          const updateStepValid = isUpdatePolicyStepValid(formikErrors);
+          const validStepIds = getValidStepIds(formikErrors);
 
           const isFleetless = !values.fleetMatch;
-          const isTemplateStepDisabled = !(generalStepValid && isFleetless);
-          const isUpdateStepDisabled = !(generalStepValid && templateStepValid && isFleetless);
 
           return (
             <>
@@ -132,13 +148,25 @@ const EditDeviceWizard = () => {
                 <WizardStep name={t('General info')} id={generalInfoStepId}>
                   <GeneralInfoStep />
                 </WizardStep>
-                <WizardStep name={t('Device template')} id={deviceTemplateStepId} isDisabled={isTemplateStepDisabled}>
+                <WizardStep
+                  name={t('Device template')}
+                  id={deviceTemplateStepId}
+                  isDisabled={isWizardStepDisabled(deviceTemplateStepId, orderedIds, validStepIds) || !isFleetless}
+                >
                   <DeviceTemplateStep isFleet={false} labels={device.metadata.labels} />
                 </WizardStep>
-                <WizardStep name={t('Updates')} id={deviceUpdatePolicyStepId} isDisabled={isUpdateStepDisabled}>
+                <WizardStep
+                  name={t('Updates')}
+                  id={deviceUpdatePolicyStepId}
+                  isDisabled={isWizardStepDisabled(deviceUpdatePolicyStepId, orderedIds, validStepIds) || !isFleetless}
+                >
                   <DeviceUpdateStep />
                 </WizardStep>
-                <WizardStep name={t('Review and save')} id={reviewDeviceStepId} isDisabled={!updateStepValid}>
+                <WizardStep
+                  name={t('Review and save')}
+                  id={reviewDeviceStepId}
+                  isDisabled={isWizardStepDisabled(reviewDeviceStepId, orderedIds, validStepIds)}
+                >
                   <ReviewDeviceStep error={submitError} />
                 </WizardStep>
               </Wizard>

--- a/libs/ui-components/src/components/Fleet/CreateFleet/CreateFleetWizard.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/CreateFleetWizard.tsx
@@ -57,9 +57,12 @@ const getValidStepIds = (formikErrors: FormikErrors<FleetFormValues>): string[] 
   return validStepIds;
 };
 
+// Do not disable the current step where there could be validation errors
 const isDisabledStep = (stepId: string, validStepIds: string[]) => {
-  const validIndex = validStepIds.indexOf(stepId);
-  return validIndex === -1 || validIndex !== orderedIds.indexOf(stepId);
+  const stepIdx = orderedIds.findIndex((orderedStepId) => orderedStepId === stepId);
+  return orderedIds.some((orderedId, orderedStepIdx) => {
+    return orderedStepIdx < stepIdx && !validStepIds.includes(orderedId);
+  });
 };
 
 const CreateFleetWizard = () => {

--- a/libs/ui-components/src/components/Fleet/CreateFleet/CreateFleetWizard.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/CreateFleetWizard.tsx
@@ -36,6 +36,7 @@ import { usePermissionsContext } from '../../common/PermissionsContext';
 import PageWithPermissions from '../../common/PageWithPermissions';
 import { useAppContext } from '../../../hooks/useAppContext';
 import ResourceLink from '../../common/ResourceLink';
+import { isWizardStepDisabled } from '../../../utils/wizards';
 
 const orderedIds = [generalInfoStepId, deviceTemplateStepId, updatePolicyStepId, reviewStepId];
 
@@ -55,14 +56,6 @@ const getValidStepIds = (formikErrors: FormikErrors<FleetFormValues>): string[] 
     validStepIds.push(reviewStepId);
   }
   return validStepIds;
-};
-
-// Do not disable the current step where there could be validation errors
-const isDisabledStep = (stepId: string, validStepIds: string[]) => {
-  const stepIdx = orderedIds.findIndex((orderedStepId) => orderedStepId === stepId);
-  return orderedIds.some((orderedId, orderedStepIdx) => {
-    return orderedStepIdx < stepIdx && !validStepIds.includes(orderedId);
-  });
 };
 
 const CreateFleetWizard = () => {
@@ -148,7 +141,7 @@ const CreateFleetWizard = () => {
                 <WizardStep
                   name={t('Device template')}
                   id={deviceTemplateStepId}
-                  isDisabled={isDisabledStep(deviceTemplateStepId, validStepIds)}
+                  isDisabled={isWizardStepDisabled(deviceTemplateStepId, orderedIds, validStepIds)}
                 >
                   {currentStep?.id === deviceTemplateStepId && (
                     <DeviceTemplateStep isFleet isReadOnly={isReadOnly} labels={fleet?.metadata.labels} />
@@ -157,14 +150,14 @@ const CreateFleetWizard = () => {
                 <WizardStep
                   name={t('Updates')}
                   id={updatePolicyStepId}
-                  isDisabled={isDisabledStep(updatePolicyStepId, validStepIds)}
+                  isDisabled={isWizardStepDisabled(updatePolicyStepId, orderedIds, validStepIds)}
                 >
                   {currentStep?.id === updatePolicyStepId && <UpdatePolicyStep isReadOnly={isReadOnly} />}
                 </WizardStep>
                 <WizardStep
                   name={reviewStepLabel}
                   id={reviewStepId}
-                  isDisabled={isDisabledStep(reviewStepId, validStepIds)}
+                  isDisabled={isWizardStepDisabled(reviewStepId, orderedIds, validStepIds)}
                 >
                   {currentStep?.id === reviewStepId && <ReviewStep error={error} />}
                 </WizardStep>

--- a/libs/ui-components/src/components/ImageBuilds/CreateImageBuildWizard/CreateImageBuildWizard.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/CreateImageBuildWizard/CreateImageBuildWizard.tsx
@@ -35,6 +35,7 @@ import { useFetch } from '../../../hooks/useFetch';
 import { useEditImageBuild } from './useEditImageBuild';
 import { OciRegistriesContextProvider, useOciRegistriesContext } from '../OciRegistriesContext';
 import { getImageBuildStatusReason } from '../../../utils/imageBuilds';
+import { isWizardStepDisabled } from '../../../utils/wizards';
 
 const orderedIds = [sourceImageStepId, outputImageStepId, registrationStepId, reviewStepId];
 
@@ -54,13 +55,6 @@ const getValidStepIds = (formikErrors: FormikErrors<ImageBuildFormValues>): stri
     validStepIds.push(reviewStepId);
   }
   return validStepIds;
-};
-
-const isDisabledStep = (stepId: string, validStepIds: string[]) => {
-  const stepIdx = orderedIds.findIndex((stepOrderId) => stepOrderId === stepId);
-  return orderedIds.some((orderedId, orderedStepIdx) => {
-    return orderedStepIdx < stepIdx && !validStepIds.includes(orderedId);
-  });
 };
 
 const CreateImageBuildWizard = () => {
@@ -195,21 +189,21 @@ const CreateImageBuildWizard = () => {
                       <WizardStep
                         name={t('Image output')}
                         id={outputImageStepId}
-                        isDisabled={isDisabledStep(outputImageStepId, validStepIds)}
+                        isDisabled={isWizardStepDisabled(outputImageStepId, orderedIds, validStepIds)}
                       >
                         {currentStep?.id === outputImageStepId && <OutputImageStep />}
                       </WizardStep>
                       <WizardStep
                         name={t('Registration')}
                         id={registrationStepId}
-                        isDisabled={isDisabledStep(registrationStepId, validStepIds)}
+                        isDisabled={isWizardStepDisabled(registrationStepId, orderedIds, validStepIds)}
                       >
                         {currentStep?.id === registrationStepId && <RegistrationStep />}
                       </WizardStep>
                       <WizardStep
                         name={t('Review')}
                         id={reviewStepId}
-                        isDisabled={isDisabledStep(reviewStepId, validStepIds)}
+                        isDisabled={isWizardStepDisabled(reviewStepId, orderedIds, validStepIds)}
                       >
                         {currentStep?.id === reviewStepId && <ReviewStep error={error} />}
                       </WizardStep>

--- a/libs/ui-components/src/components/ImportResourceWizard/ImportResourceWizard.tsx
+++ b/libs/ui-components/src/components/ImportResourceWizard/ImportResourceWizard.tsx
@@ -39,6 +39,26 @@ import PageWithPermissions from '../common/PageWithPermissions';
 import { usePermissionsContext } from '../common/PermissionsContext';
 import FlightCtlWizardFooter from '../common/FlightCtlWizardFooter';
 import { RESOURCE, VERB } from '../../types/rbac';
+import { isWizardStepDisabled } from '../../utils/wizards';
+
+const orderedIds = [repositoryStepId, resourceSyncStepId, reviewStepId];
+
+const getValidStepIds = (
+  values: ImportResourceFormValues,
+  formikErrors: FormikErrors<ImportResourceFormValues>,
+): string[] => {
+  const validStepIds: string[] = [];
+  if (isRepoStepValid(values, formikErrors)) {
+    validStepIds.push(repositoryStepId);
+  }
+  if (isResourceSyncStepValid(formikErrors)) {
+    validStepIds.push(resourceSyncStepId);
+  }
+  if (validStepIds.length === orderedIds.length - 1) {
+    validStepIds.push(reviewStepId);
+  }
+  return validStepIds;
+};
 
 const validationSchema = (t: TFunction) =>
   Yup.lazy((values: ImportResourceFormValues) =>
@@ -137,46 +157,47 @@ const ImportResourceWizardContent = ({
         navigate(successRoute);
       }}
     >
-      {({ values, errors: formikErrors }) => (
-        <>
-          <LeaveFormConfirmation />
-          <Wizard
-            footer={
-              <FlightCtlWizardFooter<ImportResourceFormValues>
-                firstStepId={repositoryStepId}
-                submitStepId={reviewStepId}
-                validateStep={validateFooterStep}
-                saveButtonText={t('Import')}
-              />
-            }
-            onStepChange={(_, step) => setCurrentStep(step)}
-          >
-            <WizardStep name={t('Select or create repository')} id={repositoryStepId}>
-              {(!currentStep || currentStep?.id === repositoryStepId) && (
-                <RepositoryStep repositories={gitRepositories} hasLoaded={!!repoList} />
-              )}
-            </WizardStep>
-            <WizardStep
-              name={t('Add resource sync')}
-              id={resourceSyncStepId}
-              isDisabled={
-                (!currentStep || currentStep?.id === repositoryStepId) && !isRepoStepValid(values, formikErrors)
+      {({ values, errors: formikErrors }) => {
+        const validStepIds = getValidStepIds(values, formikErrors);
+        return (
+          <>
+            <LeaveFormConfirmation />
+            <Wizard
+              footer={
+                <FlightCtlWizardFooter<ImportResourceFormValues>
+                  firstStepId={repositoryStepId}
+                  submitStepId={reviewStepId}
+                  validateStep={validateFooterStep}
+                  saveButtonText={t('Import')}
+                />
               }
+              onStepChange={(_, step) => setCurrentStep(step)}
             >
-              {currentStep?.id === resourceSyncStepId && (
-                <ResourceSyncStep description={resourceSyncDescription} defaultSyncType={resourceSyncType} />
-              )}
-            </WizardStep>
-            <WizardStep
-              name={t('Review')}
-              id={reviewStepId}
-              isDisabled={!isRepoStepValid(values, formikErrors) || !isResourceSyncStepValid(formikErrors)}
-            >
-              {currentStep?.id === reviewStepId && <ReviewStep errors={errors} infoText={reviewInfoText} />}
-            </WizardStep>
-          </Wizard>
-        </>
-      )}
+              <WizardStep name={t('Select or create repository')} id={repositoryStepId}>
+                {(!currentStep || currentStep?.id === repositoryStepId) && (
+                  <RepositoryStep repositories={gitRepositories} hasLoaded={!!repoList} />
+                )}
+              </WizardStep>
+              <WizardStep
+                name={t('Add resource sync')}
+                id={resourceSyncStepId}
+                isDisabled={isWizardStepDisabled(resourceSyncStepId, orderedIds, validStepIds)}
+              >
+                {currentStep?.id === resourceSyncStepId && (
+                  <ResourceSyncStep description={resourceSyncDescription} defaultSyncType={resourceSyncType} />
+                )}
+              </WizardStep>
+              <WizardStep
+                name={t('Review')}
+                id={reviewStepId}
+                isDisabled={isWizardStepDisabled(reviewStepId, orderedIds, validStepIds)}
+              >
+                {currentStep?.id === reviewStepId && <ReviewStep errors={errors} infoText={reviewInfoText} />}
+              </WizardStep>
+            </Wizard>
+          </>
+        );
+      }}
     </Formik>
   );
 };

--- a/libs/ui-components/src/utils/wizards.ts
+++ b/libs/ui-components/src/utils/wizards.ts
@@ -11,9 +11,14 @@
  * isWizardStepDisabled('B', ['A','B','C'], ['A']);      // false — User can access step B since A is valid.
  * isWizardStepDisabled('C', ['A','B','C'], ['A']);      // true  — User is blocked from accessing step C since B is invalid.
  */
+
 export const isWizardStepDisabled = (stepId: string, orderedStepIds: string[], validStepIds: string[]) => {
-  const stepIdx = orderedStepIds.findIndex((orderedStepId) => orderedStepId === stepId);
-  return orderedStepIds.some((orderedId, orderedStepIdx) => {
-    return orderedStepIdx < stepIdx && !validStepIds.includes(orderedId);
-  });
+  const stepIndex = orderedStepIds.indexOf(stepId);
+  if (stepIndex <= 0) {
+    return false;
+  }
+
+  // If there are any invalid steps before the current one, the current step should be disabled.
+  const previousStepIds = orderedStepIds.slice(0, stepIndex);
+  return previousStepIds.some((id) => !validStepIds.includes(id));
 };

--- a/libs/ui-components/src/utils/wizards.ts
+++ b/libs/ui-components/src/utils/wizards.ts
@@ -1,0 +1,19 @@
+/**
+ * Determines if a WizardStep should be disabled.
+ *
+ * A step becomes disabled when any of the steps before it are invalid:
+ * - This allows users to move from the last step they reached, back to previous steps.
+ * - Users cannot skip ahead from an invalid step to a subsequent step.
+ *
+ * @example
+ * // orderedStepIds: [A, B, C]. validStepIds: [A]
+ * isWizardStepDisabled('A', ['A','B','C'], ['A']);      // false — A is valid
+ * isWizardStepDisabled('B', ['A','B','C'], ['A']);      // false — User can access step B since A is valid.
+ * isWizardStepDisabled('C', ['A','B','C'], ['A']);      // true  — User is blocked from accessing step C since B is invalid.
+ */
+export const isWizardStepDisabled = (stepId: string, orderedStepIds: string[], validStepIds: string[]) => {
+  const stepIdx = orderedStepIds.findIndex((orderedStepId) => orderedStepId === stepId);
+  return orderedStepIds.some((orderedId, orderedStepIdx) => {
+    return orderedStepIdx < stepIdx && !validStepIds.includes(orderedId);
+  });
+};


### PR DESCRIPTION
Fixes the issue in the CreateFleetWizard whereby when a validation error was present in step N, and user moved to N-1, then they couldn't move back to step N.