### PR TITLE
[release-1.2] ImagePromotion API calls should target image builder api (#672)

### DIFF
--- a/apps/ocp-plugin/src/utils/apiCalls.ts
+++ b/apps/ocp-plugin/src/utils/apiCalls.ts
@@ -47,7 +47,7 @@ const uiProxy = `${window.location.protocol}//${apiServer}`;
 export const apiProxy = `${uiProxy}/api`;
 
 const alertsAPI = `${apiProxy}/alerts`;
-const imageBuilderPathRegex = /^image(builds|exports)/;
+const imageBuilderPathRegex = /^image(builds|exports|promotions)/;
 const catalogPathRegex = /^(catalogs|catalogitems)/;
 const vulnerabilityPathRegex = /^vulnerabilities/;
 


### PR DESCRIPTION
Backport of https://github.com/flightctl/flightctl-ui/pull/672