### PR TITLE
EDM-4153: Improve layout of Repository select dropdown

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -1214,7 +1214,6 @@
   "Build image": "Build image",
   "You do not have permissions to promote builds to the catalog": "You do not have permissions to promote builds to the catalog",
   "Add to the software catalog testing channel upon successful build": "Add to the software catalog testing channel upon successful build",
-  "Repositories used for output images must be writable.": "Repositories used for output images must be writable.",
   "Management-ready by default": "Management-ready by default",
   "The agent is automatically included in this image. This ensures your devices are ready to be managed immediately after they are deployed.": "The agent is automatically included in this image. This ensures your devices are ready to be managed immediately after they are deployed.",
   "Target repository": "Target repository",

--- a/libs/ui-components/src/components/ImageBuilds/CreateImageBuildWizard/steps/OutputImageStep.tsx
+++ b/libs/ui-components/src/components/ImageBuilds/CreateImageBuildWizard/steps/OutputImageStep.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Alert, Content, FormGroup, FormSection, Gallery } from '@patternfly/react-core';
 import { FormikErrors, useFormikContext } from 'formik';
 
-import { OciRepoSpec, RepoSpecType, Repository } from '@flightctl/types';
+import { RepoSpecType } from '@flightctl/types';
 import { ExportFormatType } from '@flightctl/types/imagebuilder';
 import { ImageBuildFormValues } from '../types';
 import { useTranslation } from '../../../../hooks/useTranslation';
@@ -13,7 +13,6 @@ import { usePermissionsContext } from '../../../common/PermissionsContext';
 import { RESOURCE, VERB } from '../../../../types/rbac';
 import { SelectImageBuildExportCard } from '../../ImageExportCards';
 import { getAllExportFormats } from '../../../../utils/imageBuilds';
-import { isOciRepoSpec } from '../../../Repository/CreateRepository/utils';
 import { useOciRegistriesContext } from '../../OciRegistriesContext';
 import ImageUrlCard from '../../ImageUrlCard';
 
@@ -33,16 +32,6 @@ const OutputImageStep = () => {
   const { checkPermissions } = usePermissionsContext();
   const { ociRegistries, refetch } = useOciRegistriesContext();
   const [canCreateRepo] = checkPermissions([{ kind: RESOURCE.REPOSITORY, verb: VERB.CREATE }]);
-
-  const writableRepoValidation = React.useCallback(
-    (repo: Repository) => {
-      if (isOciRepoSpec(repo.spec) && repo.spec.accessMode === OciRepoSpec.accessMode.READ) {
-        return t('Repositories used for output images must be writable.');
-      }
-      return undefined;
-    },
-    [t],
-  );
 
   const handleFormatToggle = (format: ExportFormatType, isChecked: boolean) => {
     const currentFormats = values.exportFormats;
@@ -75,7 +64,6 @@ const OutputImageStep = () => {
           options={{
             writeAccessOnly: true,
           }}
-          validateRepoSelection={writableRepoValidation}
           helperText={t(
             'Only OCI-compliant registries are shown. Other repository types, such as Git or HTTP, are not supported for image builds.',
           )}

--- a/libs/ui-components/src/components/form/FormSelect.css
+++ b/libs/ui-components/src/components/form/FormSelect.css
@@ -7,6 +7,19 @@
   overflow: auto;
 }
 
+.fctl-form-select__menu .pf-v6-c-menu__item-main {
+  position: relative;
+  padding-inline-end: calc(var(--pf-t--global--icon--size--md) + var(--pf-v6-c-menu__item-main--ColumnGap));
+}
+
+/* Render the select checkmark with absolute position so it doesn't affect the alignment of the content */
+.fctl-form-select__menu .pf-v6-c-menu__item-select-icon {
+  position: absolute;
+  inset-inline-end: 0;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
 .fctl-form-select {
   max-width: 30rem;
 }

--- a/libs/ui-components/src/components/form/RepositorySelect.tsx
+++ b/libs/ui-components/src/components/form/RepositorySelect.tsx
@@ -2,10 +2,12 @@ import * as React from 'react';
 import { useField, useFormikContext } from 'formik';
 import {
   Button,
+  Content,
+  ContentVariants,
   Divider,
-  Flex,
-  FlexItem,
   FormGroup,
+  Grid,
+  GridItem,
   Icon,
   MenuFooter,
   SelectList,
@@ -31,8 +33,6 @@ export const getRepositoryItems = (
   repositories: Repository[],
   repoType: RepoSpecType,
   selectedRepoName?: string,
-  // Returns an error message if the repository cannot be selected
-  validateRepoSelection?: (repo: Repository) => string | undefined,
 ) => {
   const invalidRepoItems: Record<string, SelectItem> = {};
   const validRepoItems: Record<string, SelectItem> = {};
@@ -42,50 +42,40 @@ export const getRepositoryItems = (
       return repo.spec.type === repoType;
     })
     .forEach((repo) => {
-      const selectionError = validateRepoSelection ? validateRepoSelection(repo) : undefined;
       const repoName = repo.metadata.name as string;
-      if (selectionError) {
-        invalidRepoItems[repoName] = {
-          label: repoName,
-          description: (
-            <Stack>
-              <StackItem>{getRepoUrlOrRegistry(repo.spec)}</StackItem>
-              <StackItem>{selectionError}</StackItem>
-            </Stack>
-          ),
-        };
-      } else {
-        const accessibleCondition = repo.status?.conditions?.find((c) => c.type === ConditionType.RepositoryAccessible);
-        const isAccessible = accessibleCondition && accessibleCondition.status === ConditionStatus.ConditionStatusTrue;
-        const isInaccessible =
-          accessibleCondition && accessibleCondition.status === ConditionStatus.ConditionStatusFalse;
-        const urlOrRegistry = getRepoUrlOrRegistry(repo.spec);
+      const accessibleCondition = repo.status?.conditions?.find((c) => c.type === ConditionType.RepositoryAccessible);
+      const isAccessible = accessibleCondition && accessibleCondition.status === ConditionStatus.ConditionStatusTrue;
+      const isInaccessible = accessibleCondition && accessibleCondition.status === ConditionStatus.ConditionStatusFalse;
+      const urlOrRegistry = getRepoUrlOrRegistry(repo.spec);
 
-        let accessText = t('Unknown');
-        let level: StatusLevel = 'unknown';
-        if (isAccessible) {
-          accessText = t('Available');
-          level = 'success';
-        } else if (isInaccessible) {
-          accessText = t('Not available');
-          level = 'danger';
-        }
-
-        validRepoItems[repoName] = {
-          label: repoName,
-          description: (
-            <Flex
-              justifyContent={{ default: 'justifyContentSpaceBetween' }}
-              alignItems={{ default: 'alignItemsCenter' }}
-            >
-              <FlexItem>{urlOrRegistry}</FlexItem>
-              <FlexItem>
-                <StatusDisplayContent label={accessText} level={level} />
-              </FlexItem>
-            </Flex>
-          ),
-        };
+      let accessText = t('Unknown');
+      let level: StatusLevel = 'unknown';
+      if (isAccessible) {
+        accessText = t('Available');
+        level = 'success';
+      } else if (isInaccessible) {
+        accessText = t('Not available');
+        level = 'danger';
       }
+
+      validRepoItems[repoName] = {
+        label: (
+          <Grid hasGutter style={{ alignItems: 'center' }}>
+            <GridItem span={8}>
+              <Stack>
+                <StackItem>{repoName}</StackItem>
+                <StackItem>
+                  <Content component={ContentVariants.small}>{urlOrRegistry}</Content>
+                </StackItem>
+              </Stack>
+            </GridItem>
+            <GridItem span={4}>
+              <StatusDisplayContent label={accessText} level={level} />
+            </GridItem>
+          </Grid>
+        ),
+        selectedLabel: repoName,
+      };
     });
 
   // If the selected repository has been removed, we still consider it "valid" since it needs to be selected initially
@@ -93,15 +83,18 @@ export const getRepositoryItems = (
     selectedRepoName && !repositories.some((repo) => repo.metadata.name === selectedRepoName);
   if (isSelectedRepoMissing && !validRepoItems[selectedRepoName]) {
     validRepoItems[selectedRepoName] = {
-      label: selectedRepoName,
-      description: (
-        <>
-          <Icon size="sm" status="danger">
-            <ExclamationCircleIcon />
-          </Icon>{' '}
-          {t('Missing repository')}
-        </>
+      label: (
+        <Stack>
+          <StackItem>{selectedRepoName}</StackItem>
+          <StackItem>
+            <Icon size="sm" status="danger">
+              <ExclamationCircleIcon />
+            </Icon>{' '}
+            {t('Missing repository')}
+          </StackItem>
+        </Stack>
       ),
+      selectedLabel: selectedRepoName,
     };
   }
 
@@ -121,7 +114,6 @@ type RepositorySelectProps = {
     writeAccessOnly?: boolean;
   };
   isRequired?: boolean;
-  validateRepoSelection?: (repo: Repository) => string | undefined;
 };
 
 const ReadOnlyRepositoryListItem = ({ invalidRepoItems }: { invalidRepoItems: Record<string, SelectItem> }) => {
@@ -134,7 +126,7 @@ const ReadOnlyRepositoryListItem = ({ invalidRepoItems }: { invalidRepoItems: Re
       {itemKeys.map((key) => {
         const item = invalidRepoItems[key];
         return (
-          <SelectOption key={key} value={key} description={item.description} isDisabled>
+          <SelectOption key={key} value={key} isDisabled>
             {item.label}
           </SelectOption>
         );
@@ -154,30 +146,20 @@ const RepositorySelect = ({
   helperText,
   options,
   isRequired,
-  validateRepoSelection,
 }: RepositorySelectProps) => {
   const { t } = useTranslation();
-  const { setFieldValue, setFieldError } = useFormikContext();
+  const { setFieldValue } = useFormikContext();
   const [field] = useField<string>(name);
   const [createRepoModalOpen, setCreateRepoModalOpen] = React.useState(false);
 
   const { validRepoItems, invalidRepoItems } = React.useMemo(() => {
-    return getRepositoryItems(t, repositories, repoType, field.value, validateRepoSelection);
-  }, [t, repositories, repoType, field.value, validateRepoSelection]);
+    return getRepositoryItems(t, repositories, repoType, field.value);
+  }, [t, repositories, repoType, field.value]);
 
   const handleCreateRepository = (repo: Repository) => {
     setCreateRepoModalOpen(false);
     if (repoRefetch) {
       repoRefetch();
-    }
-
-    // If the created repository cannot be selected, we set the error and skip marking the repository as selected
-    if (validateRepoSelection) {
-      const selectionError = validateRepoSelection(repo);
-      if (selectionError) {
-        setFieldError(name, selectionError);
-        return;
-      }
     }
 
     void setFieldValue(name, repo.metadata.name, true);


### PR DESCRIPTION
The layout looks better now, with proper spacing between the selection mark and the additional content.

Removed `validateRepoSelection` as we had made changes to the RepositoryForm to enable only creating valid repositories (for example, only writable OCI registries).

<img width="805" height="420" alt="repo-layout" src="https://github.com/user-attachments/assets/3ee72c88-e5e0-4b69-b37d-ff61fd48dbcd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated shared UI components in `libs/ui-components/` to improve the Repository select dropdown layout and simplify repository selection behavior.

- `libs/ui-components/src/components/form/FormSelect.css`: adjusts menu item spacing and positions the PatternFly select checkmark absolutely so it doesn’t overlap option content.
- `libs/ui-components/src/components/form/RepositorySelect.tsx`: removes `validateRepoSelection` support (and the related “invalid option”/error description generation). Repository creation/selection now directly commits the chosen/created repository value.
- `libs/ui-components/src/components/ImageBuilds/CreateImageBuildWizard/steps/OutputImageStep.tsx`: removes the step-level `writableRepoValidation` callback and relies on the updated helper text/RepositorySelect filtering behavior for OCI usage.

Cross-cutting impact:
- Because `RepositorySelect` is shared, this affects the image build wizard UI in both `apps/standalone/` and `apps/ocp-plugin/` (via shared `CreateImageBuildWizard` components).

- `libs/i18n/locales/en/translation.json`: updated text to align with the new “Only OCI-compliant registries are shown…” helper message.

No changes were made to the Go auth proxy, container/packaging, CI/workflows, or Cypress/E2E tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->