### PR TITLE
EDM-4782: Fix navigation for tabbed components in OCP v4.22

### DIFF
--- a/libs/ui-components/src/components/TabsNav/TabsNav.tsx
+++ b/libs/ui-components/src/components/TabsNav/TabsNav.tsx
@@ -25,18 +25,16 @@ const TabsNav: React.FC<TabsNavProps> = ({ children, 'aria-label': ariaLabel, ta
     setActiveTab(String(newActiveTab));
   }, [location.pathname, tabKeys]);
 
-  // Handle tab selection and navigate to the corresponding route
+  // Navigate to the selected tab path using absolute path from location.pathname
+  // Relative navigate() resolves differently based on the React Router version.
   const handleTabSelect = (_event: React.MouseEvent | React.KeyboardEvent | undefined, tabIndex: string | number) => {
     const tabKey = String(tabIndex);
     setActiveTab(tabKey);
 
-    const isOnTabPath = tabKeys.some((key) => location.pathname.endsWith(`/${key}`));
-    if (isOnTabPath) {
-      // React Router v6/v7 appends bare segments; navigate to sibling tab instead.
-      navigate(`../${tabKey}`, { relative: 'path' });
-    } else {
-      navigate(tabKey);
-    }
+    const pathname = location.pathname.replace(/\/$/, '');
+    const isOnTabPath = tabKeys.some((key) => pathname.endsWith(`/${key}`));
+    const nextPath = isOnTabPath ? pathname.replace(/\/[^/]+$/, `/${tabKey}`) : `${pathname}/${tabKey}`;
+    navigate(nextPath);
   };
 
   return (

--- a/libs/ui-components/src/components/TabsNav/TabsNav.tsx
+++ b/libs/ui-components/src/components/TabsNav/TabsNav.tsx
@@ -29,8 +29,14 @@ const TabsNav: React.FC<TabsNavProps> = ({ children, 'aria-label': ariaLabel, ta
   const handleTabSelect = (_event: React.MouseEvent | React.KeyboardEvent | undefined, tabIndex: string | number) => {
     const tabKey = String(tabIndex);
     setActiveTab(tabKey);
-    // Navigate to the relative path
-    navigate(tabKey);
+
+    const isOnTabPath = tabKeys.some((key) => location.pathname.endsWith(`/${key}`));
+    if (isOnTabPath) {
+      // React Router v6/v7 appends bare segments; navigate to sibling tab instead.
+      navigate(`../${tabKey}`, { relative: 'path' });
+    } else {
+      navigate(tabKey);
+    }
   };
 
   return (


### PR DESCRIPTION
After the changes from OCP v4.22 related to the React Router, whenever the user would click on a new tab, the tab element was being concatenated to the previous URL, resulting in the tab content being empty.

The change should work in OCP v4.22 and also older versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the shared `libs/ui-components/` `TabsNav` component to build **absolute** tab navigation paths compatible with React Router behavior changes introduced in **OCP v4.22** (and working with older versions).
- `TabsNav` now:
  - Derives the active tab from `location.pathname`.
  - On tab selection, trims any trailing slash and computes `nextPath` as an absolute path—**replacing the last URL segment** when already on an existing tab route, otherwise **appending** `/${tabKey}`—preventing URL concatenation that could lead to empty tab content.
- Cross-cutting impact: this shared component affects tabbed details pages in both **`apps/standalone/`** and **`apps/ocp-plugin/`**, because the OCP plugin wrappers render the same shared details pages/components that use `TabsNav`.
- No changes impact `libs/types/`, `libs/i18n/`, `libs/cypress/`, the Go/auth proxy (`proxy/`), container builds/packaging (`packaging/`), or CI configuration (`.github/workflows/`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->