### PR TITLE
EDM-3387: Allow editing default alias

### DIFF
--- a/libs/ui-components/src/components/modals/ApproveDeviceModal/ApproveDeviceForm.tsx
+++ b/libs/ui-components/src/components/modals/ApproveDeviceModal/ApproveDeviceForm.tsx
@@ -30,7 +30,6 @@ const ApproveDeviceForm: React.FC<ApproveDeviceFormProps> = ({ enrollmentRequest
 
   const disableSubmit = Object.keys(formErrors).length > 0;
   const [matchLabelsOnChange, matchStatus] = useDeviceLabelMatch();
-  const defaultAlias = enrollmentRequest.spec.labels?.alias;
 
   return (
     <FlightCtlForm>
@@ -38,7 +37,6 @@ const ApproveDeviceForm: React.FC<ApproveDeviceFormProps> = ({ enrollmentRequest
         fieldName="deviceAlias"
         aria-label={t('Alias')}
         validations={getLabelValueValidations(t)}
-        isDisabled={!!defaultAlias}
       />
       <FormGroup label={t('Name')} aria-label={t('Name')}>
         {enrollmentRequest.metadata.name}


### PR DESCRIPTION
Now that it's possible for users to provide different default labels, UI should also allow them to modify the "defaultAlias" label.