### PR TITLE
Update go 1.25 (#629)

### DIFF
--- a/packaging/images/el10/Containerfile
+++ b/packaging/images/el10/Containerfile
@@ -12,7 +12,7 @@ ENV NODE_OPTIONS='--max-old-space-size=8192'
 RUN npm ci
 RUN npm run build
 
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as proxy-build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as proxy-build
 WORKDIR /app
 COPY proxy /app
 USER 0

--- a/packaging/images/el10/Containerfile.ocp
+++ b/packaging/images/el10/Containerfile.ocp
@@ -14,7 +14,7 @@ ARG PLUGIN_VERSION=""
 ENV PLUGIN_VERSION=$PLUGIN_VERSION
 RUN npm run build:ocp
 
-FROM registry.access.redhat.com/ubi10/go-toolset:1.24.6-1763548447 as proxy-build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.25.8-1774618351 as proxy-build
 WORKDIR /app
 COPY proxy /app
 USER 0

--- a/packaging/images/el9/Containerfile
+++ b/packaging/images/el9/Containerfile
@@ -12,7 +12,7 @@ ENV NODE_OPTIONS='--max-old-space-size=8192'
 RUN npm ci
 RUN npm run build
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as proxy-build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as proxy-build
 WORKDIR /app
 COPY proxy /app
 USER 0

--- a/packaging/images/el9/Containerfile.ocp
+++ b/packaging/images/el9/Containerfile.ocp
@@ -14,7 +14,7 @@ ARG PLUGIN_VERSION=""
 ENV PLUGIN_VERSION=$PLUGIN_VERSION
 RUN npm run build:ocp
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as proxy-build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as proxy-build
 WORKDIR /app
 COPY proxy /app
 USER 0

--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl-ui
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.25.8
 
 require (
 	github.com/flightctl/flightctl v1.0.0


### PR DESCRIPTION
* Update go to 1.25.x
* Use new go-toolset tags for el9 and el10

(cherry picked from commit 2e10a91a9185da088fd8afe3491e6377006254b1)