### PR TITLE
EDM-3535: Correct isRHEM detection for OCP plugin

### DIFF
--- a/apps/ocp-plugin/src/components/AppContext/AppContext.tsx
+++ b/apps/ocp-plugin/src/components/AppContext/AppContext.tsx
@@ -23,7 +23,7 @@ import { Prompt } from 'react-router-dom';
 import { getUser } from '@openshift-console/dynamic-plugin-sdk/lib/app/core/reducers';
 import { useSelector } from 'react-redux';
 import { useFetch } from '../../hooks/useFetch';
-import { uiProxy } from '../../utils/apiCalls';
+import { apiProxy } from '../../utils/apiCalls';
 
 import '@flightctl/ui-components/src/styles/global.css';
 import './AppContext.css';
@@ -34,7 +34,7 @@ const useUiSettings = (): { isRHEM: boolean } => {
   React.useEffect(() => {
     const controller = new AbortController();
 
-    fetch(`${uiProxy}/ui-settings.json`, { signal: controller.signal })
+    fetch(`${apiProxy}/ui-settings`, { signal: controller.signal })
       .then((response) => (response.ok ? response.json() : Promise.reject(new Error('Failed to load UI settings'))))
       .then((data: { isRHEM?: boolean }) => {
         const isRHEM = !!data.isRHEM;

--- a/apps/ocp-plugin/src/components/AppContext/AppContext.tsx
+++ b/apps/ocp-plugin/src/components/AppContext/AppContext.tsx
@@ -23,9 +23,33 @@ import { Prompt } from 'react-router-dom';
 import { getUser } from '@openshift-console/dynamic-plugin-sdk/lib/app/core/reducers';
 import { useSelector } from 'react-redux';
 import { useFetch } from '../../hooks/useFetch';
+import { uiProxy } from '../../utils/apiCalls';
 
 import '@flightctl/ui-components/src/styles/global.css';
 import './AppContext.css';
+
+const useUiSettings = (): { isRHEM: boolean } => {
+  const [settings, setSettings] = React.useState({ isRHEM: window.isRHEM ?? false });
+
+  React.useEffect(() => {
+    const controller = new AbortController();
+
+    fetch(`${uiProxy}/ui-settings.json`, { signal: controller.signal })
+      .then((response) => (response.ok ? response.json() : Promise.reject(new Error('Failed to load UI settings'))))
+      .then((data: { isRHEM?: boolean }) => {
+        const isRHEM = !!data.isRHEM;
+        window.isRHEM = isRHEM;
+        setSettings({ isRHEM });
+      })
+      .catch(() => {
+        // Keep defaults when settings cannot be loaded.
+      });
+
+    return () => controller.abort();
+  }, []);
+
+  return settings;
+};
 
 /**
  * OCP Plugin App Context Provider
@@ -78,10 +102,11 @@ const appRoutes = {
 export const useValuesAppContext = (): AppContextProps => {
   const fetch = useFetch();
   const userInfo = useSelector(getUser);
+  const settings = useUiSettings();
 
   return {
     appType: FlightCtlApp.OCP,
-    settings: {},
+    settings,
     user: userInfo?.username || '',
     router: {
       Link,

--- a/apps/ocp-plugin/src/utils/apiCalls.ts
+++ b/apps/ocp-plugin/src/utils/apiCalls.ts
@@ -43,7 +43,7 @@ const apiServer = `${window.location.hostname}${
   window.FCTL_API_PORT ? `:${window.FCTL_API_PORT}` : ''
 }/api/proxy/plugin/flightctl-plugin/api-proxy`;
 
-const uiProxy = `${window.location.protocol}//${apiServer}`;
+export const uiProxy = `${window.location.protocol}//${apiServer}`;
 export const apiProxy = `${uiProxy}/api`;
 
 const alertsAPI = `${apiProxy}/alerts`;

--- a/proxy/app.go
+++ b/proxy/app.go
@@ -80,6 +80,8 @@ func main() {
 		apiRouter.HandleFunc("/logout", authHandler.Logout)
 	}
 
+	router.HandleFunc("/ui-settings.json", server.UISettingsHandler).Methods(http.MethodGet)
+
 	spa := server.SpaHandler{}
 	router.PathPrefix("/").Handler(server.GzipHandler(spa))
 

--- a/proxy/app.go
+++ b/proxy/app.go
@@ -72,15 +72,15 @@ func main() {
 	// Viewing the login command is always available
 	apiRouter.HandleFunc("/login-command", authHandler.GetLoginCommand)
 
-	// Login/logout actions are only available in the standalone UI
-	if config.OcpPlugin != "true" {
+	if config.OcpPlugin == "true" {
+		apiRouter.HandleFunc("/ui-settings", server.UISettingsHandler).Methods(http.MethodGet)
+	} else {
+		// Login/logout actions are only available in the standalone UI
 		apiRouter.HandleFunc("/login", authHandler.Login)
 		apiRouter.HandleFunc("/login/info", authHandler.GetUserInfo)
 		apiRouter.HandleFunc("/login/refresh", authHandler.Refresh)
 		apiRouter.HandleFunc("/logout", authHandler.Logout)
 	}
-
-	router.HandleFunc("/ui-settings.json", server.UISettingsHandler).Methods(http.MethodGet)
 
 	spa := server.SpaHandler{}
 	router.PathPrefix("/").Handler(server.GzipHandler(spa))

--- a/proxy/config/config.go
+++ b/proxy/config/config.go
@@ -21,18 +21,15 @@ var (
 	BaseUiUrl              = getEnvUrlVar("BASE_UI_URL", "http://localhost:9000")
 	AuthInsecure           = getEnvVar("AUTH_INSECURE_SKIP_VERIFY", "")
 	OcpPlugin              = getEnvVar("IS_OCP_PLUGIN", "false")
-	IsRHEM                 = getEnvVar("IS_RHEM", "")
 )
-
-func IsRHEMEnabled() bool {
-	return getEnvVar("IS_RHEM", "") == "true"
-}
 
 var (
 	// TrustXForwardedHeaders enables use of X-Forwarded-Proto and X-Forwarded-Host for request
 	// origin (e.g. TLS termination at an ingress). When false, only r.TLS and r.Host are used.
 	// Set to true when a trusted reverse proxy sets these headers; see also TrustedProxyNets.
 	TrustXForwardedHeaders = parseBoolEnv("TRUST_X_FORWARDED_HEADERS", false)
+	// IsRHEM enables the RHEM mode for the UI.
+	IsRHEM = parseBoolEnv("IS_RHEM", false)
 )
 
 // trustedProxyNets is parsed from TRUSTED_PROXY_CIDRS (comma-separated). When non-empty and

--- a/proxy/config/config.go
+++ b/proxy/config/config.go
@@ -22,6 +22,13 @@ var (
 	AuthInsecure           = getEnvVar("AUTH_INSECURE_SKIP_VERIFY", "")
 	OcpPlugin              = getEnvVar("IS_OCP_PLUGIN", "false")
 	IsRHEM                 = getEnvVar("IS_RHEM", "")
+)
+
+func IsRHEMEnabled() bool {
+	return getEnvVar("IS_RHEM", "") == "true"
+}
+
+var (
 	// TrustXForwardedHeaders enables use of X-Forwarded-Proto and X-Forwarded-Host for request
 	// origin (e.g. TLS termination at an ingress). When false, only r.TLS and r.Host are used.
 	// Set to true when a trusted reverse proxy sets these headers; see also TrustedProxyNets.

--- a/proxy/server/server.go
+++ b/proxy/server/server.go
@@ -16,7 +16,7 @@ type SpaHandler struct{}
 
 func serveIndexPage(w http.ResponseWriter, r *http.Request) {
 	indexName := "index"
-	if config.IsRHEM == "true" {
+	if config.IsRHEM {
 		indexName = "index-rhem"
 	}
 	content, err := os.ReadFile(fmt.Sprintf("./dist/%s.html", indexName))

--- a/proxy/server/settings.go
+++ b/proxy/server/settings.go
@@ -1,0 +1,20 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/flightctl/flightctl-ui/config"
+)
+
+type uiSettings struct {
+	IsRHEM bool `json:"isRHEM"`
+}
+
+func UISettingsHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	settings := uiSettings{
+		IsRHEM: config.IsRHEMEnabled(),
+	}
+	_ = json.NewEncoder(w).Encode(settings)
+}

--- a/proxy/server/settings.go
+++ b/proxy/server/settings.go
@@ -11,10 +11,19 @@ type uiSettings struct {
 	IsRHEM bool `json:"isRHEM"`
 }
 
+// UISettingsHandler serves the UI configuration settings as JSON.
+// It returns the current RHEM mode status and other UI-specific flags.
 func UISettingsHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
 	settings := uiSettings{
-		IsRHEM: config.IsRHEMEnabled(),
+		IsRHEM: config.IsRHEM,
 	}
-	_ = json.NewEncoder(w).Encode(settings)
+	payload, err := json.Marshal(settings)
+	if err != nil {
+		http.Error(w, "Failed to encode settings", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(payload); err != nil {
+		return
+	}
 }


### PR DESCRIPTION
The OCP plugin did not receive the "settings" therefore the "isRHEM" detection didn't work there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Areas affected

- apps/ocp-plugin/: Platform-specific OCP plugin frontend
- proxy/: Go auth proxy backend (UI settings endpoint + RHEM index selection)
- libs/ui-components/: Read-only impact (consumers depend on `settings.isRHEM`)

## Summary

This PR fixes `isRHEM` detection for the OCP plugin by exposing runtime UI settings from the Go proxy and consuming them in the plugin’s app context.

### apps/ocp-plugin/
- Updated `apps/ocp-plugin/src/components/AppContext/AppContext.tsx`:
  - Added a local `useUiSettings()` hook that initializes `isRHEM` from `window.isRHEM`, then fetches `${apiProxy}/ui-settings` (AbortController-protected).
  - Coerces `data.isRHEM` to a boolean (`!!data.isRHEM`), writes it back to `window.isRHEM`, and updates React state; defaults remain if the fetch fails/aborts.
  - `useValuesAppContext` now provides `settings: { isRHEM: boolean }` instead of a hardcoded empty `settings` object.
- Updated `apps/ocp-plugin/src/utils/apiCalls.ts`:
  - `uiProxy` is now exported so other modules can reuse the computed UI proxy base URL.

### proxy/
- Updated `proxy/config/config.go`:
  - `IsRHEM` now parses `IS_RHEM` as a boolean (`parseBoolEnv("IS_RHEM", false)`).
- Added `proxy/server/settings.go`:
  - Introduces `UISettingsHandler`, returning JSON `{ "isRHEM": <bool> }` sourced from `config.IsRHEM`.
- Updated `proxy/app.go`:
  - Conditionally registers `GET /api/ui-settings` only when `config.OcpPlugin == "true"`.
- Updated `proxy/server/server.go`:
  - `serveIndexPage` now checks `config.IsRHEM` as a boolean to choose between `index` and `index-rhem`.

## Cross-cutting implications

- The OCP plugin now relies on a new runtime proxy endpoint (`/api/ui-settings`) to determine `isRHEM`, aligning plugin behavior with server/env configuration.
- While this PR does not modify `libs/ui-components/`, it enables consistent `settings.isRHEM` availability to components that already consume it.
- No changes were made to `libs/types/`, `libs/i18n/`, `libs/cypress/`, `apps/standalone/`, packaging, container builds, or CI/E2E configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->