### PR TITLE
NO-ISSUE: patch CVE-2024-52011 in launch-editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12808,14 +12808,14 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.1.tgz",
-      "integrity": "sha512-eB/uXmFVpY4zezmGp5XtU21kwo7GBbKB+EQ+UZeWtGb9yAM5xt/Evk+lYH3eRNAtId+ej4u7TYPFZ07w4s7rRw==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+      "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "picocolors": "^1.0.0",
-        "shell-quote": "^1.8.1"
+        "picocolors": "^1.1.1",
+        "shell-quote": "^1.8.4"
       }
     },
     "node_modules/lazystream": {
@@ -17387,11 +17387,14 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -18488,9 +18491,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## CVE Fix

Fixes CVE-2024-52011 (Dependabot alert #132) by updating transitive dev dependency `launch-editor` to a patched version.

### Vulnerabilities Addressed

| CVE ID | Severity | Package | Old Version | New Version |
|--------|----------|---------|-------------|-------------|
| CVE-2024-52011 | HIGH | launch-editor | 2.6.1 | 2.14.1 |

### Strategy Justification

**CVE-2024-52011 — launch-editor**

| # | Strategy | Result | Details |
|---|----------|--------|---------|
| 1 | Direct update (minor) | Skipped | Package is transitive via `webpack-dev-server` |
| 2 | Transitive update (`npm update`) | Success | `npm update launch-editor` refreshed the lockfile to `2.14.1` (first patched: `2.9.0`) |
| 3 | Override/pin | Skipped | Not needed |
| 4 | Major version update | Skipped | Not needed |

Dependency chain: `webpack-dev-server@5.2.3` → `launch-editor@^2.6.1`.

### Validation

- Dependencies: `launch-editor` updated to `2.14.1` (>= fixed `2.9.0`)
- Vulnerability scan: CVE-2024-52011 no longer reported by `npm audit`
- Lint: `npm run lint` passed
- Build: `npm run build` passed

Note: the lockfile also picks up `tmp@0.2.7` (from `0.2.5`) as a transitive dev dependency refresh during the same update.

### Rollback

To revert this change:
```bash
git revert <commit-sha>
```

Made with [Cursor](https://cursor.com)