### PR TITLE
NO-ISSUE: Restore Prettier as default formatter for TSX files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,8 +26,7 @@
     "editor.codeActionsOnSave": {
       "source.organizeImports": "never",
       "source.sortImports": "never"
-    },
-    "editor.defaultFormatter": "vscode.typescript-language-features"
+    }
   },
   "[json]": {
     "editor.formatOnSave": true


### PR DESCRIPTION
Revert the vscode.typescript-language-features override added in EDM-3927 so format-on-save matches `npm run format` (Prettier) again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated `.vscode/settings.json` to restore Prettier as the default formatter for TSX files.
- Aligns VS Code format-on-save behavior with `npm run format`.
- No changes to shared UI components, application code, auth proxy, container builds, E2E tests, or CI configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->