### PR TITLE
EDM-4859: Better align the Catalog content to the page

### DIFF
--- a/libs/ui-components/src/components/Catalog/CatalogPage.tsx
+++ b/libs/ui-components/src/components/Catalog/CatalogPage.tsx
@@ -234,7 +234,7 @@ export const CatalogPageContent = ({
               </div>
             </PageSection>
           ) : (
-            <PageSection hasBodyWrapper={false} type="wizard">
+            <PageSection hasBodyWrapper={false}>
               <Split hasGutter>
                 <SplitItem className="fctl-catalog-page fctl-catalog-page__filters">
                   <DescriptionList>


### PR DESCRIPTION
Make the content for Catalog consistent with the rest of the pages. The outer wrapping element does not use full-height unless the content requires so.


See comparison with Image Builds page, and how the Catalog would look like for fewer or more catalog items.

With fewer items:
<img width="3850" height="2013" alt="with-few" src="https://github.com/user-attachments/assets/bfc4bc70-99ea-4797-93e6-2c0aba5922c9" />

With many items:
<img width="3850" height="2013" alt="with-many" src="https://github.com/user-attachments/assets/e97e5f40-2b68-4a11-b7fb-0c87afec6322" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated the shared Catalog UI in `libs/ui-components/` to use the default `PageSection` layout instead of the wizard layout, improving content height and page alignment.
- Catalog rendering, filters, empty states, and split-pane behavior remain unchanged.
- No changes to `libs/types/`, `libs/i18n/`, `libs/cypress/`, platform-specific apps, auth proxy, packaging, or CI.
- As a shared component change, the updated layout may affect both standalone and OCP plugin consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->