### PR TITLE
EDM-3780: Hide pagination when no items exist

### DIFF
--- a/libs/ui-components/src/components/Table/TablePagination.tsx
+++ b/libs/ui-components/src/components/Table/TablePagination.tsx
@@ -17,7 +17,7 @@ const PaginationTemplate = ({
   isUpdating: boolean;
 }) => {
   const { t } = useTranslation();
-  const pagesCount = Math.ceil((itemCount || 0) / PAGE_SIZE);
+  const pagesCount = Math.ceil(itemCount / PAGE_SIZE);
 
   const page = String(currentPage <= pagesCount ? currentPage : 0);
   const totalPages = String(pagesCount);
@@ -54,6 +54,10 @@ function TablePagination<T extends ApiList>({
   const onSetPage = (_event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPage: number) => {
     setCurrentPage(newPage);
   };
+
+  if (itemCount === 0) {
+    return null;
+  }
 
   return (
     <Pagination


### PR DESCRIPTION
Applies to all tables across the entire application.

Examples:
<img width="1530" height="980" alt="page2" src="https://github.com/user-attachments/assets/c65819ad-146e-4e4e-b751-b65dc29d2225" />

<img width="1553" height="825" alt="page1" src="https://github.com/user-attachments/assets/e0f8baa3-c354-4358-8b7c-f619c134212f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

### Bug Fixes
* Updated the shared table pagination component (`libs/ui-components/src/components/Table/TablePagination.tsx`) to not render pagination controls when `pagination.itemCount` is `0`, preventing the pagination UI from showing on empty tables across the app.
* Adjusted pagination page count calculation to compute `pagesCount` based on `Math.ceil(itemCount / PAGE_SIZE)` without the previous falsy `itemCount || 0` guard.

### Cross-cutting implications
* Because this is a shared UI component in `libs/ui-components`, the change impacts all table views that use `TablePagination` (including both `apps/standalone/` and `apps/ocp-plugin/` where applicable).

### Scope / untouched areas
* No changes were indicated for `libs/types/`, `libs/i18n/`, `libs/cypress/`, `proxy/`, packaging, or CI/workflows.
* No CI configuration, auth proxy (Go), or container build behavior was modified.
* No E2E/Cypress test changes were described in the provided summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->