### PR TITLE
EDM-4143: Modified queued status icon

### DIFF
--- a/libs/ui-components/src/components/ImageBuilds/ImageBuildAndExportStatus.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/ImageBuildAndExportStatus.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Stack, StackItem } from '@patternfly/react-core';
 import { TFunction } from 'react-i18next';
+import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
+import { PendingIcon } from '@patternfly/react-icons/dist/js/icons/pending-icon';
 
 import {
   ImageBuildCondition,
@@ -29,7 +31,14 @@ type ImageExportStatusProps = {
 type LevelAndLabel = {
   level: StatusLevel;
   label: string;
+  customIcon?: React.ComponentClass<SVGIconProps>;
 };
+
+const getQueuedStatusInfo = (t: TFunction): LevelAndLabel => ({
+  level: 'unknown',
+  label: t('Queued'),
+  customIcon: PendingIcon,
+});
 
 const getImageBuildStatusInfo = (condition: ImageBuildCondition | undefined, t: TFunction): LevelAndLabel => {
   // Without the Ready condition, the build wouldn't be even queued for processing.
@@ -39,7 +48,7 @@ const getImageBuildStatusInfo = (condition: ImageBuildCondition | undefined, t: 
 
   switch (condition.reason) {
     case ImageBuildConditionReason.ImageBuildConditionReasonPending:
-      return { level: 'unknown', label: t('Queued') };
+      return getQueuedStatusInfo(t);
     case ImageBuildConditionReason.ImageBuildConditionReasonBuilding:
       return { level: 'info', label: t('Building') };
     case ImageBuildConditionReason.ImageBuildConditionReasonPushing:
@@ -64,7 +73,7 @@ const getImageExportStatusInfo = (condition: ImageExportCondition | undefined, t
   switch (reason) {
     case ImageExportConditionReason.ImageExportConditionReasonPending:
       // ImageExports will have a "pending" state while their associated imageBuild is incomplete.
-      return { level: 'unknown', label: t('Queued') };
+      return getQueuedStatusInfo(t);
     case ImageExportConditionReason.ImageExportConditionReasonConverting:
       // Main status while the export image is being generated
       return { level: 'info', label: t('Converting') };
@@ -88,11 +97,13 @@ const ImageBuildAndExportStatus = ({
   label,
   message,
   imageReference,
+  customIcon,
 }: {
   level: StatusLevel;
   label: string;
   message: React.ReactNode | undefined;
   imageReference: string | undefined;
+  customIcon?: React.ComponentClass<SVGIconProps>;
 }) => {
   const { t } = useTranslation();
   if (imageReference) {
@@ -106,7 +117,7 @@ const ImageBuildAndExportStatus = ({
     );
   }
 
-  return <StatusDisplayContent label={label} level={level} message={message} />;
+  return <StatusDisplayContent label={label} level={level} message={message} customIcon={customIcon} />;
 };
 
 export const ImageBuildStatusDisplay = ({ buildStatus }: ImageBuildStatusProps) => {
@@ -114,7 +125,7 @@ export const ImageBuildStatusDisplay = ({ buildStatus }: ImageBuildStatusProps) 
 
   const conditions = buildStatus?.conditions || [];
   const readyCondition = conditions.find((c) => c.type === ImageBuildConditionType.ImageBuildConditionTypeReady);
-  const { level, label } = getImageBuildStatusInfo(readyCondition, t);
+  const { level, label, customIcon } = getImageBuildStatusInfo(readyCondition, t);
 
   return (
     <ImageBuildAndExportStatus
@@ -122,6 +133,7 @@ export const ImageBuildStatusDisplay = ({ buildStatus }: ImageBuildStatusProps) 
       label={label}
       message={readyCondition?.message}
       imageReference={buildStatus?.imageReference}
+      customIcon={customIcon}
     />
   );
 };
@@ -131,7 +143,7 @@ export const ImageExportStatusDisplay = ({ imageStatus, imageReference }: ImageE
 
   const conditions = imageStatus?.conditions || [];
   const readyCondition = conditions.find((c) => c.type === ImageExportConditionType.ImageExportConditionTypeReady);
-  const { level, label } = getImageExportStatusInfo(readyCondition, t);
+  const { level, label, customIcon } = getImageExportStatusInfo(readyCondition, t);
 
   return (
     <ImageBuildAndExportStatus
@@ -139,6 +151,7 @@ export const ImageExportStatusDisplay = ({ imageStatus, imageReference }: ImageE
       label={label}
       message={readyCondition?.message}
       imageReference={imageReference}
+      customIcon={customIcon}
     />
   );
 };


### PR DESCRIPTION
Table showing all possible statuses. 
Icon has been replaced with `PendingIcon` which looks like an hourglass. 

<img width="2600" height="867" alt="queued-icon" src="https://github.com/user-attachments/assets/b42b5948-f814-48d6-ad37-faff4df159b8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

**Area Affected:** `libs/ui-components/` (shared UI components)

**Changes:**
- Updated the image build and export status display for queued/pending states to render a dedicated PatternFly `PendingIcon` (hourglass) rather than the previous generic queued indicator.
- Added support for passing a per-status custom icon through the shared status rendering component.

**Technical Implementation (key file):**
- `libs/ui-components/src/components/ImageBuilds/ImageBuildAndExportStatus.tsx`
  - Introduces a `getQueuedStatusInfo(t)` helper that returns the queued status label/level along with `customIcon: PendingIcon`
  - Updates `getImageBuildStatusInfo()` and `getImageExportStatusInfo()` so pending/queued “reason” paths use `getQueuedStatusInfo()`
  - Extends the shared `ImageBuildAndExportStatus` renderer with an optional `customIcon` prop and forwards it into `StatusDisplayContent`
  - Updates `ImageBuildStatusDisplay` and `ImageExportStatusDisplay` to extract and pass through `customIcon` from their status-info helpers

**Cross-Cutting Impact:**
- This is a shared UI component change that should affect any screen(s) in the standalone app and the OCP plugin that reuse the image build/export status UI.

**Scope:**
- Localized to the shared UI component; no changes indicated for `libs/types/`, `libs/i18n/`, `libs/cypress/`, `apps/*`, the Go auth proxy, container builds, packaging, or CI/workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->