### PR TITLE
EDM-4012: Reset filters when logType selection changes

### DIFF
--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsSearchToolbar.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsSearchToolbar.tsx
@@ -16,7 +16,12 @@ import {
 import { useFormikContext } from 'formik';
 
 import { useTranslation } from '../../../hooks/useTranslation';
-import { DEVICE_LOG_BASE_PATH, DeviceLogCategory, DeviceLogSearchParams } from '../../../utils/deviceLogs';
+import {
+  DEVICE_LOGS_FORM_INITIAL_VALUES,
+  DEVICE_LOG_BASE_PATH,
+  DeviceLogCategory,
+  DeviceLogSearchParams,
+} from '../../../utils/deviceLogs';
 import FormSelect from '../../form/FormSelect';
 import TextField from '../../form/TextField';
 import DeviceLogsPriorityField from './DeviceLogsLevelField';
@@ -37,11 +42,19 @@ const DeviceLogsToolbar = ({ onLogTypeChange }: DeviceLogsToolbarProps) => {
   const { t } = useTranslation();
   const categoryItems = React.useMemo(() => getCategoryItems(t), [t]);
 
-  const { submitForm, isSubmitting, values, errors } = useFormikContext<DeviceLogSearchParams>();
+  const { submitForm, isSubmitting, values, setValues, errors } = useFormikContext<DeviceLogSearchParams>();
   const validationError = React.useMemo(() => {
     const allErrors = Object.values(errors).filter(Boolean);
     return allErrors.join(', ');
   }, [errors]);
+
+  const doChangeLogType = React.useCallback(
+    (value: string) => {
+      setValues({ ...DEVICE_LOGS_FORM_INITIAL_VALUES, category: value as DeviceLogCategory });
+      onLogTypeChange();
+    },
+    [setValues, onLogTypeChange],
+  );
 
   const isSubmitDisabled = isSubmitting || Boolean(validationError);
 
@@ -63,7 +76,7 @@ const DeviceLogsToolbar = ({ onLogTypeChange }: DeviceLogsToolbarProps) => {
                   flexWrap={{ default: 'nowrap' }}
                 >
                   <FlexItem>
-                    <FormSelect name="category" items={categoryItems} onChange={onLogTypeChange} />
+                    <FormSelect name="category" items={categoryItems} onChange={doChangeLogType} />
                   </FlexItem>
                   {values.category === DeviceLogCategory.SYSTEM && (
                     <FlexItem style={{ minWidth: '12rem' }}>

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsTab.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsTab.tsx
@@ -52,9 +52,9 @@ const DeviceLogsTab = ({ deviceId }: DeviceLogsTabProps) => {
   );
 
   const onResetForm = React.useCallback(() => {
-    setLastSearchParams(undefined);
+    setLastSearchParams(DEVICE_LOGS_FORM_INITIAL_VALUES);
     closeSession();
-  }, [closeSession]);
+  }, [closeSession, setLastSearchParams]);
 
   const onDownload = React.useCallback(() => {
     if (!lastSearchParams) {


### PR DESCRIPTION
When log type changes, we must reset the selected filters since not all filters apply to all log types (eg. for "file path" only filter is the file name)