### PR TITLE
EDM-4140: Reduce size of icons in Catalog landing page cards

### DIFF
--- a/libs/ui-components/src/components/Catalog/CatalogLandingPage.tsx
+++ b/libs/ui-components/src/components/Catalog/CatalogLandingPage.tsx
@@ -49,7 +49,7 @@ const GettingStartedCard = ({
       <CardHeader>
         <Stack hasGutter>
           <StackItem>
-            <Icon size="2xl" style={{ '--pf-v6-c-icon__content--Color': activeColor.value } as React.CSSProperties}>
+            <Icon size="xl" style={{ '--pf-v6-c-icon__content--Color': activeColor.value } as React.CSSProperties}>
               {icon}
             </Icon>
           </StackItem>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR reduces the visual size of icons in the Catalog landing page “Getting started” card by updating the PatternFly `Icon` size used by the shared `GettingStartedCard` component.

## Areas Affected

**libs/ui-components/** – Shared UI component update:
- `src/components/Catalog/CatalogLandingPage.tsx`: changed `Icon size` from `"2xl"` to `"xl"` for the `GettingStartedCard` rendering.

## Impact

A minimal, UI-only visual adjustment to the Catalog landing page cards (smaller icon dimensions) with no functional behavior changes.

## Cross-cutting Implications

Because this change is in the shared `libs/ui-components` library, it will affect both the standalone and OCP plugin applications wherever the catalog landing page cards are rendered.

No changes were made to platform-specific app code outside `libs/ui-components`, the Go auth proxy, container builds/packaging, E2E tests, or CI configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->