### PR TITLE
EDM-4142: Remove arrow in Create item button

### DIFF
--- a/libs/ui-components/src/components/Catalog/CatalogLandingPage.tsx
+++ b/libs/ui-components/src/components/Catalog/CatalogLandingPage.tsx
@@ -176,8 +176,6 @@ export const CatalogLandingPageContent = ({ permissions }: Pick<LandingPagePermi
             >
               <Button
                 variant="secondary"
-                icon={<ArrowRightIcon />}
-                iconPosition="end"
                 onClick={() => navigate(ROUTE.CATALOG_ADD_ITEM)}
                 isAriaDisabled={!canCreateCatalog || !canCreateCatalogItem}
               >


### PR DESCRIPTION
Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**Area affected:** `libs/ui-components/` (shared UI components)

**Change summary:**  
Updated `CatalogLandingPage`’s “Create a new catalog item” footer: the **“Create item”** button no longer renders the `ArrowRightIcon` (removed the `icon` and `iconPosition` props). The button’s click navigation to `ROUTE.CATALOG_ADD_ITEM` and the disabled/aria-disabled gating based on `canCreateCatalog` / `canCreateCatalogItem` remain unchanged. Other buttons (e.g., “Start a build”, “Import”) keep their arrow icons.

**Cross-cutting implications:**  
Because both `apps/standalone` and `apps/ocp-plugin` render the shared `CatalogPage`/`CatalogLandingPage` components, this UI change applies to both platforms wherever the catalog landing page is shown.

**Type:** Shared UI component refinement impacting standalone and OCP plugin apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->