### PR TITLE
EDM-4015: Display highlighted content while empty live search is active

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -663,6 +663,7 @@
   "Relative file path": "Relative file path",
   "Retrieve logs": "Retrieve logs",
   "Retrieving logs": "Retrieving logs",
+  "No matching log entries yet. Log entries that match your filter will appear here in real time.": "No matching log entries yet. Log entries that match your filter will appear here in real time.",
   "YYYY-MM-DD": "YYYY-MM-DD",
   "Toggle calendar for start date": "Toggle calendar for start date",
   "Toggle calendar for end date": "Toggle calendar for end date",

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsInnerToolbar.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsInnerToolbar.tsx
@@ -30,6 +30,7 @@ import './DeviceLogsInnerToolbar.css';
 export type DeviceLogsInnerToolbarProps = {
   lastSearchParams: DeviceLogSearchParams;
   isStreaming: boolean;
+  hasLogs: boolean;
   onApplySearchParams: (params: DeviceLogSearchParams) => Promise<boolean>;
   onStartLiveStream: () => Promise<boolean>;
   onStopLiveStream: VoidFunction;
@@ -42,6 +43,7 @@ export type DeviceLogsInnerToolbarProps = {
 const DeviceLogsInnerToolbar = ({
   lastSearchParams,
   isStreaming,
+  hasLogs,
   onApplySearchParams,
   onStartLiveStream,
   onStopLiveStream,
@@ -172,6 +174,7 @@ const DeviceLogsInnerToolbar = ({
                   type="button"
                   icon={<ExternalLinkAltIcon />}
                   aria-label={t('View raw logs')}
+                  isDisabled={!hasLogs}
                   onClick={onOpenRaw}
                 />
               </ToolbarItem>
@@ -181,6 +184,7 @@ const DeviceLogsInnerToolbar = ({
                   type="button"
                   icon={<DownloadIcon />}
                   aria-label={t('Download logs')}
+                  isDisabled={!hasLogs}
                   onClick={onDownload}
                 />
               </ToolbarItem>

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsTab.css
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsTab.css
@@ -1,0 +1,19 @@
+.fctl-device-logs-viewer {
+  position: relative;
+}
+
+.fctl-device-logs-viewer .fctl-device-logs-viewer__waiting-overlay {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  /* Prevent the overlay from blocking the inner toolbar controls */
+  pointer-events: none;
+}
+
+.fctl-device-logs-viewer .fctl-device-logs-viewer__waiting-overlay-text {
+  font-weight: var(--pf-t--global--font--weight--body--bold);
+  font-size: var(--pf-t--global--font--size--lg);
+}

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsTab.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsTab.tsx
@@ -240,12 +240,10 @@ const DeviceLogsTab = ({ deviceId }: DeviceLogsTabProps) => {
                   <FlexItem>
                     <Spinner size="xl" />
                   </FlexItem>
-                  <FlexItem>
-                    <StackItem className="fctl-device-logs-viewer__waiting-overlay-text">
-                      {t(
-                        'No matching log entries yet. Log entries that match your filter will appear here in real time.',
-                      )}
-                    </StackItem>
+                  <FlexItem className="fctl-device-logs-viewer__waiting-overlay-text">
+                    {t(
+                      'No matching log entries yet. Log entries that match your filter will appear here in real time.',
+                    )}
                   </FlexItem>
                 </Flex>
               </Bullseye>

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsTab.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsTab.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Bullseye, Spinner, Stack, StackItem } from '@patternfly/react-core';
+import { Bullseye, Flex, FlexItem, Spinner, Stack, StackItem } from '@patternfly/react-core';
 import { LogViewer } from '@patternfly/react-log-viewer';
 import { Formik } from 'formik';
 
@@ -22,6 +22,10 @@ import { UserPreferencesContext } from '../../Masthead/UserPreferencesProvider';
 import { DeviceLogsDisconnectedBanner, DeviceLogsEmptyState, DeviceLogsRetrievalError } from './DeviceLogsEmptyState';
 import DeviceLogsSearchToolbar from './DeviceLogsSearchToolbar';
 import DeviceLogsInnerToolbar from './DeviceLogsInnerToolbar';
+
+import './DeviceLogsTab.css';
+
+const LOG_VIEWER_HEIGHT = 700;
 
 type DeviceLogsTabProps = {
   deviceId: string;
@@ -165,9 +169,10 @@ const DeviceLogsTab = ({ deviceId }: DeviceLogsTabProps) => {
   const lineCount = logs.length;
   const isSearching = isConnecting || isFetching || isRetrievePending;
   const hasDisplayedLogs = Boolean(lastSearchParams && lineCount > 0);
-  const showLogViewer = Boolean(lastSearchParams && (hasDisplayedLogs || isStreaming)) && !isSearching;
+  const showLogViewer = Boolean(lastSearchParams) && (hasDisplayedLogs || isStreaming) && !isSearching;
   const showEmptyState = !isSearching && !showLogViewer && !errorTypeOrMsg;
   const showRetrievalError = !isSearching && !showLogViewer && Boolean(errorTypeOrMsg);
+  const isEmptyLiveSearch = isStreaming && lineCount === 0;
 
   return (
     <Formik<DeviceLogSearchParams>
@@ -196,38 +201,55 @@ const DeviceLogsTab = ({ deviceId }: DeviceLogsTabProps) => {
         )}
         {showEmptyState && <DeviceLogsEmptyState />}
         {showRetrievalError && <DeviceLogsRetrievalError errorTypeOrMsg={errorTypeOrMsg as DeviceLogErrorType} />}
-        {showLogViewer && lastSearchParams && (
-          <StackItem>
-            <Stack hasGutter>
-              <StackItem>
-                <LogViewer
-                  data={logs}
-                  height={700}
-                  hasLineNumbers
-                  theme={resolvedTheme}
-                  isTextWrapped
-                  scrollToRow={isStreaming && lineCount > 0 ? lineCount : undefined}
-                  toolbar={
-                    <DeviceLogsInnerToolbar
-                      lastSearchParams={lastSearchParams}
-                      isStreaming={isStreaming}
-                      onApplySearchParams={runSearchWithParams}
-                      onStartLiveStream={handleStartLiveStream}
-                      onStopLiveStream={handleStopLiveStream}
-                      onClearLiveLogsPreference={handleClearLiveLogsPreference}
-                      onClearSession={onClearSession}
-                      onDownload={onDownload}
-                      onOpenRaw={onOpenRaw}
-                    >
-                      {/* If we receive a disconection error after we had retrieved some logs, the logs stay visible. Users can download them and retry if needed. */}
-                      {errorTypeOrMsg === 'CONNECTION_CLOSED' && (
-                        <DeviceLogsDisconnectedBanner onRetry={() => void retrySearch()} />
+        {showLogViewer && (
+          <StackItem className="fctl-device-logs-viewer">
+            <LogViewer
+              data={logs}
+              height={LOG_VIEWER_HEIGHT}
+              hasLineNumbers
+              theme={resolvedTheme}
+              isTextWrapped
+              scrollToRow={isEmptyLiveSearch ? undefined : lineCount}
+              toolbar={
+                <DeviceLogsInnerToolbar
+                  lastSearchParams={lastSearchParams as DeviceLogSearchParams}
+                  isStreaming={isStreaming}
+                  hasLogs={lineCount > 0}
+                  onApplySearchParams={runSearchWithParams}
+                  onStartLiveStream={handleStartLiveStream}
+                  onStopLiveStream={handleStopLiveStream}
+                  onClearLiveLogsPreference={handleClearLiveLogsPreference}
+                  onClearSession={onClearSession}
+                  onDownload={onDownload}
+                  onOpenRaw={onOpenRaw}
+                >
+                  {/* If we receive a disconection error after we had retrieved some logs, the logs stay visible. Users can download them and retry if needed. */}
+                  {errorTypeOrMsg === 'CONNECTION_CLOSED' && (
+                    <DeviceLogsDisconnectedBanner onRetry={() => void retrySearch()} />
+                  )}
+                </DeviceLogsInnerToolbar>
+              }
+            />
+            {isEmptyLiveSearch && (
+              <Bullseye
+                className="fctl-device-logs-viewer__waiting-overlay"
+                aria-live="polite"
+                style={{ height: LOG_VIEWER_HEIGHT }}
+              >
+                <Flex direction={{ default: 'column' }} alignItems={{ default: 'alignItemsCenter' }}>
+                  <FlexItem>
+                    <Spinner size="xl" />
+                  </FlexItem>
+                  <FlexItem>
+                    <StackItem className="fctl-device-logs-viewer__waiting-overlay-text">
+                      {t(
+                        'No matching log entries yet. Log entries that match your filter will appear here in real time.',
                       )}
-                    </DeviceLogsInnerToolbar>
-                  }
-                />
-              </StackItem>
-            </Stack>
+                    </StackItem>
+                  </FlexItem>
+                </Flex>
+              </Bullseye>
+            )}
           </StackItem>
         )}
       </Stack>


### PR DESCRIPTION
We display a highlighted content whenever a "liveLogs=true" search is triggered, and there no still no results.

<img width="1486" height="1317" alt="empty-wait-ux" src="https://github.com/user-attachments/assets/32a2e01b-637f-4015-a5fc-32bed9574baa" />
