### PR TITLE
EDM-3810: Add data-testid hooks for Cypress E2E

### DIFF
--- a/apps/standalone/src/app/components/AppLayout/AppToolbar.tsx
+++ b/apps/standalone/src/app/components/AppLayout/AppToolbar.tsx
@@ -112,6 +112,7 @@ const AppToolbar = () => {
             toggle={(toggleRef) => (
               <MenuToggle
                 aria-label={t('Help menu')}
+                data-testid="masthead-help-menu"
                 ref={toggleRef}
                 variant="plain"
                 onClick={() => setHelpDropdownOpen(!helpDropdownOpen)}
@@ -122,6 +123,7 @@ const AppToolbar = () => {
             popperProps={{ position: 'right' }}
           >
             <DropdownItem
+              data-testid="masthead-command-line-tools"
               onClick={() => {
                 navigate(ROUTE.COMMAND_LINE_TOOLS);
               }}

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsPage.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceDetailsPage.tsx
@@ -172,6 +172,7 @@ const DeviceDetailsPage = ({ children, hideTerminal }: DeviceDetailsPageProps) =
             <DropdownList>
               {hasEditPermissions && (
                 <DropdownItem
+                  data-testid="device-details-menu-edit-configurations"
                   onClick={() => navigate({ route: ROUTE.DEVICE_EDIT, postfix: deviceId })}
                   {...editActionProps}
                 >

--- a/libs/ui-components/src/components/Device/DevicesPage/EnrolledDeviceTableRow.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/EnrolledDeviceTableRow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ActionsColumn, OnSelect, Td, Tr } from '@patternfly/react-table';
+import { ActionsColumn, IAction, OnSelect, Td, Tr } from '@patternfly/react-table';
 
 import { Device } from '@flightctl/types';
 import DeviceFleet from '../DeviceDetails/DeviceFleet';
@@ -53,6 +53,42 @@ const EnrolledDeviceTableRow = ({
 
   const columnIds = React.useMemo(() => deviceColumns.map(({ id }) => id), [deviceColumns]);
 
+  const actionItems: IAction[] = [
+    ...(canEdit
+      ? [
+          {
+            title: t('Edit device configurations'),
+            'data-testid': 'device-row-menu-edit-configurations',
+            onClick: () => navigate({ route: ROUTE.DEVICE_EDIT, postfix: deviceName }),
+            ...editActionProps,
+          } as IAction,
+        ]
+      : []),
+    {
+      title: t('View device details'),
+      'data-testid': 'device-row-menu-view-details',
+      onClick: () => navigate({ route: ROUTE.DEVICE_DETAILS, postfix: deviceName }),
+    } as IAction,
+    ...(canResume && resumeAction
+      ? [
+          resumeAction({
+            resourceId: deviceName,
+            resourceName: deviceAlias,
+            disabledReason: resumeDisabledReason,
+          }),
+        ]
+      : []),
+    ...(canDecommission && decommissionAction
+      ? [
+          decommissionAction({
+            resourceId: deviceName,
+            resourceName: deviceAlias,
+            disabledReason: decommissionDisabledReason,
+          }),
+        ]
+      : []),
+  ];
+
   return (
     <Tr data-testid={`enrolled-device-row-${rowIndex}`}>
       <Td
@@ -69,7 +105,7 @@ const EnrolledDeviceTableRow = ({
             id={deviceName}
             name={deviceAlias || t('Untitled')}
             routeLink={ROUTE.DEVICE_DETAILS}
-            data-testid={`device-name-link-${rowIndex}`}
+            data-testid={`device-name-link-${deviceName}`}
           />
         </Td>
       )}
@@ -99,42 +135,8 @@ const EnrolledDeviceTableRow = ({
         </Td>
       )}
       {!hideActions && (
-        <Td isActionCell data-testid={`device-row-actions-${rowIndex}`}>
-          <ActionsColumn
-            items={[
-              ...(canEdit
-                ? [
-                    {
-                      title: t('Edit device configurations'),
-                      onClick: () => navigate({ route: ROUTE.DEVICE_EDIT, postfix: deviceName }),
-                      ...editActionProps,
-                    },
-                  ]
-                : []),
-              {
-                title: t('View device details'),
-                onClick: () => navigate({ route: ROUTE.DEVICE_DETAILS, postfix: deviceName }),
-              },
-              ...(canResume && resumeAction
-                ? [
-                    resumeAction({
-                      resourceId: deviceName,
-                      resourceName: deviceAlias,
-                      disabledReason: resumeDisabledReason,
-                    }),
-                  ]
-                : []),
-              ...(canDecommission && decommissionAction
-                ? [
-                    decommissionAction({
-                      resourceId: deviceName,
-                      resourceName: deviceAlias,
-                      disabledReason: decommissionDisabledReason,
-                    }),
-                  ]
-                : []),
-            ]}
-          />
+        <Td isActionCell data-testid={`device-row-actions-${deviceName}`}>
+          <ActionsColumn items={actionItems} />
         </Td>
       )}
     </Tr>

--- a/libs/ui-components/src/components/Fleet/CreateFleet/steps/GeneralInfoStep.tsx
+++ b/libs/ui-components/src/components/Fleet/CreateFleet/steps/GeneralInfoStep.tsx
@@ -35,7 +35,7 @@ const GeneralInfoStep = ({ isEdit, isReadOnly }: GeneralInfoStepProps) => {
         validations={getDnsSubdomainValidations(t)}
       />
       <FormGroup label={t('Fleet labels')}>
-        <LabelsField name="fleetLabels" isDisabled={isReadOnly} />
+        <LabelsField name="fleetLabels" isDisabled={isReadOnly} labelGroupTestId="fleet-create-wizard-fleet-labels" />
       </FormGroup>
       <FormGroup label={t('Device selector')}>
         <DeviceLabelSelector isReadOnly={isReadOnly} />

--- a/libs/ui-components/src/components/Fleet/FleetDetails/FleetDetailsPage.tsx
+++ b/libs/ui-components/src/components/Fleet/FleetDetails/FleetDetailsPage.tsx
@@ -48,6 +48,7 @@ const FleetDetailPage = () => {
       loading={isLoading}
       error={error}
       id={fleetId}
+      titleDataTestId="fleet-details-title"
       resourceLink={ROUTE.FLEETS}
       resourceType="Fleets"
       resourceTypeLabel={t('Fleets')}
@@ -64,12 +65,18 @@ const FleetDetailPage = () => {
           <DetailsPageActions>
             <DropdownList>
               {isManaged && (
-                <DropdownItem onClick={() => navigate({ route: ROUTE.FLEET_EDIT, postfix: fleetId })}>
+                <DropdownItem
+                  data-testid="fleet-details-menu-view-configurations"
+                  onClick={() => navigate({ route: ROUTE.FLEET_EDIT, postfix: fleetId })}
+                >
                   {t('View fleet configurations')}
                 </DropdownItem>
               )}
               {canEdit && !isManaged && (
-                <DropdownItem onClick={() => navigate({ route: ROUTE.FLEET_EDIT, postfix: fleetId })}>
+                <DropdownItem
+                  data-testid="fleet-details-menu-edit-configurations"
+                  onClick={() => navigate({ route: ROUTE.FLEET_EDIT, postfix: fleetId })}
+                >
                   {t('Edit fleet configurations')}
                 </DropdownItem>
               )}

--- a/libs/ui-components/src/components/Fleet/FleetRow.tsx
+++ b/libs/ui-components/src/components/Fleet/FleetRow.tsx
@@ -93,11 +93,7 @@ const FleetRow: React.FC<FleetRowProps> = ({
       />
       <Td dataLabel={t('Name')}>
         <FleetOwnerLinkIcon ownerName={getOwnerName(ResourceKind.RESOURCE_SYNC, fleet.metadata.owner)}>
-          <ResourceLink
-            id={fleetName}
-            routeLink={ROUTE.FLEET_DETAILS}
-            data-testid={`fleet-name-link-${fleetName}`}
-          />
+          <ResourceLink id={fleetName} routeLink={ROUTE.FLEET_DETAILS} data-testid={`fleet-name-link-${fleetName}`} />
         </FleetOwnerLinkIcon>
       </Td>
       <Td dataLabel={t('System image')}>{fleet.spec.template.spec.os?.image || '-'}</Td>

--- a/libs/ui-components/src/components/Fleet/FleetRow.tsx
+++ b/libs/ui-components/src/components/Fleet/FleetRow.tsx
@@ -32,14 +32,16 @@ const useFleetActions = (fleetName: string, isManaged: boolean, canEdit: boolean
 
   actions.push({
     title: t('View fleet details'),
+    'data-testid': 'fleet-row-menu-view-details',
     onClick: () => navigate({ route: ROUTE.FLEET_DETAILS, postfix: fleetName }),
-  });
+  } as IAction);
 
   // If users can't edit, the wizard will be in read-only mode
   actions.push({
     title: isManaged || !canEdit ? t('View fleet configurations') : t('Edit fleet configurations'),
+    'data-testid': isManaged || !canEdit ? 'fleet-row-menu-view-configurations' : 'fleet-row-menu-edit-configurations',
     onClick: () => navigate({ route: ROUTE.FLEET_EDIT, postfix: fleetName }),
-  });
+  } as IAction);
   return actions;
 };
 
@@ -65,6 +67,7 @@ const FleetRow: React.FC<FleetRowProps> = ({
   if (canDelete) {
     actions.push({
       title: t('Delete fleet'),
+      'data-testid': 'fleet-row-menu-delete-fleet',
       onClick: onDeleteClick,
       tooltipProps: isManaged
         ? {
@@ -74,7 +77,7 @@ const FleetRow: React.FC<FleetRowProps> = ({
           }
         : undefined,
       isAriaDisabled: isManaged,
-    });
+    } as IAction);
   }
 
   return (
@@ -90,7 +93,11 @@ const FleetRow: React.FC<FleetRowProps> = ({
       />
       <Td dataLabel={t('Name')}>
         <FleetOwnerLinkIcon ownerName={getOwnerName(ResourceKind.RESOURCE_SYNC, fleet.metadata.owner)}>
-          <ResourceLink id={fleetName} routeLink={ROUTE.FLEET_DETAILS} />
+          <ResourceLink
+            id={fleetName}
+            routeLink={ROUTE.FLEET_DETAILS}
+            data-testid={`fleet-name-link-${fleetName}`}
+          />
         </FleetOwnerLinkIcon>
       </Td>
       <Td dataLabel={t('System image')}>{fleet.spec.template.spec.os?.image || '-'}</Td>
@@ -101,11 +108,11 @@ const FleetRow: React.FC<FleetRowProps> = ({
           error={fleetRolloutError}
         />
       </Td>
-      <Td dataLabel={t('Status')}>
+      <Td dataLabel={t('Status')} data-testid={`fleet-row-status-${fleetName}`}>
         <FleetStatus fleet={fleet} />
       </Td>
       {!hideActions && (
-        <Td isActionCell>
+        <Td isActionCell data-testid={`fleet-row-actions-${fleetName}`}>
           <ActionsColumn items={actions} />
         </Td>
       )}

--- a/libs/ui-components/src/components/Fleet/FleetsPage.tsx
+++ b/libs/ui-components/src/components/Fleet/FleetsPage.tsx
@@ -54,14 +54,14 @@ const FleetPageActions = ({ createText }: { createText?: string }) => {
     <Split hasGutter>
       {canCreateFleet && (
         <SplitItem>
-          <Button variant="primary" onClick={() => navigate(ROUTE.FLEET_CREATE)}>
+          <Button variant="primary" onClick={() => navigate(ROUTE.FLEET_CREATE)} data-testid="toolbar-create-fleet">
             {createText || t('Create a fleet')}
           </Button>
         </SplitItem>
       )}
       {canImportFleet && (
         <SplitItem>
-          <Button variant="secondary" onClick={() => navigate(ROUTE.FLEET_IMPORT)}>
+          <Button variant="secondary" onClick={() => navigate(ROUTE.FLEET_IMPORT)} data-testid="toolbar-import-fleets">
             {t('Import fleets')}
           </Button>
         </SplitItem>
@@ -144,7 +144,12 @@ const FleetTable = () => {
           )}
           {canDelete && (
             <ToolbarItem>
-              <Button isDisabled={!hasSelectedRows} onClick={() => setIsMassDeleteModalOpen(true)} variant="secondary">
+              <Button
+                isDisabled={!hasSelectedRows}
+                onClick={() => setIsMassDeleteModalOpen(true)}
+                variant="secondary"
+                data-testid="toolbar-delete-fleets"
+              >
                 {t('Delete fleets')}
               </Button>
             </ToolbarItem>

--- a/libs/ui-components/src/components/Repository/CreateRepository/CreateRepositoryForm.tsx
+++ b/libs/ui-components/src/components/Repository/CreateRepository/CreateRepositoryForm.tsx
@@ -422,6 +422,7 @@ const CreateRepositoryFormContent = ({ isEdit, onClose, options, children }: Cre
           {showResourceSyncs && canCreateRS && (
             <Checkbox
               id="use-resource-syncs"
+              data-testid="repository-form-use-resource-syncs"
               className="fctl-create-repo__rs-checkbox"
               label={
                 <LabelWithHelperText

--- a/libs/ui-components/src/components/Repository/RepositoryList.tsx
+++ b/libs/ui-components/src/components/Repository/RepositoryList.tsx
@@ -109,18 +109,19 @@ const RepositoryTableRow = ({
   const navigate = useNavigate();
 
   const actions: IAction[] = [];
+  const repoName = repository.metadata.name as string;
   if (canEdit) {
     actions.push({
       title: t('Edit repository'),
       onClick: () => navigate({ route: ROUTE.REPO_EDIT, postfix: repository.metadata.name }),
-      'data-testid': `repository-dropdown-edit-${rowIndex}`,
+      'data-testid': 'repository-row-menu-edit-repository',
     } as IAction);
   }
   if (canDelete) {
     actions.push({
       title: t('Delete repository'),
       onClick: () => setDeleteModalRepoId(repository.metadata.name),
-      'data-testid': `repository-dropdown-delete-${rowIndex}`,
+      'data-testid': 'repository-row-menu-delete-repository',
     } as IAction);
   }
   return (
@@ -133,11 +134,7 @@ const RepositoryTableRow = ({
         }}
       />
       <Td dataLabel={t('Name')}>
-        <ResourceLink
-          id={repository.metadata.name as string}
-          routeLink={ROUTE.REPO_DETAILS}
-          data-testid={`repository-name-link-${rowIndex}`}
-        />
+        <ResourceLink id={repoName} routeLink={ROUTE.REPO_DETAILS} data-testid={`repository-name-link-${repoName}`} />
       </Td>
       <Td dataLabel={t('Type')}>{getRepoTypeLabel(t, repository.spec.type)}</Td>
       <Td dataLabel={t('URL')}>{getRepoUrlOrRegistry(repository.spec) || '-'}</Td>
@@ -146,7 +143,7 @@ const RepositoryTableRow = ({
       </Td>
       <Td dataLabel={t('Last transition')}>{getLastTransitionTimeText(repository, t).text}</Td>
       {!!actions.length && (
-        <Td isActionCell data-testid={`repository-row-actions-${rowIndex}`}>
+        <Td isActionCell data-testid={`repository-row-actions-${repoName}`}>
           <ActionsColumn items={actions} />
         </Td>
       )}

--- a/libs/ui-components/src/components/Table/Table.tsx
+++ b/libs/ui-components/src/components/Table/Table.tsx
@@ -69,6 +69,7 @@ export const Table = ({
           {!emptyData && onSelectAll && (
             <Th
               aria-label={t('Select all rows')}
+              data-testid="table-select-all-rows"
               select={{
                 onSelect: (_event, isSelecting) => onSelectAll(isSelecting),
                 isSelected: !!isAllSelected,

--- a/libs/ui-components/src/components/form/LabelsField.tsx
+++ b/libs/ui-components/src/components/form/LabelsField.tsx
@@ -15,12 +15,21 @@ type LabelsFieldProps = {
   addButtonText?: string;
   helperText?: React.ReactNode;
   onChangeCallback?: (newLabels: FlightCtlLabel[], hasErrors: boolean) => void;
+  /** Applied to the PatternFly `LabelGroup` root for E2E selectors (e.g. fleet wizard fleet labels). */
+  labelGroupTestId?: string;
 };
 
 const maxWidthDefaultLabel = '18ch'; // Can fit more chars as it doesn't have a "Close" button
 const maxWidthNonDefaultLabel = '16ch'; // Can fit less chars due to the "Close" button
 
-const LabelsField = ({ name, onChangeCallback, addButtonText, helperText, isLoading }: LabelsFieldProps) => {
+const LabelsField = ({
+  name,
+  onChangeCallback,
+  addButtonText,
+  helperText,
+  isLoading,
+  labelGroupTestId,
+}: LabelsFieldProps) => {
   const [{ value: labels }, meta, { setValue: setLabels }] = useField<FlightCtlLabel[]>(name);
   const updateLabels = async (newLabels: FlightCtlLabel[]) => {
     const errors = await setLabels(newLabels, true);
@@ -68,6 +77,7 @@ const LabelsField = ({ name, onChangeCallback, addButtonText, helperText, isLoad
       <LabelGroup
         numLabels={5}
         isEditable={!isLoading}
+        data-testid={labelGroupTestId}
         addLabelControl={
           <EditableLabelControl
             defaultLabel="key=value"

--- a/libs/ui-components/src/components/modals/massModals/MassDeleteFleetModal/MassDeleteFleetModal.tsx
+++ b/libs/ui-components/src/components/modals/massModals/MassDeleteFleetModal/MassDeleteFleetModal.tsx
@@ -176,7 +176,14 @@ const MassDeleteFleetModal: React.FC<MassDeleteFleetModalProps> = ({ onClose, fl
         </Stack>
       </ModalBody>
       <ModalFooter>
-        <Button key="delete" variant="danger" onClick={deleteFleets} isLoading={isDeleting} isDisabled={isDeleting}>
+        <Button
+          key="delete"
+          variant="danger"
+          onClick={deleteFleets}
+          isLoading={isDeleting}
+          isDisabled={isDeleting}
+          data-testid="modal-delete-fleets-confirm"
+        >
           {t('Delete fleets')}
         </Button>
         <Button key="cancel" variant="link" onClick={onClose} isDisabled={isDeleting}>


### PR DESCRIPTION
Stable selectors for fleets, repositories, devices, masthead, and shared table controls aligned with flightctl-ui-tests flows.

Made-with: Cursor