### PR TITLE
EDM-3868: Reset page to 1 when filters change

### DIFF
--- a/libs/ui-components/src/components/Catalog/InstallWizard/steps/SelectTargetStep.tsx
+++ b/libs/ui-components/src/components/Catalog/InstallWizard/steps/SelectTargetStep.tsx
@@ -36,7 +36,6 @@ import FormSelect from '../../../form/FormSelect';
 import { getArtifactLabel, getFullArtifactURI } from '../../../../utils/catalog';
 import LearnMoreLink from '../../../common/LearnMoreLink';
 import { useAppLinks } from '../../../../hooks/useAppLinks';
-import { FilterSearchParams } from '../../../../utils/status/devices';
 import { isSameCatalogRef } from '../utils';
 
 export const isSelectTargetStepValid = (errors: FormikErrors<InstallAppFormik>) => {
@@ -59,14 +58,7 @@ const DeviceTarget = ({
     isLoading: devicesLoading,
     isUpdating: devicesUpdating,
     pagination: devicePagination,
-  } = useDevicesPaginated({
-    textFilters: {
-      [FilterSearchParams.NameOrAlias]: deviceNameFilter,
-    },
-    onlyDecommissioned: false,
-    onlyFleetless: true,
-    excludePackageMode: isOsItem,
-  });
+  } = useDevicesPaginated({ deviceNameFilter, excludePackageMode: isOsItem });
 
   const handleDeviceSelect = React.useCallback(
     async (device: Device) => {

--- a/libs/ui-components/src/components/Catalog/InstallWizard/steps/SpecificationsStep.tsx
+++ b/libs/ui-components/src/components/Catalog/InstallWizard/steps/SpecificationsStep.tsx
@@ -249,8 +249,6 @@ const SpecificationsStep = ({ catalogItem, showNewDevice }: SpecificationsStepPr
 
   const { isLoading: fleetsLoading, pagination: fleetPagination } = useFleets({ onlyUnmanaged: true });
   const { devices, isLoading: devicesLoading } = useDevicesPaginated({
-    onlyDecommissioned: false,
-    onlyFleetless: true,
     excludePackageMode: catalogItem.spec.type === CatalogItemType.CatalogItemTypeOS,
   });
 

--- a/libs/ui-components/src/components/Device/DevicesPage/DevicesPage.tsx
+++ b/libs/ui-components/src/components/Device/DevicesPage/DevicesPage.tsx
@@ -5,7 +5,7 @@ import { type DeviceList } from '@flightctl/types';
 import ListPage from '../../ListPage/ListPage';
 import ListPageBody from '../../ListPage/ListPageBody';
 import { useTranslation } from '../../../hooks/useTranslation';
-import { useTablePagination } from '../../../hooks/useTablePagination';
+import { useResetPaginationOnFilterChange, useTablePagination } from '../../../hooks/useTablePagination';
 import { useDevices } from './useDevices';
 import { useDeviceBackendFilters } from './useDeviceBackendFilters';
 
@@ -20,6 +20,7 @@ const DevicesPage = ({ canListER }: { canListER: boolean }) => {
   const { t } = useTranslation();
 
   const {
+    filterKey,
     textFilters,
     clearTextFilters,
     setTextFilter,
@@ -38,6 +39,8 @@ const DevicesPage = ({ canListER }: { canListER: boolean }) => {
   const [onlyDecommissioned, setOnlyDecommissioned] = React.useState<boolean>(false);
 
   const { currentPage, setCurrentPage, onPageFetched, nextContinue, itemCount } = useTablePagination<DeviceList>();
+
+  useResetPaginationOnFilterChange(`${filterKey}|${onlyDecommissioned}`, setCurrentPage);
 
   const {
     devices: data,

--- a/libs/ui-components/src/components/Device/DevicesPage/useDeviceBackendFilters.ts
+++ b/libs/ui-components/src/components/Device/DevicesPage/useDeviceBackendFilters.ts
@@ -18,6 +18,15 @@ const validAppStatuses = Object.values(ApplicationsSummaryStatusType) as string[
 const validUpdatedStatuses = Object.values(DeviceUpdatedStatusType) as string[];
 const validDeviceStatuses = Object.values(DeviceSummaryStatusType) as string[];
 
+const getSearchParamsQueryKey = (searchParams: URLSearchParams): string => {
+  return (
+    [...searchParams.entries()]
+      .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+      .sort()
+      .join('&') || ''
+  );
+};
+
 const getNewParams = (currentParams: URLSearchParams, newValues: { [key: string]: string[] }) => {
   let newParams = [...currentParams.entries()];
   const keys = Object.keys(newValues);
@@ -170,7 +179,10 @@ export const useDeviceBackendFilters = () => {
     Object.values(activeStatuses).some((s) => !!s.length) ||
     DEVICE_TEXT_FILTER_KEYS.some((key) => !!textFilters[key]);
 
+  const filterKey = React.useMemo(() => getSearchParamsQueryKey(searchParams), [searchParams]);
+
   return {
+    filterKey,
     textFilters,
     setTextFilter,
     clearTextFilters,

--- a/libs/ui-components/src/components/Device/DevicesPage/useDeviceBackendFilters.ts
+++ b/libs/ui-components/src/components/Device/DevicesPage/useDeviceBackendFilters.ts
@@ -18,10 +18,13 @@ const validAppStatuses = Object.values(ApplicationsSummaryStatusType) as string[
 const validUpdatedStatuses = Object.values(DeviceUpdatedStatusType) as string[];
 const validDeviceStatuses = Object.values(DeviceSummaryStatusType) as string[];
 
+const DEVICE_FILTER_PARAM_KEYS = Object.values(FilterSearchParams);
+
 const getSearchParamsQueryKey = (searchParams: URLSearchParams): string => {
   return (
-    [...searchParams.entries()]
-      .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+    DEVICE_FILTER_PARAM_KEYS.flatMap((key) =>
+      searchParams.getAll(key).map((value) => `${key}=${encodeURIComponent(value)}`),
+    )
       .sort()
       .join('&') || ''
   );

--- a/libs/ui-components/src/components/Device/DevicesPage/useDevices.ts
+++ b/libs/ui-components/src/components/Device/DevicesPage/useDevices.ts
@@ -18,7 +18,11 @@ import { useFetchPeriodically } from '../../../hooks/useFetchPeriodically';
 import { type FlightCtlLabel } from '../../../types/extraTypes';
 import { type FilterStatusMap } from './types';
 import { PAGE_SIZE } from '../../../constants';
-import { type PaginationDetails, useTablePagination } from '../../../hooks/useTablePagination';
+import {
+  type PaginationDetails,
+  useResetPaginationOnFilterChange,
+  useTablePagination,
+} from '../../../hooks/useTablePagination';
 
 type DevicesEndpointArgs = {
   /** Free-text filters synced with URL (name/alias, CVE ID, …). */
@@ -186,19 +190,34 @@ export type DevicesPaginatedResult = {
 
 /**
  * Hook for fetching devices with built-in pagination support.
- * Use this for paginated tables/modals.
+
+* Use this for paginated tables/modals of enrolled, fleetless devices.
  */
-export const useDevicesPaginated = (args: {
-  textFilters?: Partial<Record<DeviceTextFilterKey, string>>;
-  ownerFleets?: string[];
-  onlyDecommissioned: boolean;
-  onlyFleetless?: boolean;
-  selectedOsModes?: DeviceOsModeFilterValue[];
+export const useDevicesPaginated = ({
+  deviceNameFilter,
+  excludePackageMode,
+}: {
+  deviceNameFilter?: string;
   excludePackageMode?: boolean;
-}): DevicesPaginatedResult => {
+} = {}): DevicesPaginatedResult => {
   const pagination = useTablePagination<DeviceList>();
+
+  useResetPaginationOnFilterChange(
+    `${deviceNameFilter || ''}|${excludePackageMode ?? false}`,
+    pagination.setCurrentPage,
+  );
+
+  const textFilters = deviceNameFilter
+    ? {
+        [FilterSearchParams.NameOrAlias]: deviceNameFilter,
+      }
+    : undefined;
+
   const [devicesEndpoint, devicesDebouncing] = useDevicesEndpoint({
-    ...args,
+    textFilters,
+    onlyDecommissioned: false,
+    onlyFleetless: true,
+    excludePackageMode,
     nextContinue: pagination.nextContinue,
   });
 

--- a/libs/ui-components/src/hooks/useTablePagination.ts
+++ b/libs/ui-components/src/hooks/useTablePagination.ts
@@ -42,3 +42,13 @@ export const useTablePagination = <T extends ApiList>(): PaginationDetails<T> =>
 
   return { onPageFetched, currentPage, setCurrentPage, nextContinue, itemCount };
 };
+
+export const useResetPaginationOnFilterChange = (queryKey: string, setCurrentPage: (page: number) => void) => {
+  const prevQueryKeyRef = React.useRef(queryKey);
+  React.useEffect(() => {
+    if (prevQueryKeyRef.current !== queryKey) {
+      prevQueryKeyRef.current = queryKey;
+      setCurrentPage(1);
+    }
+  }, [queryKey, setCurrentPage]);
+};


### PR DESCRIPTION
Fixes filters not returning the expected results when the user was on a page other than page 1.

 Fixed for:
-  Main devices page
 - Decommissioned devices page
 - Catalog page for deploying an element to fleetless devices (simplified signature of `useDevicesPaginated` to make the code simpler while keeping all existing functionality)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pagination resets to page 1 when device filters change.
  * The fix applies to the main devices page, the decommissioned devices page, and the catalog deployment flow.
  * Invalid filters do not trigger pagination changes.

* **Shared UI Components**
  * Added `useResetPaginationOnFilterChange` for reusable pagination state handling.
  * Simplified `useDevicesPaginated` to accept device name and package-mode filters.
  * Updated catalog device selection to use the revised pagination API.

* **Cross-Cutting Impact**
  * Changes are limited to `libs/ui-components/`.
  * Shared UI changes can affect both standalone and OCP plugin consumers.
  * No changes affect `libs/types/`, `libs/i18n/`, `libs/cypress/`, platform-specific app code, the Go auth proxy, container builds, E2E tests, or CI configuration.
  * No security impact is indicated. The change improves pagination correctness and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->