### PR TITLE
EDM-3320: Improve alignment in Device table rows

### DIFF
--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceFleet.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceFleet.tsx
@@ -22,6 +22,7 @@ const FleetLessDevice = () => {
         <Button
           isInline
           variant="plain"
+          style={{ paddingBlock: 0 }}
           icon={<OutlinedQuestionCircleIcon />}
           aria-label={t('Ownership information')}
         />

--- a/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestTableRow.tsx
+++ b/libs/ui-components/src/components/EnrollmentRequest/EnrollmentRequestTableRow.tsx
@@ -69,6 +69,7 @@ const EnrollmentRequestTableRow: React.FC<EnrollmentRequestTableRow> = ({
         <Td dataLabel={t('Approve')}>
           <Button
             variant="link"
+            isInline
             onClick={approveEnrollment}
             data-testid={`enrollment-request-approve-button-${rowIndex}`}
           >

--- a/libs/ui-components/src/components/common/CopyButton.tsx
+++ b/libs/ui-components/src/components/common/CopyButton.tsx
@@ -1,16 +1,15 @@
 import * as React from 'react';
+import { Button, Icon, Tooltip } from '@patternfly/react-core';
 import { CopyIcon } from '@patternfly/react-icons/dist/js/icons/copy-icon';
-import { Button, ButtonProps, Icon, Tooltip } from '@patternfly/react-core';
 
 import { useTranslation } from '../../hooks/useTranslation';
 
 interface CopyButtonProps {
   text: string;
-  variant?: ButtonProps['variant'];
   ariaLabel?: string;
 }
 
-const CopyButton = ({ ariaLabel, text, variant }: CopyButtonProps) => {
+const CopyButton = ({ ariaLabel, text }: CopyButtonProps) => {
   const { t } = useTranslation();
 
   const [copied, setCopied] = React.useState(false);
@@ -37,8 +36,9 @@ const CopyButton = ({ ariaLabel, text, variant }: CopyButtonProps) => {
   return (
     <Tooltip content={copied ? t('Copied!') : ariaLabel || t('Copy text')}>
       <Button
-        variant={variant || 'plain'}
-        isInline={variant === 'link'}
+        variant="plain"
+        isInline
+        style={{ paddingBlock: 0 }}
         onClick={onCopy}
         icon={
           <Icon size="sm">

--- a/libs/ui-components/src/components/modals/ApproveDeviceModal/ApproveDeviceForm.tsx
+++ b/libs/ui-components/src/components/modals/ApproveDeviceModal/ApproveDeviceForm.tsx
@@ -10,7 +10,6 @@ import FlightCtlForm from '../../form/FlightCtlForm';
 import { FlightCtlLabel } from '../../../types/extraTypes';
 import { useTranslation } from '../../../hooks/useTranslation';
 import useDeviceLabelMatch from '../../../hooks/useDeviceLabelMatch';
-import ResourceLink from '../../common/ResourceLink';
 import DeviceLabelMatch from './DeviceLabelMatch';
 
 export type ApproveDeviceFormValues = {
@@ -42,7 +41,7 @@ const ApproveDeviceForm: React.FC<ApproveDeviceFormProps> = ({ enrollmentRequest
         isDisabled={!!defaultAlias}
       />
       <FormGroup label={t('Name')} aria-label={t('Name')}>
-        <ResourceLink id={enrollmentRequest.metadata.name as string} variant="full" />
+        {enrollmentRequest.metadata.name}
       </FormGroup>
       <FormGroup label={t('Labels')}>
         <LabelsField name="labels" onChangeCallback={matchLabelsOnChange} />


### PR DESCRIPTION
Simplified display to make all columns in EnrolledDevicesTable vertically aligned.
See screenshot with added guidelines to validate alignment is correct.

<img width="1736" height="1061" alt="alignment-final" src="https://github.com/user-attachments/assets/482d52a6-ac62-42fa-9828-d92cd0376bad" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted button spacing and inline presentation for help/row actions and copy controls.

* **Refactor**
  * Standardized copy button to a consistent plain, inline appearance.
  * Enrollment approval now displays request name as plain text instead of a linked element.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->