### PR TITLE
EDM-4011: Fix parser missing footer depending on formatting

### DIFF
--- a/libs/ui-components/src/utils/deviceLogCommandHandler.ts
+++ b/libs/ui-components/src/utils/deviceLogCommandHandler.ts
@@ -92,7 +92,8 @@ export const parseDeviceLogFileProbeBuffer = (buffer: string): DeviceLogFileProb
 
 const parseLastDeviceLogStreamFooter = (buffer: string): { contentBeforeFooter: string; exitCode: number } | null => {
   const escapedPrefix = DEVICE_LOGS_STREAM_FOOTER_PREFIX.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const re = new RegExp(`^${escapedPrefix}\\s+(\\d+)\\s*\\r?\\n?$`, 'gm');
+  // Match footer markers even when the transport does not preserve a strict line boundary.
+  const re = new RegExp(`${escapedPrefix}\\s+(\\d+)\\s*\\r?\\n?`, 'g');
   re.lastIndex = 0;
   let last: RegExpExecArray | undefined;
   let m: RegExpExecArray | null;


### PR DESCRIPTION
We were sometimes failing to identify when the marker of the end of content was received, which lead to showing a TIMEOUT error to the user.