### PR TITLE
CVE-2026-59879: patch immutable to v4.3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11237,13 +11237,10 @@
       "license": "ISC"
     },
     "node_modules/immutable": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
-      "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "lodash": "^4.18.0"
   },
   "overrides": {
-    "js-yaml": "4.3.0"
+    "js-yaml": "4.3.0",
+    "immutable": "4.3.9"
   }
 }


### PR DESCRIPTION
## CVE Fix

### Vulnerabilities Addressed

| CVE ID | Severity | Package | Old Version | New Version |
|--------|----------|---------|-------------|-------------|
| CVE-2026-59879 | High | immutable | 3.8.3 | 4.3.9 |
| CVE-2026-59880 | High | immutable | 3.8.3 | 4.3.9 |

Dependabot: https://github.com/flightctl/flightctl-ui/security/dependabot/162 , https://github.com/flightctl/flightctl-ui/security/dependabot/163

Advisory: https://github.com/advisories/GHSA-v56q-mh7h-f735, https://github.com/advisories/GHSA-xvcm-6775-5m9r

### Strategy Justification

**CVE-2026-59879 — immutable**

| # | Strategy | Result | Details |
|---|----------|--------|---------|
| 1 | Direct update (minor) | N/A | Transitive only via `@openshift-console/dynamic-plugin-sdk` |
| 2 | Transitive update | N/A | Cannot upgrade `@openshift-console/dynamic-plugin-sdk` (ocp-plugin constraint); SDK pins `immutable: "3.x"` and no patched 3.x exists |
| 3 | Override/pin | Success | Root npm override `"immutable": "4.3.9"`; lockfile updated; SDK stays at 4.19.1 |
| 4 | Major version update | Skipped | Major bump applied via override (Strategy 3); 5.1.8 not required |

No application source changes. Same override pattern as the recent `js-yaml` CVE fix, so it is straightforward to backport to `release-1.1` and `release-1.2`.

### Validation

- Dependencies: `immutable` updated to 4.3.9 via npm override (SDK remains 4.19.1)
- Vulnerability scan: FIXED (`npm audit` / `verify.py` — CVE-2026-59879 absent)
- Tests: `npm run lint` PASS; `npm run build` and `npm run build:ocp` PASS

### Rollback

To revert this change:
```bash
git revert <commit-sha>
```
Or remove the `"immutable": "4.3.9"` entry from root `package.json` `overrides` and run `npm install`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **Dependency/security:** Updated the root npm `overrides` to force `immutable` **3.8.3 → 4.3.9** to address **CVE-2026-59879** and **CVE-2026-59880**; retained the existing `js-yaml` override (**4.3.0**).
- **Lockfile:** Updated dependency resolution (notably `package-lock.json` now resolves `immutable` to **4.3.9**).
- **Affected areas:** Dependency-only change; no application source changes across `libs/ui-components/`, `libs/types/`, `libs/i18n/`, `libs/cypress/`, `apps/standalone/`, `apps/ocp-plugin/`, proxy/auth proxy, packaging, or `.github/workflows/` (no CI/E2E/container build logic changes).
- **Cross-cutting implications:** OCP runtime continues to use `immutable` **3.8.x** (no change to that runtime behavior); `flightctl-ui` does not use `immutable` directly and it isn’t part of the build.
- **Validation:** Vulnerability checks report fixes, `npm run lint` passes, and both build commands pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->