### PR TITLE
[release-1.2] Patch CVE-2026-13676 by updating fast-uri to 3.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9811,9 +9811,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Resolves CVE-2026-13676 (HIGH) in fast-uri.
Updated fast-uri from 3.1.2 to 3.1.3 via lockfile update. Fixes host confusion via failed IDN canonicalization.

Assisted-by: Claude <noreply@anthropic.com>
(cherry picked from commit b7a887458b0ef09a02010e4f9730f5a28783d6ca) Made-with: Cursor