### PR TITLE
EDM-4149: Better responsive layout for GettingStarted Catalog page

### DIFF
--- a/libs/ui-components/src/components/Catalog/CatalogLandingPage.css
+++ b/libs/ui-components/src/components/Catalog/CatalogLandingPage.css
@@ -1,0 +1,26 @@
+.fctl-getting-started-cards {
+  width: 100%;
+  container-type: inline-size;
+  container-name: getting-started-cards;
+}
+
+/* Card size is approximately 350px */
+.fctl-getting-started-cards__item {
+  flex: 1 1 22rem;
+  min-width: min(100%, 22rem);
+  max-width: 100%;
+}
+
+/* Container fits two cards */
+@container getting-started-cards (min-width: 45rem) {
+  .fctl-getting-started-cards__item {
+    max-width: calc((100% - var(--pf-v6-l-flex--ColumnGap, var(--pf-t--global--spacer--md))) / 2);
+  }
+}
+
+/* Container fits three cards */
+@container getting-started-cards (min-width: 68rem) {
+  .fctl-getting-started-cards__item {
+    max-width: calc((100% - 2 * var(--pf-v6-l-flex--ColumnGap, var(--pf-t--global--spacer--md))) / 3);
+  }
+}

--- a/libs/ui-components/src/components/Catalog/CatalogLandingPage.tsx
+++ b/libs/ui-components/src/components/Catalog/CatalogLandingPage.tsx
@@ -9,8 +9,8 @@ import {
   EmptyStateActions,
   EmptyStateBody,
   EmptyStateFooter,
-  Grid,
-  GridItem,
+  Flex,
+  FlexItem,
   Icon,
   List,
   ListItem,
@@ -33,6 +33,8 @@ import WithTooltip from '../common/WithTooltip';
 import LearnMoreLink from '../common/LearnMoreLink';
 import { useAppLinks } from '../../hooks/useAppLinks';
 import ResourceListEmptyState from '../common/ResourceListEmptyState';
+
+import './CatalogLandingPage.css';
 
 const GettingStartedCard = ({
   children,
@@ -63,6 +65,10 @@ const GettingStartedCard = ({
     </Card>
   );
 };
+
+const GettingStartedCardItem = ({ children }: React.PropsWithChildren) => (
+  <FlexItem className="fctl-getting-started-cards__item">{children}</FlexItem>
+);
 
 const catalogPermissions = [
   { kind: RESOURCE.IMAGE_BUILD, verb: VERB.CREATE },
@@ -125,8 +131,13 @@ export const CatalogLandingPageContent = ({ permissions }: Pick<LandingPagePermi
   const navigate = useNavigate();
 
   return (
-    <Grid hasGutter span={catalogDocsLink ? 3 : 4}>
-      <GridItem>
+    <Flex
+      className="fctl-getting-started-cards"
+      flexWrap={{ default: 'wrap' }}
+      alignItems={{ default: 'alignItemsStretch' }}
+      gap={{ default: 'gapMd' }}
+    >
+      <GettingStartedCardItem>
         <GettingStartedCard
           title={t('Build custom images')}
           icon={<BuilderImageIcon />}
@@ -164,8 +175,8 @@ export const CatalogLandingPageContent = ({ permissions }: Pick<LandingPagePermi
             </StackItem>
           </Stack>
         </GettingStartedCard>
-      </GridItem>
-      <GridItem>
+      </GettingStartedCardItem>
+      <GettingStartedCardItem>
         <GettingStartedCard
           title={t('Create a new catalog item')}
           icon={<PlusCircleIcon />}
@@ -199,8 +210,8 @@ export const CatalogLandingPageContent = ({ permissions }: Pick<LandingPagePermi
             </StackItem>
           </Stack>
         </GettingStartedCard>
-      </GridItem>
-      <GridItem>
+      </GettingStartedCardItem>
+      <GettingStartedCardItem>
         <GettingStartedCard
           title={t('Import catalog')}
           icon={<ImportIcon />}
@@ -236,9 +247,9 @@ export const CatalogLandingPageContent = ({ permissions }: Pick<LandingPagePermi
             </StackItem>
           </Stack>
         </GettingStartedCard>
-      </GridItem>
+      </GettingStartedCardItem>
       {catalogDocsLink && (
-        <GridItem>
+        <GettingStartedCardItem>
           <GettingStartedCard
             title={t('Learn more')}
             icon={<BookOpenIcon />}
@@ -256,9 +267,9 @@ export const CatalogLandingPageContent = ({ permissions }: Pick<LandingPagePermi
               </StackItem>
             </Stack>
           </GettingStartedCard>
-        </GridItem>
+        </GettingStartedCardItem>
       )}
-    </Grid>
+    </Flex>
   );
 };
 


### PR DESCRIPTION
Use container queries to make the layout adapt to the actual available content (excluding the left navigation panel)

How it looks at different viewports:

<img width="3851" height="948" alt="vp-1" src="https://github.com/user-attachments/assets/439309b5-40e7-45b1-9a3d-4fef76d7a819" />
<img width="2570" height="1085" alt="vp-2" src="https://github.com/user-attachments/assets/c53a6cce-6718-4461-b3aa-f1dd96ef0dcd" />
<img width="1828" height="1398" alt="vp-3" src="https://github.com/user-attachments/assets/e008db50-3bc1-4bea-af27-d2a259a7ca38" />
<img width="780" height="700" alt="vp-4" src="https://github.com/user-attachments/assets/289c8c97-3ca6-469c-a659-b3c62ace1413" />
<img width="475" height="986" alt="vp-5" src="https://github.com/user-attachments/assets/49bbdccf-d26c-457d-bd72-3d25f2b361ec" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Affected Areas
- **libs/ui-components/** (shared UI components; Catalog “Getting Started” landing page, catalog creation wizard UI, various status/accessibility wording)
- **libs/i18n/** (**en** translations)

## Summary
- Refactors the Catalog landing “Getting Started” card grid to use a Flex container with **CSS container queries** so cards size/wrap based on the available content width (excluding the left nav), matching the responsive layouts shown.
- Includes related UI-component tweaks around catalog icon creation inputs, status wording (“accessible” → “available”), queued status presentation for image builds/exports, and small PatternFly focus-related prop adjustments.
- Updates **English** translation strings to match the wording changes.

## Changes Made
### Catalog landing responsive layout
- **Added** `libs/ui-components/src/components/Catalog/CatalogLandingPage.css`
  - Defines a named container (`getting-started-cards`) and `@container` breakpoints to target ~2-column and ~3-column card arrangements based on container width.
- **Modified** `libs/ui-components/src/components/Catalog/CatalogLandingPage.tsx`
  - Replaces PatternFly `Grid/GridItem` with `Flex/FlexItem` for wrapping/stretched alignment and applies the new container-query classes.
  - Adds `GettingStartedCardItem` wrapper to apply the per-card sizing rules.
  - Slight icon sizing adjustment on the card header.

### Catalog “Add item” wizard: remove icon field
- **Modified** `libs/ui-components/src/components/Catalog/AddCatalogItemWizard/CreateCatalogModal.tsx`
  - Removes the “Icon” form group (`IconUploadField`) and related validation/initial values.
- **Modified** `libs/ui-components/src/components/Catalog/AddCatalogItemWizard/types.ts`
  - Removes `icon` from `CreateCatalogFormValues`.
- **Modified** `libs/ui-components/src/components/Catalog/AddCatalogItemWizard/utils.ts`
  - Removes JSON patching of `/spec/icon` and excludes `icon` from the catalog spec construction.

### Status wording: “accessible” → “available”
- **Modified** `libs/ui-components/src/utils/status/repository.ts`
- **Modified** `libs/ui-components/src/components/form/RepositorySelect.tsx`
- **Modified** `libs/ui-components/src/components/Events/useEvents.ts`
- **Modified** `libs/ui-components/src/components/ImageBuilds/SourceImageValidation.tsx`
  - Updates labels from “Checking image accessibility / Accessible / Not accessible” to the corresponding “availability” wording.

- **Modified** `libs/i18n/locales/en/translation.json`
  - Updates the corresponding English strings to match the new “available” phrasing.

### Image build/export: queued state icon
- **Modified** `libs/ui-components/src/components/ImageBuilds/ImageBuildAndExportStatus.tsx`
  - Adds a custom icon for the “Queued” status (PendingIcon) and threads it through to the status display.

### Small UI behavior tweaks (focus handling)
- **Modified**:
  - `libs/ui-components/src/components/DetailsPage/DetailsPageActions.tsx`
  - `libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsLevelField.tsx`
  - `libs/ui-components/src/components/Device/DeviceDetails/DeviceLogsTimeRangeField.tsx`
  - `libs/ui-components/src/components/form/FilterSelect.tsx`
  - `libs/ui-components/src/components/form/FormSelect.tsx`
  - (Removes/adjusts `shouldFocusFirstItemOnOpen` / related props in these menu/popup components.)

## Impact
- **Shared UI component change:** Because this is under `libs/ui-components/`, all consuming apps will get the new responsive card behavior on the Catalog landing page and the updated “available” wording/status presentation where these components are used.
- **No changes observed** in platform-specific app code, proxy/auth, packaging, or CI configuration—this PR’s changes are limited to `libs/ui-components/` and `libs/i18n/` (English).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->