### PR TITLE
EDM-4156: Add divider to menu footer

### DIFF
--- a/libs/ui-components/src/components/form/FormSelect.tsx
+++ b/libs/ui-components/src/components/form/FormSelect.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import {
   Button,
+  Divider,
   FormGroup,
   MenuFooter,
   MenuToggle,
@@ -143,19 +144,22 @@ const FormSelect = ({
         )}
         {children}
         {addAction && (
-          <MenuFooter>
-            <Button
-              variant="link"
-              isInline
-              icon={<PlusCircleIcon />}
-              onClick={() => {
-                setIsOpen(false);
-                addAction.onAdd();
-              }}
-            >
-              {addAction.label}
-            </Button>
-          </MenuFooter>
+          <>
+            <Divider />
+            <MenuFooter>
+              <Button
+                variant="link"
+                isInline
+                icon={<PlusCircleIcon />}
+                onClick={() => {
+                  setIsOpen(false);
+                  addAction.onAdd();
+                }}
+              >
+                {addAction.label}
+              </Button>
+            </MenuFooter>
+          </>
         )}
       </Select>
 

--- a/libs/ui-components/src/components/form/RepositorySelect.tsx
+++ b/libs/ui-components/src/components/form/RepositorySelect.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useField, useFormikContext } from 'formik';
 import {
   Button,
+  Divider,
   Flex,
   FlexItem,
   FormGroup,
@@ -195,19 +196,22 @@ const RepositorySelect = ({
           <ReadOnlyRepositoryListItem invalidRepoItems={invalidRepoItems} />
 
           {canCreateRepo && (
-            <MenuFooter>
-              <Button
-                variant="link"
-                isInline
-                icon={<PlusCircleIcon />}
-                onClick={() => {
-                  setCreateRepoModalOpen(true);
-                }}
-                isDisabled={isReadOnly}
-              >
-                {t('Create repository')}
-              </Button>
-            </MenuFooter>
+            <>
+              <Divider />
+              <MenuFooter>
+                <Button
+                  variant="link"
+                  isInline
+                  icon={<PlusCircleIcon />}
+                  onClick={() => {
+                    setCreateRepoModalOpen(true);
+                  }}
+                  isDisabled={isReadOnly}
+                >
+                  {t('Create repository')}
+                </Button>
+              </MenuFooter>
+            </>
           )}
         </FormSelect>
 


### PR DESCRIPTION
Added divider both to the "Create catalog" and "Create repository"
<img width="797" height="337" alt="Screenshot From 2026-06-11 12-52-51" src="https://github.com/user-attachments/assets/0e35164c-b56c-43a1-ac60-e126950e79eb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds visual dividers to the footer action areas of shared select/menu components, improving separation between selectable options and “create” actions.

## Areas Affected

**libs/ui-components/**
- `libs/ui-components/src/components/form/FormSelect.tsx`: When `addAction` is present, inserts a `Divider` above the menu footer/button (e.g., “Create catalog”).
- `libs/ui-components/src/components/form/RepositorySelect.tsx`: Inserts a `Divider` above the “Create repository” menu footer/button.

## Cross-Cutting Implications

Changes are isolated to the shared UI components library; no platform-specific app, auth proxy, packaging/container build, E2E tests, or CI configuration changes were made. The updated menu footer rendering applies anywhere these shared select components are used (e.g., across standalone and any other consumers of `libs/ui-components`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->