### PR TITLE
[release-1.0] Backport: Patch CVE-2025-61729 in Go proxy

### DIFF
--- a/proxy/go.mod
+++ b/proxy/go.mod
@@ -1,8 +1,8 @@
 module github.com/flightctl/flightctl-ui
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.6
+toolchain go1.25.9
 
 require (
 	github.com/flightctl/flightctl v1.0.0-main.0.20251127101911-da85f5a8551a


### PR DESCRIPTION
## CVE Fix

### Vulnerabilities Addressed

| CVE ID | Severity | Package | Old Version | New Version |
|--------|----------|---------|-------------|-------------|
| CVE-2025-61729 | HIGH (CVSS 7.5) | Go stdlib `crypto/x509` | go 1.24.0 / toolchain go1.25.8 | go 1.25.0 / toolchain go1.25.9 |

### Description

CVE-2025-61729 is a Denial of Service vulnerability in Go's `crypto/x509` package. A malicious X.509 certificate with a large number of Subject Alternative Names causes quadratic runtime in `HostnameError.Error()`, leading to CPU/memory exhaustion. Fixed in Go 1.24.11 and Go 1.25.5+.

The `proxy/` component directly imports `crypto/x509` and `crypto/tls`, making it susceptible.

### Strategy Justification

**CVE-2025-61729 — Go crypto/x509**

| # | Strategy | Result | Details |
|---|----------|--------|---------|
| 1 | Direct update (minor) | Success | Bumped Go version to `go 1.25.0` / `toolchain go1.25.9` in proxy/go.mod (matching backend) |

### Changes

- `proxy/go.mod`: Updated `go` directive from `1.24.0` to `1.25.0`, `toolchain` from `go1.25.8` to `go1.25.9`

### Validation

- Dependencies: Updated to fixed version (go1.25.9 >= fix threshold go1.25.5)
- Vulnerability scan: govulncheck binary scan confirms CVE-2025-61729 is **not present**
- Tests: Pre-existing failure in `auth/redirect_test.go` (unrelated to this change)

### Rollback

To revert this change:
```bash
git revert <commit-sha>
```
