### PR TITLE
EDM-4118: Define max width for filter chips

### DIFF
--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsInnerToolbar.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsInnerToolbar.tsx
@@ -136,6 +136,7 @@ const DeviceLogsInnerToolbar = ({
                     <Label
                       key={filter.key}
                       variant="outline"
+                      textMaxWidth="25ch"
                       onClose={
                         filter.onRemove
                           ? (e) => {


### PR DESCRIPTION
Restrict the max characters for the filter chips.
The Labels show a tooltip if the length exceeds the visible characters.

<img width="1820" height="656" alt="max-chips-width" src="https://github.com/user-attachments/assets/f00ee908-07cb-4bdc-82ff-b198ea38ff5e" />
