### PR TITLE
CVE-2026-59869: patch js-yaml to v4.3.0

### DIFF
--- a/apps/ocp-plugin/package.json
+++ b/apps/ocp-plugin/package.json
@@ -86,7 +86,7 @@
     "@types/react-redux": "^7.1.33",
     "formik": "^2.4.9",
     "i18next": "^21.8.14",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.0",
     "monaco-editor": "^0.51.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",

--- a/apps/standalone/package.json
+++ b/apps/standalone/package.json
@@ -52,7 +52,7 @@
     "i18next": "^21.8.14",
     "i18next-browser-languagedetector": "^7.2.1",
     "i18next-http-backend": "^2.5.0",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.0",
     "monaco-editor": "^0.51.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",

--- a/libs/ui-components/package.json
+++ b/libs/ui-components/package.json
@@ -40,7 +40,7 @@
     "@xterm/xterm": "^5.5.0",
     "file-saver": "^2.0.2",
     "formik": "^2.4.5",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.0",
     "percent-round": "^2.3.1",
     "react-markdown": "^8.0.7",
     "semver": "^7.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,28 +91,6 @@
         "webpack-dev-server": "^6.0.0"
       }
     },
-    "apps/ocp-plugin/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "apps/ocp-plugin/node_modules/react-redux": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.2.tgz",
@@ -246,28 +224,6 @@
         "webpack-dev-server": "^6.0.0"
       }
     },
-    "apps/standalone/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "libs/i18n": {
       "name": "@flightctl/i18n",
       "version": "0.0.0",
@@ -327,28 +283,6 @@
         "react-i18next": "11.7.3 - 15.x",
         "react-router-dom": "^5.3 || ^6.30.3",
         "victory": "^37.3.6"
-      }
-    },
-    "libs/ui-components/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "libs/ui-components/node_modules/react-router": {
@@ -2584,9 +2518,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2596,7 +2530,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
@@ -2629,19 +2563,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
@@ -12423,10 +12344,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@types/react-redux": "^7.1.33",
         "formik": "^2.4.9",
         "i18next": "^21.8.14",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "monaco-editor": "^0.51.0",
         "react": "17.0.1",
         "react-dom": "17.0.1",
@@ -92,9 +92,19 @@
       }
     },
     "apps/ocp-plugin/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -206,7 +216,7 @@
         "i18next": "^21.8.14",
         "i18next-browser-languagedetector": "^7.2.1",
         "i18next-http-backend": "^2.5.0",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "monaco-editor": "^0.51.0",
         "react": "17.0.1",
         "react-dom": "17.0.1",
@@ -237,9 +247,19 @@
       }
     },
     "apps/standalone/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -277,7 +297,7 @@
         "@xterm/xterm": "^5.5.0",
         "file-saver": "^2.0.2",
         "formik": "^2.4.5",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "percent-round": "^2.3.1",
         "react-markdown": "^8.0.7",
         "semver": "^7.7.3",
@@ -310,9 +330,19 @@
       }
     },
     "libs/ui-components/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
   "dependencies": {
     "fast-json-patch": "^3.1.1",
     "lodash": "^4.18.0"
+  },
+  "overrides": {
+    "js-yaml": "4.3.0"
   }
 }


### PR DESCRIPTION
## CVE Fix

### Vulnerabilities Addressed

| CVE ID | Severity | Package | Old Version | New Version |
|--------|----------|---------|-------------|-------------|
| CVE-2026-59869 | High | js-yaml | 4.1.0 | 4.3.0 |

Related: Dependabot alert #160 ([GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m)).

https://github.com/advisories/

### Strategy Justification

**CVE-2026-59869 — js-yaml**

Running `npm update js-yaml` was not enough as 2 dev tools were pinning to exact older versions.
Added `overrides` in package.json


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Upgraded `js-yaml` to `4.3.0` in `libs/ui-components/`, `apps/standalone/`, and `apps/ocp-plugin/` to address CVE-2026-59869.
- Added root `package.json` overrides to enforce `js-yaml@4.3.0` for development tools that pinned older versions.
- Affects shared UI component dependencies and both standalone and OCP plugin applications; no direct code or public API changes.
- No changes to `libs/types/`, `libs/i18n/`, `libs/cypress/`, `proxy/`, `packaging/`, or `.github/workflows/`. No Go auth proxy, container build, E2E test, or CI configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->