### PR TITLE
Patch CVE-2025-61729 in Go proxy

### DIFF
--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -1,8 +1,8 @@
 module github.com/flightctl/flightctl-ui
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	github.com/flightctl/flightctl v1.0.0


### PR DESCRIPTION
## CVE Fix

### Vulnerabilities Addressed

| CVE ID | Severity | Package | Old Version | New Version |
|--------|----------|---------|-------------|-------------|
| CVE-2025-61729 | HIGH (CVSS 7.5) | Go stdlib `crypto/x509` | go 1.24.0 / toolchain go1.25.8 | go 1.25.0 / toolchain go1.25.9 |

### Description

CVE-2025-61729 is a Denial of Service vulnerability in Go's `crypto/x509` package. A malicious X.509 certificate with a large number of Subject Alternative Names causes quadratic runtime in `HostnameError.Error()`, leading to CPU/memory exhaustion. Fixed in Go 1.24.11 and Go 1.25.5+.

The `proxy/` component directly imports `crypto/x509` and `crypto/tls`, making it susceptible.

### Strategy Justification

**CVE-2025-61729 — Go crypto/x509**

| # | Strategy | Result | Details |
|---|----------|--------|---------|
| 1 | Direct update (minor) | Success | Bumped Go version to `go 1.25.0` / `toolchain go1.25.9` in proxy/go.mod (matching backend) |

### Changes

- `proxy/go.mod`: Updated `go` directive from `1.24.0` to `1.25.0`, `toolchain` from `go1.25.8` to `go1.25.9`

### Validation

- Dependencies: Updated to fixed version (go1.25.9 >= fix threshold go1.25.5)
- Vulnerability scan: govulncheck binary scan confirms CVE-2025-61729 is **not present**
- Tests: Pre-existing failure in `auth/redirect_test.go` (unrelated to this change)

### Rollback

To revert this change:
```bash
git revert <commit-sha>
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated `proxy/` (Go auth proxy) to patch HIGH-severity CVE-2025-61729 in Go’s `crypto/x509` by bumping `proxy/go.mod` from `go 1.24.0` → `go 1.25.0` and the toolchain from `go1.25.8` → `go1.25.9`. This change is confined to the Go proxy; it does not affect shared UI components (`libs/ui-components/`), shared types/i18n (`libs/types/`, `libs/i18n/`), Cypress E2E (`libs/cypress/`), platform-specific app code (`apps/standalone/`, `apps/ocp-plugin/`), packaging, or CI configuration (`.github/workflows/`). Validation includes a `govulncheck` scan confirming the CVE is not present after the update, noting an unrelated pre-existing test failure in `auth/redirect_test.go`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->