### PR TITLE
[release-1.0] Update to go v1.25 tooling

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@ ENV NODE_OPTIONS='--max-old-space-size=8192'
 RUN npm ci
 RUN npm run build
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as proxy-build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as proxy-build
 WORKDIR /app
 COPY proxy /app
 USER 0

--- a/Containerfile.ocp
+++ b/Containerfile.ocp
@@ -12,7 +12,7 @@ ENV NODE_OPTIONS='--max-old-space-size=8192'
 RUN npm ci
 RUN npm run build:ocp
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1762373805 as proxy-build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8-1774618347 as proxy-build
 WORKDIR /app
 COPY proxy /app
 USER 0


### PR DESCRIPTION
Manual backport of https://github.com/flightctl/flightctl-ui/pull/629 due to `release-1.0` having the older file structure for `Containerfiles`