### PR TITLE
Patch CVE-2026-13676 by updating fast-uri to 3.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9811,9 +9811,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## CVE Fix

### Vulnerabilities Addressed

| CVE ID | Severity | Package | Old Version | New Version |
|--------|----------|---------|-------------|-------------|
| CVE-2026-13676 | HIGH | fast-uri | 3.1.2 | 3.1.3 |

### Strategy Justification

| # | Strategy | Result | Details |
|---|----------|--------|---------|
| 1 | Direct update (minor) | Success | `npm update fast-uri` — lockfile-only change |

### Description

fast-uri 2.3.1 through 3.1.2 fails to canonicalize Unicode (IDN) hostnames for HTTP-family URLs, enabling host confusion and potential security bypasses.

### Validation

- Build: PASS (`npm run build`)
- fast-uri updated from 3.1.2 to 3.1.3 (lockfile only)

### Rollback

To revert this change:
```bash
git revert <commit-sha>
```