### PR TITLE
EDM-3993: Fix checkOrigin test for OCP proxy

### DIFF
--- a/proxy/bridge/terminal.go
+++ b/proxy/bridge/terminal.go
@@ -131,7 +131,7 @@ func checkOrigin(r *http.Request) bool {
 	baseURL, err := url.Parse(config.BaseUiUrl)
 	if err != nil {
 		log.WithError(err).Debugf("WebSocket origin check: failed to parse BaseUiUrl")
-	} else if originMatchesConfiguredBaseUI(originURL, baseURL) {
+	} else if clientorigin.FromURL(originURL) == clientorigin.FromURL(baseURL) {
 		return true
 	}
 
@@ -149,10 +149,6 @@ func checkOrigin(r *http.Request) bool {
 		origin, r.Host, config.BaseUiUrl, effectiveOrigin, xfh,
 	)
 	return false
-}
-
-func originMatchesConfiguredBaseUI(originURL, baseURL *url.URL) bool {
-	return clientorigin.FromURL(originURL) == clientorigin.FromURL(baseURL)
 }
 
 // isOpenShiftConsolePluginProxyOriginAllowed permits the console WebSocket backend hop only when

--- a/proxy/bridge/terminal.go
+++ b/proxy/bridge/terminal.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/flightctl/flightctl-ui/common"
 	"github.com/flightctl/flightctl-ui/config"
+	clientorigin "github.com/flightctl/flightctl-ui/origin"
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
 )
@@ -103,13 +104,17 @@ func buildDeviceConsoleURL(r *http.Request) (string, error) {
 
 // checkOrigin validates the Origin header against allowed origins.
 // It allows:
+//   - Requests without an Origin header (same-origin from browsers)
 //   - Requests from the configured BaseUiUrl origin
 //   - Same-origin requests (Origin matches request Host)
-//   - Requests without an Origin header (same-origin from browsers)
+//   - When trusted X-Forwarded-Host is set (OpenShift console plugin proxy), the
+//     effective client-facing origin matches BASE_UI_URL even if Origin is wrong (e.g. http://localhost)
 //
 // Host comparisons are case-insensitive per RFC 3986.
 func checkOrigin(r *http.Request) bool {
 	origin := r.Header.Get("Origin")
+	xfh := r.Header.Get("X-Forwarded-Host")
+	effectiveOrigin := clientorigin.EffectiveRequestOrigin(r)
 
 	// If no Origin header is present, allow the request (same-origin from browsers).
 	if origin == "" {
@@ -118,26 +123,47 @@ func checkOrigin(r *http.Request) bool {
 
 	originURL, err := url.Parse(origin)
 	if err != nil {
-		// Log rejected origin safely using %q to escape user-controlled input and prevent log injection
-		log.Warnf("Rejected WebSocket connection - invalid Origin header: %q", origin)
+		log.Warnf(
+			"Rejected WebSocket connection - invalid Origin header: %q",
+			origin,
+		)
 		return false
 	}
 
 	baseURL, err := url.Parse(config.BaseUiUrl)
 	if err != nil {
 		log.WithError(err).Warnf("Failed to parse BaseUiUrl for origin check")
-	} else if originURL.Scheme == baseURL.Scheme && strings.EqualFold(originURL.Host, baseURL.Host) {
+	} else if originMatchesConfiguredBaseUI(originURL, baseURL) {
 		return true
 	}
 
-	// Allow same-origin requests
+	// Allow same-origin requests (direct access to the proxy, not via console plugin).
 	if strings.EqualFold(originURL.Host, r.Host) {
 		return true
 	}
 
-	// Log rejected origin safely using %q to escape user-controlled input and prevent log injection
-	log.Warnf("Rejected WebSocket connection - unauthorized Origin header: %q", origin)
+	// OpenShift console plugin proxy often forwards a placeholder Origin (e.g. http://localhost)
+	// while setting X-Forwarded-Host/Proto to the real console URL.
+	if config.ShouldTrustForwardedHeaders(r) && strings.TrimSpace(xfh) != "" {
+		if baseURL != nil && clientorigin.FromURL(baseURL) == effectiveOrigin {
+			return true
+		}
+		log.Warnf(
+			"Rejected WebSocket connection - forwarded origin mismatch effectiveOrigin=%q baseUiOrigin=%q",
+			effectiveOrigin, clientorigin.FromURL(baseURL),
+		)
+	} else {
+		log.Warnf(
+			"Rejected WebSocket connection - unauthorized Origin header: %q (request Host=%q, BASE_UI_URL=%q, effectiveOrigin=%q)",
+			origin, r.Host, config.BaseUiUrl, effectiveOrigin,
+		)
+	}
+
 	return false
+}
+
+func originMatchesConfiguredBaseUI(originURL, baseURL *url.URL) bool {
+	return originURL.Scheme == baseURL.Scheme && strings.EqualFold(originURL.Host, baseURL.Host)
 }
 
 func (t TerminalBridge) HandleTerminal(w http.ResponseWriter, r *http.Request) {

--- a/proxy/bridge/terminal.go
+++ b/proxy/bridge/terminal.go
@@ -107,8 +107,9 @@ func buildDeviceConsoleURL(r *http.Request) (string, error) {
 //   - Requests without an Origin header (same-origin from browsers)
 //   - Requests from the configured BaseUiUrl origin
 //   - Same-origin requests (Origin matches request Host)
-//   - When trusted X-Forwarded-Host is set (OpenShift console plugin proxy), the
-//     effective client-facing origin matches BASE_UI_URL even if Origin is wrong (e.g. http://localhost)
+//   - OpenShift console plugin proxy only: Origin is the console's documented placeholder
+//     (http://localhost) and X-Forwarded-Host/Proto match BASE_UI_URL — not a blanket bypass
+//     for arbitrary Origin values when forwarded headers match the destination host
 //
 // Host comparisons are case-insensitive per RFC 3986.
 func checkOrigin(r *http.Request) bool {
@@ -123,47 +124,59 @@ func checkOrigin(r *http.Request) bool {
 
 	originURL, err := url.Parse(origin)
 	if err != nil {
-		log.Warnf(
-			"Rejected WebSocket connection - invalid Origin header: %q",
-			origin,
-		)
+		log.Warnf("Rejected WebSocket connection - invalid Origin header: %q", origin)
 		return false
 	}
 
 	baseURL, err := url.Parse(config.BaseUiUrl)
 	if err != nil {
-		log.WithError(err).Warnf("Failed to parse BaseUiUrl for origin check")
+		log.WithError(err).Debugf("WebSocket origin check: failed to parse BaseUiUrl")
 	} else if originMatchesConfiguredBaseUI(originURL, baseURL) {
 		return true
 	}
 
 	// Allow same-origin requests (direct access to the proxy, not via console plugin).
-	if strings.EqualFold(originURL.Host, r.Host) {
+	if clientorigin.FromURL(originURL) == clientorigin.DirectRequestOrigin(r) {
 		return true
 	}
 
-	// OpenShift console plugin proxy often forwards a placeholder Origin (e.g. http://localhost)
-	// while setting X-Forwarded-Host/Proto to the real console URL.
-	if config.ShouldTrustForwardedHeaders(r) && strings.TrimSpace(xfh) != "" {
-		if baseURL != nil && clientorigin.FromURL(baseURL) == effectiveOrigin {
-			return true
-		}
-		log.Warnf(
-			"Rejected WebSocket connection - forwarded origin mismatch effectiveOrigin=%q baseUiOrigin=%q",
-			effectiveOrigin, clientorigin.FromURL(baseURL),
-		)
-	} else {
-		log.Warnf(
-			"Rejected WebSocket connection - unauthorized Origin header: %q (request Host=%q, BASE_UI_URL=%q, effectiveOrigin=%q)",
-			origin, r.Host, config.BaseUiUrl, effectiveOrigin,
-		)
+	if isOpenShiftConsolePluginProxyOriginAllowed(r, origin, baseURL, xfh, effectiveOrigin) {
+		return true
 	}
 
+	log.Debugf(
+		"Rejected WebSocket connection - Origin=%q requestHost=%q BASE_UI_URL=%q effectiveOrigin=%q xForwardedHost=%q",
+		origin, r.Host, config.BaseUiUrl, effectiveOrigin, xfh,
+	)
 	return false
 }
 
 func originMatchesConfiguredBaseUI(originURL, baseURL *url.URL) bool {
-	return originURL.Scheme == baseURL.Scheme && strings.EqualFold(originURL.Host, baseURL.Host)
+	return clientorigin.FromURL(originURL) == clientorigin.FromURL(baseURL)
+}
+
+// isOpenShiftConsolePluginProxyOriginAllowed permits the console WebSocket backend hop only when
+// Origin is openshift/console's fixed placeholder (http://localhost), not when an attacker
+// supplies another Origin but forges X-Forwarded-Host to match BASE_UI_URL.
+func isOpenShiftConsolePluginProxyOriginAllowed(
+	r *http.Request,
+	origin string,
+	baseURL *url.URL,
+	xfh, effectiveOrigin string,
+) bool {
+	if config.OcpPlugin != "true" {
+		return false
+	}
+	if !config.ShouldTrustForwardedHeaders(r) || strings.TrimSpace(xfh) == "" {
+		return false
+	}
+	if baseURL == nil {
+		return false
+	}
+	if !clientorigin.IsOpenShiftConsoleProxyWebSocketOrigin(origin) {
+		return false
+	}
+	return clientorigin.FromURL(baseURL) == effectiveOrigin
 }
 
 func (t TerminalBridge) HandleTerminal(w http.ResponseWriter, r *http.Request) {

--- a/proxy/origin/origin.go
+++ b/proxy/origin/origin.go
@@ -1,0 +1,83 @@
+package origin
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/flightctl/flightctl-ui/config"
+)
+
+// EffectiveRequest returns the client-facing scheme and host for the request.
+// When trusted X-Forwarded-* headers are present, they define the origin; otherwise r.Host is used.
+func EffectiveRequest(r *http.Request) (scheme, host string) {
+	scheme = "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	host = r.Host
+	if !config.ShouldTrustForwardedHeaders(r) {
+		return scheme, host
+	}
+	if p := r.Header.Get("X-Forwarded-Proto"); p != "" {
+		scheme = strings.TrimSpace(strings.Split(p, ",")[0])
+	}
+	if xfh := r.Header.Get("X-Forwarded-Host"); xfh != "" {
+		host = strings.TrimSpace(strings.Split(xfh, ",")[0])
+	}
+	return scheme, host
+}
+
+// EffectiveRequestOrigin returns the normalized client-facing origin (scheme://host[:port]).
+func EffectiveRequestOrigin(r *http.Request) string {
+	rs, rh := EffectiveRequest(r)
+	return Normalize(rs, rh)
+}
+
+// FromURL returns Normalize for an http(s) URL scheme and host.
+func FromURL(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	return Normalize(u.Scheme, u.Host)
+}
+
+// Normalize returns a canonical origin string for scheme and host (default ports omitted).
+func Normalize(scheme, host string) string {
+	scheme = strings.ToLower(strings.TrimSpace(scheme))
+	host = strings.ToLower(strings.TrimSpace(host))
+
+	hostname, port := splitHostAndPort(host)
+	hostname = formatHostname(hostname)
+
+	if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
+		port = ""
+	}
+
+	if port == "" {
+		return scheme + "://" + hostname
+	}
+	return scheme + "://" + net.JoinHostPort(strings.Trim(hostname, "[]"), port)
+}
+
+func splitHostAndPort(host string) (hostname, port string) {
+	if host == "" {
+		return "", ""
+	}
+	if h, p, err := net.SplitHostPort(host); err == nil {
+		return h, p
+	}
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		return strings.Trim(host, "[]"), ""
+	}
+	return host, ""
+}
+
+func formatHostname(hostname string) string {
+	hostname = strings.Trim(hostname, "[]")
+	if strings.Contains(hostname, ":") {
+		return "[" + hostname + "]"
+	}
+	return hostname
+}

--- a/proxy/origin/origin.go
+++ b/proxy/origin/origin.go
@@ -9,6 +9,20 @@ import (
 	"github.com/flightctl/flightctl-ui/config"
 )
 
+// openshiftConsoleProxyWebSocketOrigin is the Origin openshift/console sets on outbound
+// WebSocket dials to plugin backends (see openshift/console pkg/proxy/proxy.go).
+const openshiftConsoleProxyWebSocketOrigin = "http://localhost"
+
+// IsOpenShiftConsoleProxyWebSocketOrigin reports whether origin is the console proxy's
+// documented placeholder, not an arbitrary cross-site Origin.
+func IsOpenShiftConsoleProxyWebSocketOrigin(origin string) bool {
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	return Normalize(u.Scheme, u.Host) == openshiftConsoleProxyWebSocketOrigin
+}
+
 // EffectiveRequest returns the client-facing scheme and host for the request.
 // When trusted X-Forwarded-* headers are present, they define the origin; otherwise r.Host is used.
 func EffectiveRequest(r *http.Request) (scheme, host string) {
@@ -41,6 +55,16 @@ func FromURL(u *url.URL) string {
 		return ""
 	}
 	return Normalize(u.Scheme, u.Host)
+}
+
+// DirectRequestOrigin returns the normalized origin for the direct connection (r.Host),
+// without using X-Forwarded-* headers.
+func DirectRequestOrigin(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return Normalize(scheme, r.Host)
 }
 
 // Normalize returns a canonical origin string for scheme and host (default ports omitted).


### PR DESCRIPTION
The  `checkOrigin` function was not working well in the case of the OCP plugin, as the proxy sets a hardcoded `http://localhost` origin.

Fix was tested locally and in OpenShift (with and without `enableMultiClusterExtensions`)

Made-with: Cursor