### PR TITLE
Update CodeRabbit config: refine action pinning, enforce AI attribution

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -312,7 +312,10 @@ reviews:
     - path: ".github/workflows/**/*"
       instructions: |
         CI/CD security (prodsec-skills):
-        - Pin actions by full SHA, not tag
+        - GitHub-owned actions (actions/*) use tag refs (e.g., @v4)
+          for readability — do NOT flag these for missing SHA pins.
+          Third-party actions must be pinned by full SHA with a
+          trailing version comment (e.g., @<sha> # v1.2.3).
         - No secrets in logs; mask sensitive outputs
         - Least privilege: minimize GITHUB_TOKEN permissions
         - No pull_request_target with checkout of PR head
@@ -482,7 +485,7 @@ reviews:
           attribution trailers: Assisted-by, Generated-by, or
           Made-with (e.g., Made-with: Cursor) are acceptable.
           Flag use of Co-Authored-By for AI tools.
-        mode: "warning"
+        mode: "error"
 
       - name: "generated-files-not-hand-edited"
         instructions: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,7 +142,7 @@ jobs:
         with:
           node-version: 22.x
       - name: Run integration tests
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@be1bab96b388bbd9ce3887e397d373c8557e15af # v6.9.2
         with:
           install-command: npm ci
           build: npm run build

--- a/.github/workflows/push-to-main.yaml
+++ b/.github/workflows/push-to-main.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Build
         id: build
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
         with:
           image: ${{ steps.os-image.outputs.image_name }}
           tags: ${{ needs.generate-tags.outputs.image_tags }}
@@ -84,7 +84,7 @@ jobs:
 
       - name: Push to Quay.io
         id: push
-        uses: redhat-actions/push-to-registry@v2.7
+        uses: redhat-actions/push-to-registry@9986a6552bc4571882a4a67e016b17361412b4df # v2.7
         with:
           image: ${{ steps.build.outputs.image }}
           tags: ${{ needs.generate-tags.outputs.image_tags }}
@@ -109,7 +109,7 @@ jobs:
 
       - name: Build
         id: build
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
         with:
           image: ${{ steps.os-image.outputs.image_name }}
           tags: ${{ needs.generate-tags.outputs.image_tags }}
@@ -133,7 +133,7 @@ jobs:
 
       - name: Push to Quay.io
         id: push
-        uses: redhat-actions/push-to-registry@v2.7
+        uses: redhat-actions/push-to-registry@9986a6552bc4571882a4a67e016b17361412b4df # v2.7
         with:
           image: ${{ steps.build.outputs.image }}
           tags: ${{ needs.generate-tags.outputs.image_tags }}


### PR DESCRIPTION
## Summary

- Refine action-pinning rule: allow tag refs for GitHub-owned actions (`actions/*`), require SHA pins only for third-party actions
- Escalate `ai-attribution` check from warning to error

## Test plan

- [ ] Verify CodeRabbit does not flag `actions/checkout@v4` or similar GitHub-owned action tag refs
- [ ] Verify `ai-attribution` fires at error severity on PRs with `Co-Authored-By` AI trailers

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Area Affected
- **.github/workflows/** (CI configuration and CodeRabbit config)

## Summary
Configuration-only updates to CI/security guidance and workflow action pins:

1. **Action pinning rule (`.coderabbit.yaml`)**  
   - Allows GitHub-owned actions matching `actions/*` to be referenced by version tags (e.g., `actions/checkout@v4`) without requiring full-commit SHA pins.  
   - Continues to require third-party actions be pinned to full commit SHAs with a trailing version comment (e.g., `@<sha> # v2.7`).

2. **AI attribution enforcement (`.coderabbit.yaml`)**  
   - Escalates the `ai-attribution` pre-merge check from `warning` to `error`. PRs containing `Co-Authored-By` AI trailers will now fail the check; properly formatted attribution trailers such as `Assisted-by`, `Generated-by`, or `Made-with` are accepted.

3. **Workflow pinning changes (`.github/workflows/ci.yaml`, `.github/workflows/push-to-main.yaml`)**  
   - Third-party actions used in workflows updated to specific commit SHAs (with trailing version labels) for cypress-io/github-action and redhat-actions/* used by image-publishing jobs.  
   - Example: the integration-tests job now uses a pinned SHA for the Cypress action (v6.9.2).

Cross-cutting implications
- No changes to application code, shared UI components, platform-specific apps, the Go auth proxy, container build logic beyond action pinning, or E2E test logic. The changes are CI/configuration-only and affect how workflows and pre-merge linting enforce security and attribution.

Notes
- Commit/PR metadata include an assistance note: "Assisted-by: Claude <noreply@anthropic.com>".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->