### PR TITLE
EDM-4121: Use tail to prevent filtering expected content

### DIFF
--- a/libs/ui-components/src/utils/deviceLogCommandBuilder.ts
+++ b/libs/ui-components/src/utils/deviceLogCommandBuilder.ts
@@ -89,21 +89,26 @@ const getCategoryOption = (params: DeviceLogSearchParams): string[] => {
 Builds the command to retrieve the logs from the journal.
 We always include a max number of lines to retrieve, to prevent the command from timing out.
 
-- Command: journalctl <unitOption> <timeOption> <priorityOption> --no-pager <followOption> -n <maxLines>
+- Snapshot: journalctl <filters> --no-pager | tail -n <maxLines>
+ "-n <maxLines>" cannot be used here because the lines are fetched before the filters are applied.
+
+- Live: journalctl <filters> --no-pager -f -n <maxLines>
+ "tail -n <maxLines>" cannot be used here because it doesn't support the follow mode.
 */
 const buildJournalCommand = (params: DeviceLogSearchParams): string => {
   const unitArgs = getCategoryOption(params);
   const timeArgs = getTimeOption(params);
   const priorityArgs = getPriorityOption(params.level);
 
-  const options = [...unitArgs, ...timeArgs, ...priorityArgs, '--no-pager'];
+  const journalArgs = [...unitArgs, ...timeArgs, ...priorityArgs, '--no-pager'];
+  const journalCmd = `journalctl ${journalArgs.map(quoteShellArg).join(' ')}`;
+
   if (params.showLiveLogs) {
-    options.push('-f');
-    options.push('-n', String(MAX_LOG_LINES_WHEN_STREAMING));
-  } else {
-    options.push('-n', String(MAX_LOG_LINES));
+    return `${journalCmd} -f -n ${MAX_LOG_LINES_WHEN_STREAMING}`;
   }
-  return `journalctl ${options.map(quoteShellArg).join(' ')}`;
+
+  // Run the command under "bash -c" so journalctl and tail are executed together.
+  return `bash -c ${quoteShellArg(`${journalCmd} 2>&1 | tail -n ${MAX_LOG_LINES}`)}`;
 };
 
 /*
@@ -161,8 +166,7 @@ const getDeviceLogFileProbeInnerCommand = (params: DeviceLogSearchParams): strin
     throw new Error('A log file path is required.');
   }
 
-  const path = `${DEVICE_LOG_BASE_PATH}/${params.logFilePath.trim()}`;
-  const quotedPath = quoteShellArg(path);
+  const path = quoteShellArg(`${DEVICE_LOG_BASE_PATH}/${params.logFilePath.trim()}`);
 
   const bashScript = [
     'path=$1',
@@ -172,7 +176,7 @@ const getDeviceLogFileProbeInnerCommand = (params: DeviceLogSearchParams): strin
     'echo "mime=$(file -b --mime-type -- "$path" 2>/dev/null)"',
   ].join('\n');
 
-  return `bash -c ${quoteShellArg(bashScript)} bash ${quotedPath}`;
+  return `bash -c ${quoteShellArg(bashScript)} bash ${path}`;
 };
 
 export const getFileProbeCommand = (params: DeviceLogSearchParams): string =>

--- a/libs/ui-components/src/utils/deviceLogCommandBuilder.ts
+++ b/libs/ui-components/src/utils/deviceLogCommandBuilder.ts
@@ -107,8 +107,8 @@ const buildJournalCommand = (params: DeviceLogSearchParams): string => {
     return `${journalCmd} -f -n ${MAX_LOG_LINES_WHEN_STREAMING}`;
   }
 
-  // Run the command under "bash -c" so journalctl and tail are executed together.
-  return `bash -c ${quoteShellArg(`${journalCmd} 2>&1 | tail -n ${MAX_LOG_LINES}`)}`;
+  // Run under bash -c with pipefail so the footer exit code reflects journalctl, not tail.
+  return `bash -c ${quoteShellArg(`set -o pipefail; ${journalCmd} 2>&1 | tail -n ${MAX_LOG_LINES}`)}`;
 };
 
 /*

--- a/libs/ui-components/src/utils/deviceLogCommandBuilder.ts
+++ b/libs/ui-components/src/utils/deviceLogCommandBuilder.ts
@@ -87,28 +87,37 @@ const getCategoryOption = (params: DeviceLogSearchParams): string[] => {
 
 /*
 Builds the command to retrieve the logs from the journal.
-We always include a max number of lines to retrieve, to prevent the command from timing out.
+
+We limit the number of lines to retrieve to prevent the command from timing out.
+"tail" is used to perform the cap because `journalctl -n` retrieves the desired number of lines, then it applies the filters.
 
 - Snapshot: journalctl <filters> --no-pager | tail -n <maxLines>
- "-n <maxLines>" cannot be used here because the lines are fetched before the filters are applied.
-
-- Live: journalctl <filters> --no-pager -f -n <maxLines>
- "tail -n <maxLines>" cannot be used here because it doesn't support the follow mode.
+- Live backlog: Same pipeline as snapshot (to retrieve the older lines), then piped to journalctl <filters> --since now --no-pager -f
 */
+const buildJournalSnapshotCommand = (journalCmd: string, maxLines: number): string =>
+  `set -o pipefail; ${journalCmd} 2>&1 | tail -n ${maxLines}`;
+
 const buildJournalCommand = (params: DeviceLogSearchParams): string => {
   const unitArgs = getCategoryOption(params);
   const timeArgs = getTimeOption(params);
   const priorityArgs = getPriorityOption(params.level);
 
   const journalArgs = [...unitArgs, ...timeArgs, ...priorityArgs, '--no-pager'];
-  const journalCmd = `journalctl ${journalArgs.map(quoteShellArg).join(' ')}`;
+  const snapshotCmd = buildJournalSnapshotCommand(
+    `journalctl ${journalArgs.map(quoteShellArg).join(' ')}`,
+    params.showLiveLogs ? MAX_LOG_LINES_WHEN_STREAMING : MAX_LOG_LINES,
+  );
 
+  let innerCommand = snapshotCmd;
   if (params.showLiveLogs) {
-    return `${journalCmd} -f -n ${MAX_LOG_LINES_WHEN_STREAMING}`;
+    // Adds follow mode on top of the snapshot command (adding only new entries to prevent duplicating content).
+    const followArgs = [...unitArgs, ...priorityArgs, '--since', 'now', '--no-pager'];
+    const followJournalCmd = `journalctl ${followArgs.map(quoteShellArg).join(' ')} -f`;
+    innerCommand = `${snapshotCmd} && ${followJournalCmd}`;
   }
 
-  // Run under bash -c with pipefail so the footer exit code reflects journalctl, not tail.
-  return `bash -c ${quoteShellArg(`set -o pipefail; ${journalCmd} 2>&1 | tail -n ${MAX_LOG_LINES}`)}`;
+  // Quote the full script once: snapshotCmd must stay unquoted until follow is appended for live mode.
+  return `bash -c ${quoteShellArg(innerCommand)}`;
 };
 
 /*


### PR DESCRIPTION
Performing `journalctl -p <level> -n 100000` could result in some missing content.
The reason is that the journal first fetches the number of lines, then applies the priority filter.

We're now using `tail` to cap the max content to prevent the UI from becoming sluggish, while preserving expected content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Areas Affected

**libs/ui-components/** - Shared UI components utility

## Summary

This PR modifies the device log command builder to prevent unexpected omission of log entries when retrieving journalctl data. The issue arose because `journalctl -p <level> -n 100000` counts lines before applying priority filters, potentially dropping expected entries.

## Changes

The `deviceLogCommandBuilder.ts` utility has been refactored to:

1. **Snapshot mode**: Changed from `journalctl -n <maxLines>` to `journalctl <filters> --no-pager | tail -n <maxLines>` under `set -o pipefail`. This ensures that priority filtering is applied before line limiting, preserving all priority-filtered content while capping the output size sent to the UI.

2. **Live/follow mode**: The snapshot portion now uses `MAX_LOG_LINES_WHEN_STREAMING`, with a separate follow command (`journalctl <followArgs> -f`) appended without line limits on the follow segment.

3. **Path handling**: The `getDeviceLogFileProbeInnerCommand` function now pre-computes the full log-file path under `DEVICE_LOG_BASE_PATH` as a single quoted positional parameter for the bash script.

The changes are composed as a single quoted bash script invocation via `bash -c ...`.

## Cross-cutting Implications

This is a shared utility change in `libs/ui-components/` that affects device log retrieval across both the standalone and OCP plugin applications. Any application using device logs will benefit from the improved filtering behavior and reduced UI sluggishness from capping log output size.

## Metrics

- **Lines changed**: +24/-11
- **Estimated review effort**: High

<!-- end of auto-generated comment: release notes by coderabbit.ai -->