### PR TITLE
Fix layout for LoginPage

### DIFF
--- a/apps/standalone/src/app/app.css
+++ b/apps/standalone/src/app/app.css
@@ -4,3 +4,7 @@ body,
   height: 100%;
 }
 
+/* Let #root's height flow to routed pages */
+#root > .fctl-app {
+  display: contents;
+}


### PR DESCRIPTION
Adding `fctl-app` main div broke the styling for the LoginPages, moving the content to the top rather than it being vertically aligned.

`display:contents` cannot be applied globally as it was affecting the OCP plugin layout, see https://github.com/flightctl/flightctl-ui/pull/707/changes/b3c9493a6751421ef382af522d235b62c2912a27

<img width="1542" height="1691" alt="fix-layout" src="https://github.com/user-attachments/assets/4bb5f598-ab6c-4cf1-9b33-c073cce13ae1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated `apps/standalone/` login page layout CSS by making the top-level `.fctl-app` container use `display: contents` so routed content can inherit the root height and render vertically centered again.

This is a standalone app change only; it does not modify shared UI components, types, i18n, Cypress tests, the Go auth proxy, packaging, or CI. The change is intentionally scoped to avoid impacting the OCP plugin layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->