### PR TITLE
EDM-4049: Do now show sync status of RS without repositories

### DIFF
--- a/libs/ui-components/src/components/ResourceSync/ResourceSyncImportStatus.tsx
+++ b/libs/ui-components/src/components/ResourceSync/ResourceSyncImportStatus.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Alert, AlertActionCloseButton, PageSection, Stack, StackItem } from '@patternfly/react-core';
 import { Trans } from 'react-i18next';
 
-import { ConditionType, type ResourceSync, type ResourceSyncList } from '@flightctl/types';
+import { ConditionType, type RepositoryList, type ResourceSync, type ResourceSyncList } from '@flightctl/types';
 
 import { useTranslation } from '../../hooks/useTranslation';
 import { useFetchPeriodically } from '../../hooks/useFetchPeriodically';
@@ -147,6 +147,9 @@ const getVisibleResourceSyncs = (rsList: ResourceSync[]) => {
   return { pendingRs, errorRs };
 };
 
+const removeRsWithMissingRepositories = (rsList: ResourceSync[], repoList: RepositoryList) =>
+  rsList.filter((rs) => repoList.items.some((repo) => repo.metadata.name === rs.spec.repository));
+
 const ResourceSyncImport = ({ type }: { type: 'fleet' | 'catalog' }) => {
   const params = new URLSearchParams();
   params.set('fieldSelector', type === 'fleet' ? 'spec.type!=catalog' : 'spec.type==catalog');
@@ -155,7 +158,26 @@ const ResourceSyncImport = ({ type }: { type: 'fleet' | 'catalog' }) => {
   });
 
   // TODO Remove the client-side filtering once the API filter is available
-  const { pendingRs, errorRs } = React.useMemo(() => getVisibleResourceSyncs(rsList?.items || []), [rsList]);
+  const { pendingRs: allPendingRs, errorRs: allErrorRs } = React.useMemo(
+    () => getVisibleResourceSyncs(rsList?.items || []),
+    [rsList],
+  );
+
+  const shouldFetchRepositories = allPendingRs.length > 0 || allErrorRs.length > 0;
+  const [repoList, isLoadingRepos] = useFetchPeriodically<RepositoryList>({
+    endpoint: shouldFetchRepositories ? 'repositories' : '',
+  });
+
+  const { pendingRs, errorRs } = React.useMemo(() => {
+    if (isLoadingRepos || !repoList) {
+      return { pendingRs: [], errorRs: [] };
+    }
+    // If the repository no longer exists, the RS will eventually error, but it's not useful to show it to the user
+    return {
+      pendingRs: removeRsWithMissingRepositories(allPendingRs, repoList),
+      errorRs: removeRsWithMissingRepositories(allErrorRs, repoList),
+    };
+  }, [allPendingRs, allErrorRs, isLoadingRepos, repoList]);
 
   if (pendingRs.length === 0 && errorRs.length === 0) {
     return null;


### PR DESCRIPTION
If users delete the repository that a RS is associated with, the UI was still showing the Pending/Error notification about that RS status. 

Since eventually the RS will fail with a condition, and the resource sync status won't change while the repository is missing, we'll hide those notifications.

```
  status:
    conditions:
    - lastTransitionTime: "2026-06-01T07:49:41.454211613Z"
      message: Repository of name "test-repo" not found
      reason: repository resource not found
      status: "False"
      type: Accessible
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the shared `libs/ui-components/` ResourceSync status component.
  * Hides pending and error notifications when the referenced repository does not exist.
  * Suppresses notifications while repository data is loading or unavailable.
* The change affects shared UI behavior and can apply to both standalone and OCP plugin consumers.
* No changes affect `libs/types/`, `libs/i18n/`, `libs/cypress/`, platform-specific app code, the Go auth proxy, container builds, E2E tests, or CI configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->