### PR TITLE
EDM-4152: Fix responsiveness for Form

### DIFF
--- a/libs/cypress/e2e/fleets/createFleet.cy.ts
+++ b/libs/cypress/e2e/fleets/createFleet.cy.ts
@@ -80,13 +80,16 @@ describe('Create fleet form', () => {
     createFleetWizardPage = new CreateFleetWizardPage();
 
     createFleetWizardPage.newFleetNameField.type(existingFleetName).blur();
-    createFleetWizardPage.openFleetRichValidationsPopover();
+
+    // Open the validation popover, and close it before continuing the test
+    createFleetWizardPage.toggleFleetRichValidationsPopover();
     createFleetWizardPage.newFleetRichValidationsPopoverError.should('contain.text', 'Name must be unique');
+    createFleetWizardPage.toggleFleetRichValidationsPopover();
+
     createFleetWizardPage.nextFleetWizardButton.should('be.disabled');
 
-    // Fix the duplicate fleet name and check that the form could be submitted
+    // Fix the duplicate fleet name and ensure that the form can now be submitted
     createFleetWizardPage.newFleetNameField.clear().type(`${existingFleetName}-2`);
-    createFleetWizardPage.newFleetRichValidationsPopoverError.should('not.exist');
     createFleetWizardPage.nextFleetWizardButton.should('be.enabled');
   });
 });

--- a/libs/cypress/pages/CreateFleetWizardPage.ts
+++ b/libs/cypress/pages/CreateFleetWizardPage.ts
@@ -19,8 +19,8 @@ export class CreateFleetWizardPage {
     return cy.get('input[aria-label="Fleet name"]');
   }
 
-  openFleetRichValidationsPopover() {
-    return cy.get('button[aria-label="Validation"').click();
+  toggleFleetRichValidationsPopover() {
+    return cy.get('[data-testid="rich-validation-field-name-validation-button"]').click();
   }
 
   get newFleetRichValidationsPopoverError() {

--- a/libs/ui-components/src/components/form/FlightCtlForm.css
+++ b/libs/ui-components/src/components/form/FlightCtlForm.css
@@ -1,0 +1,32 @@
+.fctl-form {
+  width: 100%;
+  container-type: inline-size;
+  container-name: fctl-form;
+}
+
+.fctl-form__content {
+  width: 100%;
+}
+
+/*
+ * Constrain line length only in genuinely wide form areas (e.g. full-page forms).
+ * Wizard and split-view hosts are often < 75rem even on large monitors, so keep
+ * those at full width. Breakpoints are container-based, not viewport-based.
+ */
+@container fctl-form (min-width: 75rem) {
+  .fctl-form--responsive .fctl-form__content {
+    width: 83.333%;
+  }
+}
+
+@container fctl-form (min-width: 90rem) {
+  .fctl-form--responsive .fctl-form__content {
+    width: 75%;
+  }
+}
+
+@container fctl-form (min-width: 105rem) {
+  .fctl-form--responsive .fctl-form__content {
+    width: 66.666%;
+  }
+}

--- a/libs/ui-components/src/components/form/FlightCtlForm.tsx
+++ b/libs/ui-components/src/components/form/FlightCtlForm.tsx
@@ -1,67 +1,26 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import { Form, Grid, GridItem, globalWidthBreakpoints, gridItemSpanValueShape } from '@patternfly/react-core';
+import { Form } from '@patternfly/react-core';
 
-const widthToSpan = (width: number = 0): gridItemSpanValueShape => {
-  if (width < globalWidthBreakpoints.sm) {
-    return 12;
-  }
-  if (width < globalWidthBreakpoints.md) {
-    return 10;
-  }
-  if (width < globalWidthBreakpoints.lg) {
-    return 8;
-  }
-  return 6;
-};
-
-const useContainerWidth = () => {
-  const ref = React.useRef<HTMLDivElement>(null);
-  const [width, setWidth] = React.useState<number>(0);
-
-  React.useLayoutEffect(() => {
-    if (!ref.current) return;
-    setWidth(ref.current.getBoundingClientRect().width);
-
-    let rafId: number;
-    const observer = new ResizeObserver((entries) => {
-      rafId = requestAnimationFrame(() => {
-        setWidth(entries[0].contentRect.width);
-      });
-    });
-    observer.observe(ref.current);
-    return () => {
-      observer.disconnect();
-      cancelAnimationFrame(rafId);
-    };
-  }, []);
-
-  return [ref, width] as const;
-};
+import './FlightCtlForm.css';
 
 const FlightCtlForm = ({
   className,
   children,
   isResponsive = true,
-}: React.PropsWithChildren<{ className?: string; isResponsive?: boolean }>) => {
-  const [ref, width] = useContainerWidth();
-
-  return (
-    <div ref={ref}>
-      <Grid span={isResponsive ? widthToSpan(width) : 12}>
-        <GridItem>
-          <Form
-            className={className}
-            onSubmit={(ev) => {
-              ev.preventDefault();
-            }}
-          >
-            {children}
-          </Form>
-        </GridItem>
-      </Grid>
+}: React.PropsWithChildren<{ className?: string; isResponsive?: boolean }>) => (
+  <div className={isResponsive ? 'fctl-form fctl-form--responsive' : 'fctl-form'}>
+    <div className="fctl-form__content">
+      <Form
+        className={className}
+        onSubmit={(ev) => {
+          ev.preventDefault();
+        }}
+      >
+        {children}
+      </Form>
     </div>
-  );
-};
+  </div>
+);
 
 export default FlightCtlForm;


### PR DESCRIPTION
The `FlightCtlForm` responsiveness was not working very well.

It was not taking into account the actual rendered width of the container, so in large screens with reduced viewport size, it would not occupy all available space.

As a consequence, now the Alerts in the forms adjust to the available space.

Before: large screen with reduced viewport:
<img width="500" height="846" alt="before-spacing" src="https://github.com/user-attachments/assets/5466354b-07d0-45c4-b894-81d6ee995491" />

Now we'd use container queries to adjust the spacing better.

https://github.com/user-attachments/assets/7d77c517-6686-44f8-80fc-5d3e43a1c458



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated shared UI and E2E coverage for fleet creation form responsiveness.

- **`libs/ui-components/`**: Added **`FlightCtlForm.css`** and updated **`FlightCtlForm.tsx`** to fix responsiveness via **container queries** (responsive spacing/content width changes at container-width breakpoints) rather than runtime container measurement. The component now toggles a responsive wrapper class (`fctl-form--responsive`) instead of using `useLayoutEffect`/`ResizeObserver`-driven span calculations and PatternFly grid/breakpoint helpers.
- **`libs/cypress/`**: Updated the Create Fleet wizard rich validation popover flow by switching the test/helper from `openFleetRichValidationsPopover()` to `toggleFleetRichValidationsPopover()` and adjusting the e2e interaction accordingly.

Cross-cutting impact:
- **Shared component change** in `libs/ui-components/` may affect any surface (e.g., standalone and OCP plugin) that renders `FlightCtlForm`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->