### PR TITLE
EDM-3917: Allow users to edit and remove default labels on approval

### DIFF
--- a/libs/types/models/EnrollmentRequestApproval.ts
+++ b/libs/types/models/EnrollmentRequestApproval.ts
@@ -7,9 +7,13 @@
  */
 export type EnrollmentRequestApproval = {
   /**
-   * A set of labels to apply to the device.
+   * Labels to set on the device. If replaceLabels is false (default), labels are merged with agent-provided labels from the enrollment request. If replaceLabels is true, labels are used as the complete final set ignoring agent-provided labels.
    */
   labels?: Record<string, string>;
+  /**
+   * Controls whether labels are merged or replaced during approval. If false (default), labels are merged with agent-provided labels from the enrollment request. If true, labels are used as the complete final set and agent-provided labels are ignored.
+   */
+  replaceLabels?: boolean;
   /**
    * Indicates whether the request has been approved.
    */

--- a/libs/ui-components/src/components/form/LabelsField.tsx
+++ b/libs/ui-components/src/components/form/LabelsField.tsx
@@ -19,8 +19,7 @@ type LabelsFieldProps = {
   labelGroupTestId?: string;
 };
 
-const maxWidthDefaultLabel = '18ch'; // Can fit more chars as it doesn't have a "Close" button
-const maxWidthNonDefaultLabel = '16ch'; // Can fit less chars due to the "Close" button
+const maxLabelWidth = '16ch';
 
 const LabelsField = ({
   name,
@@ -90,23 +89,16 @@ const LabelsField = ({
         {labels
           .map((label, originalIndex) => ({ ...label, originalIndex }))
           .filter((l) => !l.key.includes(CATALOG_LABEL))
-          .map(({ key, value, isDefault, originalIndex }) => {
+          .map(({ key, value, originalIndex }) => {
             const text = value ? `${key}=${value}` : key;
             const elKey = `${key}__${originalIndex}`;
-            if (isDefault) {
-              return (
-                <Label key={elKey} textMaxWidth={maxWidthDefaultLabel}>
-                  {text}
-                </Label>
-              );
-            }
 
             const closeButtonProps = isLoading && { isDisabled: true };
-            const isLabelEditable = !isLoading && !isDefault;
+            const isLabelEditable = !isLoading;
             return (
               <Label
                 key={elKey}
-                textMaxWidth={maxWidthNonDefaultLabel}
+                textMaxWidth={maxLabelWidth}
                 closeBtnProps={closeButtonProps}
                 onClose={(e) => onDelete(e, originalIndex)}
                 onEditCancel={(_, prevText) => onEdit(originalIndex, prevText)}

--- a/libs/ui-components/src/components/modals/ApproveDeviceModal/ApproveDeviceModal.tsx
+++ b/libs/ui-components/src/components/modals/ApproveDeviceModal/ApproveDeviceModal.tsx
@@ -26,7 +26,7 @@ const DeviceEnrollmentModal: React.FC<DeviceEnrollmentModalProps> = ({ enrollmen
   return (
     <Formik<ApproveDeviceFormValues>
       initialValues={{
-        labels: fromAPILabel(labels, { isDefault: true }).filter((label) => label.key !== 'alias'),
+        labels: fromAPILabel(labels).filter((label) => label.key !== 'alias'),
         deviceAlias: labels.alias || '',
       }}
       validationSchema={deviceApprovalValidationSchema(t, { massDeviceCount: 0 })}
@@ -41,6 +41,8 @@ const DeviceEnrollmentModal: React.FC<DeviceEnrollmentModalProps> = ({ enrollmen
           await put<EnrollmentRequestApproval>(`enrollmentrequests/${enrollmentRequest.metadata.name}/approval`, {
             approved: true,
             labels: deviceLabels,
+            // "replaceLabels=true" indicates that the labels we're sending are the complete final set
+            replaceLabels: true,
           });
           onClose(true);
         } catch (e) {

--- a/libs/ui-components/src/types/extraTypes.ts
+++ b/libs/ui-components/src/types/extraTypes.ts
@@ -25,7 +25,6 @@ import {
 export interface FlightCtlLabel {
   key: string;
   value?: string;
-  isDefault?: boolean;
 }
 
 export interface ApiQuery {

--- a/libs/ui-components/src/utils/labels.ts
+++ b/libs/ui-components/src/utils/labels.ts
@@ -1,22 +1,15 @@
 import { FlightCtlLabel } from '../types/extraTypes';
 
-type LabelOptions = {
-  isDefault?: boolean;
-};
-
-export const fromAPILabel = (labels: Record<string, string>, options?: LabelOptions): FlightCtlLabel[] =>
+export const fromAPILabel = (labels: Record<string, string>): FlightCtlLabel[] =>
   Object.entries(labels).map((labelEntry) => ({
     key: labelEntry[0],
     value: labelEntry[1],
-    isDefault: options?.isDefault || false,
   }));
 
 export const toAPILabel = (labels: FlightCtlLabel[]): Record<string, string> =>
   labels.reduce(
     (acc, curr) => {
-      if (!curr.isDefault) {
-        acc[curr.key] = curr.value || '';
-      }
+      acc[curr.key] = curr.value || '';
       return acc;
     },
     {} as Record<string, string>,


### PR DESCRIPTION
When approving a single device, the UI loads all default labels in the EnrollmentRequest and they can be updated and deleted. Only the labels defined in the UI by the user will be present in the newly enrolled deviced.

