### PR TITLE
EDM-4139: Remove shouldFocusFirstItemOnOpen as it does not react to hover

### DIFF
--- a/libs/ui-components/src/components/DetailsPage/DetailsPageActions.tsx
+++ b/libs/ui-components/src/components/DetailsPage/DetailsPageActions.tsx
@@ -128,7 +128,6 @@ const DetailsPageActions = ({ children }: React.PropsWithChildren) => {
       onOpenChange={(isOpen: boolean) => setActionsOpen(isOpen)}
       popperProps={{ position: 'left', preventOverflow: true }}
       shouldFocusToggleOnSelect
-      shouldFocusFirstItemOnOpen
       toggle={(toggleRef) => (
         <MenuToggle
           ref={toggleRef}

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsLevelField.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsLevelField.tsx
@@ -44,7 +44,6 @@ const DeviceLogsLevelField = () => {
             selected={level}
             onSelect={onLevelSelected}
             shouldFocusToggleOnSelect
-            shouldFocusFirstItemOnOpen
             isOpen={isOpen}
             style={{ width: '12rem' }}
             onOpenChange={(open) => {

--- a/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsTimeRangeField.tsx
+++ b/libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsTimeRangeField.tsx
@@ -331,8 +331,6 @@ const DeviceLogsTimeRangeField = () => {
         id="device-logs-time-range"
         selected={timeRange}
         onSelect={onTimeRangeSelected}
-        shouldFocusToggleOnSelect={false}
-        shouldFocusFirstItemOnOpen={false}
         isOpen={isOpen}
         onOpenChange={(open) => {
           if (open) {

--- a/libs/ui-components/src/components/form/FilterSelect.tsx
+++ b/libs/ui-components/src/components/form/FilterSelect.tsx
@@ -44,7 +44,6 @@ const FilterSelect = ({ placeholder, selectedFilters, isFilterUpdating, children
       aria-label={placeholder}
       role="menu"
       shouldFocusToggleOnSelect
-      shouldFocusFirstItemOnOpen
       toggle={(toggleRef) => (
         <MenuToggle
           ref={toggleRef}

--- a/libs/ui-components/src/components/form/FormSelect.tsx
+++ b/libs/ui-components/src/components/form/FormSelect.tsx
@@ -98,7 +98,6 @@ const FormSelect = ({
           setIsOpen(false);
         }}
         shouldFocusToggleOnSelect
-        shouldFocusFirstItemOnOpen
         toggle={(toggleRef) => (
           <MenuToggle
             status={statusToggle}


### PR DESCRIPTION
Removed `shouldFocusFirstItemOnOpen` since it always kept the focus on the first item while the menu was open, regardless of whether it was the selected item and/or if the cursor was over other items.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR removes the `shouldFocusFirstItemOnOpen` focus-management prop from shared PatternFly `Select`/dropdown usages in `libs/ui-components/`, fixing the behavior where the first item stayed focused even when the user hovered other items.

## Areas Affected

**libs/ui-components/** (shared UI components):
- Updated `Select` focus handling in multiple components by removing `shouldFocusFirstItemOnOpen`, and using `shouldFocusToggleOnSelect` where applicable:
  - `libs/ui-components/src/components/DetailsPage/DetailsPageActions.tsx`
  - `libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsLevelField.tsx`
  - `libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsTimeRangeField.tsx` (also removed the explicit `shouldFocusToggleOnSelect={false}` override)
  - `libs/ui-components/src/components/form/FilterSelect.tsx`
  - `libs/ui-components/src/components/form/FormSelect.tsx` (replaces focus prop and adds explicit dropdown close on option select via `setIsOpen(false)`)

## Cross-Cutting Implications

Because these are shared UI components, the dropdown focus behavior change affects all screens using these `Select` implementations across the product experience (including both standalone and OCP-plugin usages).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->