### PR TITLE
EDM-4014 device logs cancel

### DIFF
--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsEmptyState.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsEmptyState.tsx
@@ -18,6 +18,12 @@ import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/js/icons/exc
 import { DEVICE_LOG_BASE_PATH, DeviceLogErrorType } from '../../../utils/deviceLogs';
 import { useTranslation } from '../../../hooks/useTranslation';
 
+// Fixes the color of the text in the "red" banner button.
+const redBannerButtonFixStyle = {
+  '--pf-v6-c-button--m-link--Color': 'var(--pf-t--global--text--color--nonstatus--on-red--default)',
+  '--pf-v6-c-button--m-link--hover--Color': 'var(--pf-t--global--text--color--nonstatus--on-red--default)',
+} as React.CSSProperties;
+
 // Note: Despite the function signature, errorType can actually be a plain string.
 // This happens when we receive an uncontrolled error, and instead of the errorType we store the actual error message.
 const getErrorDetails = (t: TFunction, errorType: DeviceLogErrorType) => {
@@ -94,7 +100,7 @@ export const DeviceLogsDisconnectedBanner = ({ onRetry }: { onRetry: VoidFunctio
       <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
         <FlexItem>{t('Offline/ device lost connection')}</FlexItem>
         <FlexItem>
-          <Button variant="link" onClick={onRetry}>
+          <Button variant="link" onClick={onRetry} style={redBannerButtonFixStyle}>
             {t('Retry')}
           </Button>
         </FlexItem>

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsInnerToolbar.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsInnerToolbar.tsx
@@ -22,22 +22,31 @@ import {
   DeviceLogSearchParams,
   getActiveTimeFilterLabel,
   getDeviceLogLevelLabel,
+  getDeviceLogsFormResetValues,
 } from '../../../utils/deviceLogs';
 
 import './DeviceLogsInnerToolbar.css';
 
 export type DeviceLogsInnerToolbarProps = {
   lastSearchParams: DeviceLogSearchParams;
-  onSearchUpdate: (params: DeviceLogSearchParams) => Promise<boolean>;
-  onResetForm: VoidFunction;
+  isStreaming: boolean;
+  onApplySearchParams: (params: DeviceLogSearchParams) => Promise<boolean>;
+  onStartLiveStream: () => Promise<boolean>;
+  onStopLiveStream: VoidFunction;
+  onClearLiveLogsPreference: VoidFunction;
+  onClearSession: VoidFunction;
   onDownload: VoidFunction;
   onOpenRaw: VoidFunction;
 };
 
 const DeviceLogsInnerToolbar = ({
   lastSearchParams,
-  onSearchUpdate,
-  onResetForm,
+  isStreaming,
+  onApplySearchParams,
+  onStartLiveStream,
+  onStopLiveStream,
+  onClearLiveLogsPreference,
+  onClearSession,
   onDownload,
   onOpenRaw,
   children,
@@ -46,38 +55,31 @@ const DeviceLogsInnerToolbar = ({
   const { setValues, values } = useFormikContext<DeviceLogSearchParams>();
   const hasChildren = Boolean(children);
 
-  const updateLiveLogs = React.useCallback(
-    (checked: boolean) => {
-      const newParams = { ...lastSearchParams, showLiveLogs: checked };
-      void setValues(newParams);
-      return newParams;
-    },
-    [lastSearchParams, setValues],
-  );
+  const onClearSearch = React.useCallback(() => {
+    void setValues(getDeviceLogsFormResetValues(values.category));
+    onClearSession();
+  }, [onClearSession, setValues, values.category]);
 
-  // The "show live logs" switch can only be applied after the logs have been retrieved and it triggers a new search.
   const onShowLiveLogsChange = React.useCallback(
     (_event: React.FormEvent<HTMLInputElement>, checked: boolean) => {
-      const newParams = updateLiveLogs(checked);
-      void onSearchUpdate(newParams);
+      if (checked) {
+        void onStartLiveStream();
+      } else if (isStreaming) {
+        onStopLiveStream();
+      } else if (lastSearchParams.showLiveLogs) {
+        onClearLiveLogsPreference();
+      }
     },
-    [updateLiveLogs, onSearchUpdate],
+    [isStreaming, lastSearchParams.showLiveLogs, onClearLiveLogsPreference, onStartLiveStream, onStopLiveStream],
   );
-
-  const doResetForm = React.useCallback(() => {
-    updateLiveLogs(false);
-    onResetForm();
-  }, [onResetForm, updateLiveLogs]);
 
   const onRemoveFilter = React.useCallback(
     (filterKey: keyof DeviceLogSearchParams, defaultValue: string | undefined) => () => {
-      // We sync the form values with the search params with the current filter removed.
-      // That syncs the form controls to the updated search (including reverting non-persisted form changes)
       const newParams = { ...lastSearchParams, [filterKey]: defaultValue };
       void setValues(newParams);
-      void onSearchUpdate(newParams);
+      void onApplySearchParams(newParams);
     },
-    [onSearchUpdate, lastSearchParams, setValues],
+    [onApplySearchParams, lastSearchParams, setValues],
   );
 
   const activeFilters = React.useMemo(() => {
@@ -147,7 +149,7 @@ const DeviceLogsInnerToolbar = ({
                 </LabelGroup>
               </ToolbarItem>
               <ToolbarItem>
-                <Button variant="link" isInline onClick={doResetForm}>
+                <Button variant="link" isInline onClick={onClearSearch}>
                   {t('Clear search')}
                 </Button>
               </ToolbarItem>
@@ -157,7 +159,7 @@ const DeviceLogsInnerToolbar = ({
                 <Switch
                   id="device-logs-show-live-logs"
                   label={t('Show live logs')}
-                  isChecked={values.showLiveLogs}
+                  isChecked={isStreaming || lastSearchParams.showLiveLogs}
                   onChange={onShowLiveLogsChange}
                 />
               </ToolbarItem>

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsSearchToolbar.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsSearchToolbar.tsx
@@ -17,10 +17,10 @@ import { useFormikContext } from 'formik';
 
 import { useTranslation } from '../../../hooks/useTranslation';
 import {
-  DEVICE_LOGS_FORM_INITIAL_VALUES,
   DEVICE_LOG_BASE_PATH,
   DeviceLogCategory,
   DeviceLogSearchParams,
+  getDeviceLogsFormResetValues,
 } from '../../../utils/deviceLogs';
 import FormSelect from '../../form/FormSelect';
 import TextField from '../../form/TextField';
@@ -46,10 +46,13 @@ const DeviceLogsToolbar = ({ onLogTypeChange, isSubmitting, onCancelSearch }: De
 
   const { submitForm, setValues, values, errors } = useFormikContext<DeviceLogSearchParams>();
 
-  const onCategoryChange = React.useCallback(() => {
-    void setValues(DEVICE_LOGS_FORM_INITIAL_VALUES);
-    onLogTypeChange();
-  }, [onLogTypeChange, setValues]);
+  const onCategoryChange = React.useCallback(
+    (value: string) => {
+      void setValues(getDeviceLogsFormResetValues(value as DeviceLogCategory));
+      onLogTypeChange();
+    },
+    [onLogTypeChange, setValues],
+  );
 
   const validationError = React.useMemo(() => {
     const allErrors = Object.values(errors).filter(Boolean);

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsSearchToolbar.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsSearchToolbar.tsx
@@ -16,7 +16,12 @@ import {
 import { useFormikContext } from 'formik';
 
 import { useTranslation } from '../../../hooks/useTranslation';
-import { DEVICE_LOG_BASE_PATH, DeviceLogCategory, DeviceLogSearchParams } from '../../../utils/deviceLogs';
+import {
+  DEVICE_LOGS_FORM_INITIAL_VALUES,
+  DEVICE_LOG_BASE_PATH,
+  DeviceLogCategory,
+  DeviceLogSearchParams,
+} from '../../../utils/deviceLogs';
 import FormSelect from '../../form/FormSelect';
 import TextField from '../../form/TextField';
 import DeviceLogsPriorityField from './DeviceLogsLevelField';
@@ -31,13 +36,21 @@ const getCategoryItems = (t: TFunction) => ({
 
 export type DeviceLogsToolbarProps = {
   onLogTypeChange: VoidFunction;
+  onCancelSearch: VoidFunction;
+  isSubmitting: boolean;
 };
 
-const DeviceLogsToolbar = ({ onLogTypeChange }: DeviceLogsToolbarProps) => {
+const DeviceLogsToolbar = ({ onLogTypeChange, isSubmitting, onCancelSearch }: DeviceLogsToolbarProps) => {
   const { t } = useTranslation();
   const categoryItems = React.useMemo(() => getCategoryItems(t), [t]);
 
-  const { submitForm, isSubmitting, values, errors } = useFormikContext<DeviceLogSearchParams>();
+  const { submitForm, setValues, values, errors } = useFormikContext<DeviceLogSearchParams>();
+
+  const onCategoryChange = React.useCallback(() => {
+    void setValues(DEVICE_LOGS_FORM_INITIAL_VALUES);
+    onLogTypeChange();
+  }, [onLogTypeChange, setValues]);
+
   const validationError = React.useMemo(() => {
     const allErrors = Object.values(errors).filter(Boolean);
     return allErrors.join(', ');
@@ -63,7 +76,7 @@ const DeviceLogsToolbar = ({ onLogTypeChange }: DeviceLogsToolbarProps) => {
                   flexWrap={{ default: 'nowrap' }}
                 >
                   <FlexItem>
-                    <FormSelect name="category" items={categoryItems} onChange={onLogTypeChange} />
+                    <FormSelect name="category" items={categoryItems} onChange={onCategoryChange} />
                   </FlexItem>
                   {values.category === DeviceLogCategory.SYSTEM && (
                     <FlexItem style={{ minWidth: '12rem' }}>
@@ -108,6 +121,13 @@ const DeviceLogsToolbar = ({ onLogTypeChange }: DeviceLogsToolbarProps) => {
               </ToolbarItem>
             </ToolbarGroup>
             <ToolbarGroup variant="action-group" align={{ default: 'alignEnd' }}>
+              {isSubmitting && (
+                <ToolbarItem>
+                  <Button variant="link" onClick={onCancelSearch}>
+                    {t('Cancel')}
+                  </Button>
+                </ToolbarItem>
+              )}
               <ToolbarItem>
                 <Button
                   variant="primary"

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsTab.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsTab.tsx
@@ -27,31 +27,116 @@ type DeviceLogsTabProps = {
   deviceId: string;
 };
 
+// Adds an extra delay to "Retrieve logs", to ensure the Cancel button and the new action results can be observed clearly.
+const MIN_RETRIEVE_SPINNER_MS = 400;
+
+const toSnapshotParams = (params: DeviceLogSearchParams): DeviceLogSearchParams => ({
+  ...params,
+  showLiveLogs: false,
+});
+
 const DeviceLogsTab = ({ deviceId }: DeviceLogsTabProps) => {
   const { t } = useTranslation();
   const { settings } = useAppContext();
   const { resolvedTheme } = React.useContext(UserPreferencesContext);
   const [lastSearchParams, setLastSearchParams] = React.useState<DeviceLogSearchParams>();
+  const [isRetrievePending, setIsRetrievePending] = React.useState(false);
+  const retrievePendingStartedAtRef = React.useRef(0);
   const logPrefix = settings.isRHEM ? `rhem-${deviceId}` : `flightctl-${deviceId}`;
 
-  const { logs, isConnecting, isFetching, isStreaming, errorTypeOrMsg, search, closeSession, retrySearch } =
-    useDeviceLogs({
-      deviceId,
-    });
-  const lineCount = logs.length;
+  const {
+    logs,
+    isConnecting,
+    isFetching,
+    isStreaming,
+    errorTypeOrMsg,
+    fetchSnapshot,
+    startLiveStream,
+    clearSession,
+    stopLiveStream,
+    closeSession,
+    clearLiveLogsPreference,
+    retrySearch,
+  } = useDeviceLogs({
+    deviceId,
+  });
 
-  const onLogSearch = React.useCallback(
+  const finishRetrievePending = React.useCallback(async () => {
+    if (retrievePendingStartedAtRef.current === 0) {
+      return;
+    }
+    const remaining = MIN_RETRIEVE_SPINNER_MS - (Date.now() - retrievePendingStartedAtRef.current);
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, remaining);
+    });
+    retrievePendingStartedAtRef.current = 0;
+    setIsRetrievePending(false);
+  }, []);
+
+  const runSnapshotSearch = React.useCallback(
     async (params: DeviceLogSearchParams) => {
-      const ok = await search(params);
-      if (ok) {
-        setLastSearchParams(params);
+      const snapshotParams = toSnapshotParams(params);
+      setLastSearchParams(undefined);
+      retrievePendingStartedAtRef.current = Date.now();
+      setIsRetrievePending(true);
+      try {
+        const ok = await fetchSnapshot(snapshotParams);
+        if (ok) {
+          setLastSearchParams(snapshotParams);
+        }
+        return ok;
+      } finally {
+        await finishRetrievePending();
       }
-      return ok;
     },
-    [search],
+    [fetchSnapshot, finishRetrievePending],
   );
 
-  const onResetForm = React.useCallback(() => {
+  const handleStartLiveStream = React.useCallback(async () => {
+    if (!lastSearchParams) {
+      return false;
+    }
+    const ok = await startLiveStream(lastSearchParams);
+    if (ok) {
+      setLastSearchParams({ ...lastSearchParams, showLiveLogs: true });
+    }
+    return ok;
+  }, [lastSearchParams, startLiveStream]);
+
+  const handleStopLiveStream = React.useCallback(() => {
+    stopLiveStream();
+    setLastSearchParams((prev) => (prev ? { ...prev, showLiveLogs: false } : prev));
+  }, [stopLiveStream]);
+
+  const handleClearLiveLogsPreference = React.useCallback(() => {
+    clearLiveLogsPreference();
+    setLastSearchParams((prev) => (prev ? { ...prev, showLiveLogs: false } : prev));
+  }, [clearLiveLogsPreference]);
+
+  const runSearchWithParams = React.useCallback(
+    async (params: DeviceLogSearchParams) => {
+      if (params.showLiveLogs) {
+        const ok = await startLiveStream(params);
+        if (ok) {
+          setLastSearchParams({ ...params, showLiveLogs: true });
+        }
+        return ok;
+      }
+      return runSnapshotSearch(params);
+    },
+    [runSnapshotSearch, startLiveStream],
+  );
+
+  const onClearSession = React.useCallback(() => {
+    retrievePendingStartedAtRef.current = 0;
+    setIsRetrievePending(false);
+    setLastSearchParams(undefined);
+    clearSession();
+  }, [clearSession]);
+
+  const onCloseSession = React.useCallback(() => {
+    retrievePendingStartedAtRef.current = 0;
+    setIsRetrievePending(false);
     setLastSearchParams(undefined);
     closeSession();
   }, [closeSession]);
@@ -72,30 +157,34 @@ const DeviceLogsTab = ({ deviceId }: DeviceLogsTabProps) => {
     const content = getExportableLogContent(logs);
     const isOpen = openTextInNewTab(content);
     if (!isOpen) {
-      // Fallback to download if the tab to show the file could not be opened
       const filename = buildDownloadFilename(logPrefix, lastSearchParams);
       downloadTextAsFile(content, filename);
     }
   }, [logPrefix, logs, lastSearchParams]);
 
+  const lineCount = logs.length;
+  const isSearching = isConnecting || isFetching || isRetrievePending;
   const hasDisplayedLogs = Boolean(lastSearchParams && lineCount > 0);
-  const isInitialLoading = (isConnecting || isFetching) && !hasDisplayedLogs && !isStreaming;
-  const showLogViewer = Boolean(lastSearchParams && (hasDisplayedLogs || isStreaming)) && !isInitialLoading;
-  const showEmptyState = !isInitialLoading && !showLogViewer && !errorTypeOrMsg;
-  const showRetrievalError = !isInitialLoading && !showLogViewer && Boolean(errorTypeOrMsg);
+  const showLogViewer = Boolean(lastSearchParams && (hasDisplayedLogs || isStreaming)) && !isSearching;
+  const showEmptyState = !isSearching && !showLogViewer && !errorTypeOrMsg;
+  const showRetrievalError = !isSearching && !showLogViewer && Boolean(errorTypeOrMsg);
 
   return (
     <Formik<DeviceLogSearchParams>
       initialValues={DEVICE_LOGS_FORM_INITIAL_VALUES}
       validationSchema={getDeviceLogSearchSchema(t)}
-      onSubmit={onLogSearch}
+      onSubmit={runSnapshotSearch}
     >
       <Stack hasGutter>
         <StackItem>
-          <DeviceLogsSearchToolbar onLogTypeChange={onResetForm} />
+          <DeviceLogsSearchToolbar
+            onLogTypeChange={onCloseSession}
+            isSubmitting={isSearching}
+            onCancelSearch={onClearSession}
+          />
         </StackItem>
 
-        {isInitialLoading && (
+        {isSearching && (
           <Bullseye>
             <Stack hasGutter>
               <StackItem>
@@ -121,13 +210,19 @@ const DeviceLogsTab = ({ deviceId }: DeviceLogsTabProps) => {
                   toolbar={
                     <DeviceLogsInnerToolbar
                       lastSearchParams={lastSearchParams}
-                      onSearchUpdate={onLogSearch}
-                      onResetForm={onResetForm}
+                      isStreaming={isStreaming}
+                      onApplySearchParams={runSearchWithParams}
+                      onStartLiveStream={handleStartLiveStream}
+                      onStopLiveStream={handleStopLiveStream}
+                      onClearLiveLogsPreference={handleClearLiveLogsPreference}
+                      onClearSession={onClearSession}
                       onDownload={onDownload}
                       onOpenRaw={onOpenRaw}
                     >
                       {/* If we receive a disconection error after we had retrieved some logs, the logs stay visible. Users can download them and retry if needed. */}
-                      {errorTypeOrMsg === 'CONNECTION_CLOSED' && <DeviceLogsDisconnectedBanner onRetry={retrySearch} />}
+                      {errorTypeOrMsg === 'CONNECTION_CLOSED' && (
+                        <DeviceLogsDisconnectedBanner onRetry={() => void retrySearch()} />
+                      )}
                     </DeviceLogsInnerToolbar>
                   }
                 />

--- a/libs/ui-components/src/hooks/useDeviceLogs.ts
+++ b/libs/ui-components/src/hooks/useDeviceLogs.ts
@@ -21,6 +21,8 @@ const LOGS_WS_METADATA = {
 
 const STDIN_STREAM_BYTE = 0x00;
 const SEARCH_TIMEOUT_MS = 50_000;
+const SEARCH_CANCELLED_MESSAGE = 'CANCELLED';
+const SEARCH_SUPERSEDED_MESSAGE = 'SUPERSEDED';
 const K8S_CHANNEL_STDOUT = 1;
 const K8S_CHANNEL_STDERR = 2;
 const K8S_CHANNEL_STATUS = 3;
@@ -70,6 +72,7 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
   const organizationId = currentOrganization?.id as string;
   const wsRef = React.useRef<WebSocket>();
   const connectPromiseRef = React.useRef<Promise<void>>();
+  const connectRejectRef = React.useRef<(reason?: Error) => void>();
   const activeSearchRef = React.useRef<ActiveSearch>();
   const logSearchSeqRef = React.useRef(0);
   const isMountedRef = React.useRef(true);
@@ -77,6 +80,9 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
   const isStreamingRef = React.useRef(false);
   const partialLineRef = React.useRef('');
   const lastSuccessfulSearchParamsRef = React.useRef<DeviceLogSearchParams>();
+  const requestGenerationRef = React.useRef(0);
+
+  const isActiveSearch = React.useCallback((pending: ActiveSearch) => activeSearchRef.current === pending, []);
 
   const [logs, setLogs] = React.useState<string[]>([]);
   const [isConnecting, setIsConnecting] = React.useState(false);
@@ -117,31 +123,110 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
     connectPromiseRef.current = undefined;
     const ws = wsRef.current;
     if (ws) {
-      intentionalCloseRef.current = true;
+      // Handlers are cleared so this socket's onclose/onerror will not run; do not leave
+      // intentionalCloseRef set — that would make the next connection's disconnect look intentional.
       ws.onopen = null;
       ws.onclose = null;
       ws.onerror = null;
       ws.onmessage = null;
       ws.close();
       wsRef.current = undefined;
-    } else {
-      intentionalCloseRef.current = false;
     }
+    intentionalCloseRef.current = false;
   }, [clearActiveSearch, clearStreamingState]);
 
-  const closeSession = React.useCallback(() => {
-    lastSuccessfulSearchParamsRef.current = undefined;
-    setLogs([]);
-    setErrorTypeOrMsg(undefined);
+  const shouldCloseWebSocket = React.useCallback((): boolean => {
+    if (isStreamingRef.current) {
+      return true;
+    }
+    const ws = wsRef.current;
+    return !ws || ws.readyState !== WebSocket.OPEN;
+  }, []);
+
+  const resetSession = React.useCallback(
+    (options: { forceClose?: boolean; abortMessage?: string }) => {
+      requestGenerationRef.current += 1;
+
+      const pending = activeSearchRef.current;
+      if (pending) {
+        if (pending.timeoutId) {
+          clearTimeout(pending.timeoutId);
+        }
+        activeSearchRef.current = undefined;
+        if (pending.completionKind !== DeviceLogCompletionKind.LIVE_STREAM && options.abortMessage) {
+          pending.reject(new Error(options.abortMessage));
+        }
+      }
+
+      const closeConnection = options.forceClose === true || shouldCloseWebSocket();
+
+      if (closeConnection) {
+        const abortError = options.abortMessage ?? SEARCH_CANCELLED_MESSAGE;
+        connectRejectRef.current?.(new Error(abortError));
+        connectRejectRef.current = undefined;
+        connectPromiseRef.current = undefined;
+        intentionalCloseRef.current = true;
+        closeWebSocket();
+      } else {
+        clearActiveSearch();
+        clearStreamingState();
+      }
+
+      lastSuccessfulSearchParamsRef.current = undefined;
+      if (isMountedRef.current) {
+        setLogs([]);
+        setErrorTypeOrMsg(undefined);
+        setIsConnecting(false);
+        setIsFetching(false);
+      }
+    },
+    [clearActiveSearch, clearStreamingState, closeWebSocket, shouldCloseWebSocket],
+  );
+
+  const clearSession = React.useCallback(
+    () => resetSession({ abortMessage: SEARCH_CANCELLED_MESSAGE }),
+    [resetSession],
+  );
+
+  const closeSession = React.useCallback(() => resetSession({ forceClose: true }), [resetSession]);
+
+  const stopLiveStream = React.useCallback(() => {
+    if (!isStreamingRef.current) {
+      return;
+    }
+    requestGenerationRef.current += 1;
+    intentionalCloseRef.current = true;
     closeWebSocket();
+    if (lastSuccessfulSearchParamsRef.current) {
+      lastSuccessfulSearchParamsRef.current = {
+        ...lastSuccessfulSearchParamsRef.current,
+        showLiveLogs: false,
+      };
+    }
     if (isMountedRef.current) {
-      setIsConnecting(false);
       setIsFetching(false);
+      setErrorTypeOrMsg(undefined);
     }
   }, [closeWebSocket]);
 
+  const abortInFlightSearch = React.useCallback(() => {
+    const pending = activeSearchRef.current;
+    if (!pending) {
+      return;
+    }
+    if (pending.timeoutId) {
+      clearTimeout(pending.timeoutId);
+    }
+    activeSearchRef.current = undefined;
+    if (pending.completionKind !== DeviceLogCompletionKind.LIVE_STREAM) {
+      pending.reject(new Error(SEARCH_SUPERSEDED_MESSAGE));
+    }
+  }, []);
+
+  const cancelSearch = clearSession;
+
   const appendLiveLogLines = React.useCallback((lines: string[]) => {
-    if (lines.length === 0 || !isMountedRef.current) {
+    if (lines.length === 0 || !isMountedRef.current || !isStreamingRef.current) {
       return;
     }
     setLogs((prev) => [...prev, ...lines]);
@@ -149,9 +234,13 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
 
   const handleConsoleFrame = React.useCallback(
     async (message: Blob) => {
-      const bytes = new Uint8Array(await message.arrayBuffer());
       const pending = activeSearchRef.current;
       if (!pending) {
+        return;
+      }
+
+      const bytes = new Uint8Array(await message.arrayBuffer());
+      if (!isActiveSearch(pending)) {
         return;
       }
 
@@ -166,7 +255,7 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
             const active = activeSearchRef.current;
             const buffer = active?.buffer.trim();
             const isLive = active?.completionKind === DeviceLogCompletionKind.LIVE_STREAM;
-            if (active) {
+            if (active && isActiveSearch(active)) {
               if (active.timeoutId) {
                 clearTimeout(active.timeoutId);
               }
@@ -174,16 +263,18 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
               if (active.completionKind !== DeviceLogCompletionKind.LIVE_STREAM) {
                 active.reject(new Error(t('Log retrieval failed with exit code {{code}}', { code: parsed.code })));
               }
-            }
-            clearStreamingState();
-            if (isMountedRef.current) {
-              if (!isLive) {
-                setLogs([]);
+              clearStreamingState();
+              if (isMountedRef.current) {
+                if (!isLive) {
+                  setLogs([]);
+                }
+                setErrorTypeOrMsg(
+                  buffer
+                    ? t('Log retrieval failed with exit code {{code}}', { code: parsed.code })
+                    : 'CONNECTION_CLOSED',
+                );
+                setIsFetching(false);
               }
-              setErrorTypeOrMsg(
-                buffer ? t('Log retrieval failed with exit code {{code}}', { code: parsed.code }) : 'CONNECTION_CLOSED',
-              );
-              setIsFetching(false);
             }
             return;
           }
@@ -195,6 +286,10 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
       }
 
       if (msgType === K8S_CHANNEL_STDOUT || msgType === K8S_CHANNEL_STDERR) {
+        if (!isActiveSearch(pending)) {
+          return;
+        }
+
         if (pending.completionKind === DeviceLogCompletionKind.LIVE_STREAM) {
           const { lines, partialLine } = parseIncrementalDeviceLogStreamChunk(str, partialLineRef.current);
           partialLineRef.current = partialLine;
@@ -207,6 +302,9 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
         if (pending.completionKind === DeviceLogCompletionKind.FILE_PROBE) {
           const probeParsed = parseDeviceLogFileProbeBuffer(pending.buffer);
           if (probeParsed.status === 'incomplete') {
+            return;
+          }
+          if (!isActiveSearch(pending)) {
             return;
           }
           if (pending.timeoutId) {
@@ -240,6 +338,10 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
           return;
         }
 
+        if (!isActiveSearch(pending)) {
+          return;
+        }
+
         if (pending.timeoutId) {
           clearTimeout(pending.timeoutId);
         }
@@ -263,7 +365,7 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
         }
       }
     },
-    [t, appendLiveLogLines, clearStreamingState],
+    [t, appendLiveLogLines, clearStreamingState, isActiveSearch],
   );
 
   const ensureWebSocket = React.useCallback((): Promise<void> => {
@@ -278,6 +380,7 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
     setIsConnecting(true);
 
     connectPromiseRef.current = new Promise<void>((resolve, reject) => {
+      connectRejectRef.current = reject;
       try {
         const wsEndpoint = getWsEndpoint(deviceId);
         const wsMeta = JSON.stringify(LOGS_WS_METADATA);
@@ -293,6 +396,8 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
         };
 
         ws.onopen = () => {
+          intentionalCloseRef.current = false;
+          connectRejectRef.current = undefined;
           connectPromiseRef.current = undefined;
           if (isMountedRef.current) {
             setIsConnecting(false);
@@ -301,18 +406,27 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
         };
 
         ws.onerror = () => {
+          connectRejectRef.current = undefined;
           connectPromiseRef.current = undefined;
+          if (intentionalCloseRef.current) {
+            intentionalCloseRef.current = false;
+            reject(new Error(SEARCH_CANCELLED_MESSAGE));
+            return;
+          }
+          const wasStreaming = isStreamingRef.current;
           if (isMountedRef.current) {
             setIsConnecting(false);
-            setErrorTypeOrMsg('CONNECTION_ERROR');
+            setErrorTypeOrMsg(wasStreaming ? 'CONNECTION_CLOSED' : 'CONNECTION_ERROR');
           }
           reject(new Error('Failed to connect to device'));
           ws.close();
         };
 
         ws.onclose = (evt: CloseEvent) => {
+          connectRejectRef.current = undefined;
           connectPromiseRef.current = undefined;
           wsRef.current = undefined;
+          const wasStreaming = isStreamingRef.current;
           const pendingSearch = activeSearchRef.current;
           if (pendingSearch) {
             if (pendingSearch.timeoutId) {
@@ -329,14 +443,13 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
             setIsFetching(false);
             if (intentionalCloseRef.current) {
               intentionalCloseRef.current = false;
-            } else {
-              if (isErrorCloseEvent(evt)) {
-                setErrorTypeOrMsg('CONNECTION_CLOSED');
-              }
+            } else if (isErrorCloseEvent(evt) || wasStreaming) {
+              setErrorTypeOrMsg('CONNECTION_CLOSED');
             }
           }
         };
       } catch (err) {
+        connectRejectRef.current = undefined;
         connectPromiseRef.current = undefined;
         const msg = getErrorMessage(err);
         if (isMountedRef.current) {
@@ -350,25 +463,27 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
     return connectPromiseRef.current;
   }, [deviceId, organizationId, getWsEndpoint, handleConsoleFrame, clearStreamingState]);
 
-  const search = React.useCallback(
-    async (params: DeviceLogSearchParams): Promise<boolean> => {
-      // When the live stream is turned off, the stream stops and the current log buffer is kept.
-      if (!params.showLiveLogs && isStreamingRef.current) {
-        closeWebSocket();
-        lastSuccessfulSearchParamsRef.current = params;
-        if (isMountedRef.current) {
-          setIsFetching(false);
-          setErrorTypeOrMsg(undefined);
-        }
-        return true;
-      }
+  const executeLogRequest = React.useCallback(
+    async (params: DeviceLogSearchParams, mode: 'snapshot' | 'live'): Promise<boolean> => {
+      const generation = ++requestGenerationRef.current;
+      const isCurrentRequest = () => generation === requestGenerationRef.current;
 
       setErrorTypeOrMsg(undefined);
+      if (isMountedRef.current) {
+        setLogs([]);
+      }
       setIsFetching(true);
 
+      const commandParams: DeviceLogSearchParams =
+        mode === 'live' ? { ...params, showLiveLogs: true } : { ...params, showLiveLogs: false };
+
       try {
-        if (params.showLiveLogs) {
+        // Reuse the console WebSocket for consecutive snapshot searches. Close only when entering/leaving
+        // live follow mode (or when the tab resets the session / cancels / unmounts).
+        if (mode === 'live' || isStreamingRef.current) {
           closeWebSocket();
+        } else {
+          abortInFlightSearch();
         }
 
         await ensureWebSocket();
@@ -400,7 +515,7 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
             ws.send(encodeStdinPayload(command));
           });
 
-        const startLiveStream = (command: string) => {
+        if (mode === 'live') {
           partialLineRef.current = '';
           isStreamingRef.current = true;
           activeSearchRef.current = {
@@ -411,25 +526,28 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
             completionKind: DeviceLogCompletionKind.LIVE_STREAM,
           };
           if (isMountedRef.current) {
-            setLogs([]);
             setIsStreaming(true);
             setIsFetching(false);
           }
-          ws.send(encodeStdinPayload(command));
-        };
-
-        // Send the commands to perform the desired search.
-        if (params.showLiveLogs) {
-          startLiveStream(getRetrieveLogContentCommand(params));
+          ws.send(encodeStdinPayload(getRetrieveLogContentCommand(commandParams)));
         } else {
-          if (needsFileProbe(params, lastSuccessfulSearchParamsRef.current?.logFilePath)) {
-            await runLogRequest(getFileProbeCommand(params), DeviceLogCompletionKind.FILE_PROBE);
+          if (needsFileProbe(commandParams, lastSuccessfulSearchParamsRef.current?.logFilePath)) {
+            await runLogRequest(getFileProbeCommand(commandParams), DeviceLogCompletionKind.FILE_PROBE);
           }
-          await runLogRequest(getRetrieveLogContentCommand(params), DeviceLogCompletionKind.LOGS);
+          await runLogRequest(getRetrieveLogContentCommand(commandParams), DeviceLogCompletionKind.LOGS);
         }
-        lastSuccessfulSearchParamsRef.current = params;
+
+        if (!isCurrentRequest()) {
+          return false;
+        }
+
+        lastSuccessfulSearchParamsRef.current = commandParams;
         return true;
       } catch (e) {
+        if (!isCurrentRequest()) {
+          return false;
+        }
+
         clearStreamingState();
         if (e instanceof DeviceLogFileProbeError) {
           if (isMountedRef.current) {
@@ -440,6 +558,15 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
           return false;
         }
         const err = e instanceof Error ? e : new Error(String(e));
+        if (err.message === SEARCH_CANCELLED_MESSAGE || err.message === SEARCH_SUPERSEDED_MESSAGE) {
+          if (isMountedRef.current) {
+            setLogs([]);
+            setErrorTypeOrMsg(undefined);
+            setIsFetching(false);
+            setIsConnecting(false);
+          }
+          return false;
+        }
         if (isMountedRef.current) {
           if (err.message === 'TIMEOUT' || err.message === 'CONNECTION_ERROR') {
             setErrorTypeOrMsg(err.message as DeviceLogErrorType);
@@ -451,7 +578,17 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
         return false;
       }
     },
-    [ensureWebSocket, closeWebSocket, clearStreamingState],
+    [ensureWebSocket, closeWebSocket, clearStreamingState, abortInFlightSearch],
+  );
+
+  const fetchSnapshot = React.useCallback(
+    (params: DeviceLogSearchParams) => executeLogRequest(params, 'snapshot'),
+    [executeLogRequest],
+  );
+
+  const startLiveStream = React.useCallback(
+    (params: DeviceLogSearchParams) => executeLogRequest(params, 'live'),
+    [executeLogRequest],
   );
 
   React.useEffect(() => {
@@ -461,14 +598,25 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
     };
   }, [closeWebSocket]);
 
+  const clearLiveLogsPreference = React.useCallback(() => {
+    if (lastSuccessfulSearchParamsRef.current) {
+      lastSuccessfulSearchParamsRef.current = {
+        ...lastSuccessfulSearchParamsRef.current,
+        showLiveLogs: false,
+      };
+    }
+  }, []);
+
   const retrySearch = React.useCallback(async () => {
     const lastParams = lastSuccessfulSearchParamsRef.current;
     if (!lastParams) {
-      return;
+      return false;
     }
-    closeWebSocket();
-    await search(lastParams);
-  }, [closeWebSocket, search]);
+    if (lastParams.showLiveLogs) {
+      return startLiveStream(lastParams);
+    }
+    return fetchSnapshot(lastParams);
+  }, [fetchSnapshot, startLiveStream]);
 
   return {
     logs,
@@ -476,8 +624,13 @@ export const useDeviceLogs = ({ deviceId }: UseDeviceLogsArgs) => {
     isFetching,
     isStreaming,
     errorTypeOrMsg,
-    search,
+    fetchSnapshot,
+    startLiveStream,
+    cancelSearch,
+    clearSession,
+    stopLiveStream,
     closeSession,
+    clearLiveLogsPreference,
     retrySearch,
   };
 };

--- a/libs/ui-components/src/utils/deviceLogs.ts
+++ b/libs/ui-components/src/utils/deviceLogs.ts
@@ -78,6 +78,12 @@ export const DEVICE_LOGS_FORM_INITIAL_VALUES: DeviceLogSearchParams = {
   showLiveLogs: false,
 };
 
+/** Resets log search fields to defaults while keeping the selected log category. */
+export const getDeviceLogsFormResetValues = (category: DeviceLogCategory): DeviceLogSearchParams => ({
+  ...DEVICE_LOGS_FORM_INITIAL_VALUES,
+  category,
+});
+
 export const getDeviceLogCategoryLabel = (t: TFunction, category: DeviceLogCategory): string => {
   switch (category) {
     case DeviceLogCategory.AGENT:


### PR DESCRIPTION
Several improvements to Device logs:

1. Adds a cancel button so that if the search is stuck users can create a new one.

2. When user searched for logs with some response and they perform a new search, we now clear the old logs and ensure we show a spinner for a minimum amount of time. Otherwise the second retrieval might happen too fast and the user might not perceive that they are now looking at the new logs.

3. Whenever the logCategory changes, we reset the filters. This is because not all filters are valid in each category.

4. Improvements around "liveLogs": it behaves more consistently, and the Disconnected banner will also be displayed when the device disconnects while streaming logs.