### PR TITLE
Patch CVE-2026-6322 by updating fast-uri to 3.1.3 (release-1.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10051,9 +10051,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## CVE Fix

### Vulnerabilities Addressed

| CVE ID | Severity | Package | Old Version | New Version |
|--------|----------|---------|-------------|-------------|
| CVE-2026-6322 | HIGH | fast-uri | 3.1.0 | 3.1.3 |

### Strategy Justification

| # | Strategy | Result | Details |
|---|----------|--------|---------|
| 1 | Direct update (minor) | Success | `npm update fast-uri` — lockfile-only change |

### Validation

- Build: PASS (`npm run build`)
- fast-uri updated from 3.1.0 to 3.1.3 (fix version: 3.1.2)

### Rollback

To revert this change:
```bash
git revert <commit-sha>
```