### PR TITLE
EDM-4987: Do not send wrong bytes that causes the session logout

### DIFF
--- a/libs/ui-components/src/hooks/terminalWsUtils.ts
+++ b/libs/ui-components/src/hooks/terminalWsUtils.ts
@@ -1,9 +1,0 @@
-/** Prefix WebSocket payload with a k8s-style channel byte (0x00 stdin, 0x04 resize). */
-export const msgToBytes = (msg: string, resize?: boolean) => {
-  const encoder = new TextEncoder();
-  const encodedData = encoder.encode(msg);
-  const result = new Uint8Array(encodedData.length + 1);
-  result[0] = resize ? 0x4 : 0x00;
-  result.set(encodedData, 1);
-  return result;
-};

--- a/libs/ui-components/src/hooks/useAppConsoleWebSocket.ts
+++ b/libs/ui-components/src/hooks/useAppConsoleWebSocket.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useAppContext } from './useAppContext';
-import { msgToBytes } from './terminalWsUtils';
 
 const APP_CONSOLE_CLOSE_CODE = 1000;
 const APP_CONSOLE_CLOSE_REASON = 'client disconnect';
@@ -100,16 +99,14 @@ export const useAppConsoleWebSocket = (
   const forceConnectRef = React.useRef(false);
 
   const sendMessage = React.useCallback((data: string, resize?: boolean) => {
-    const ws = wsRef.current;
-    if (ws?.readyState !== WebSocket.OPEN) {
-      return;
-    }
-    // Serial stdin is raw bytes; resize uses device-console channel framing (0x4 + size JSON).
+    // App console uses raw serial websocket (raw bytes, not k8s channels). Resize is not supported
     if (resize) {
-      ws.send(msgToBytes(data, true));
       return;
     }
-    ws.send(new TextEncoder().encode(data));
+    const ws = wsRef.current;
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(new TextEncoder().encode(data));
+    }
   }, []);
 
   const disconnect = React.useCallback(() => {

--- a/libs/ui-components/src/hooks/useWebSocket.ts
+++ b/libs/ui-components/src/hooks/useWebSocket.ts
@@ -1,9 +1,20 @@
 import * as React from 'react';
 import { useTranslation } from './useTranslation';
 import { useAppContext } from './useAppContext';
-import { msgToBytes } from './terminalWsUtils';
 
 const isErrorCloseEvent = (evt: CloseEvent) => evt.code !== 1000 && evt.code !== 1001;
+
+const k8sStreamChannel = 0x00;
+const k8sResizeChannel = 0x04;
+
+/** Device console uses k8s stream channels */
+const encodeK8sChannelFrame = (msg: string, resize?: boolean): Uint8Array<ArrayBuffer> => {
+  const encodedData = new TextEncoder().encode(msg);
+  const frame = new Uint8Array(new ArrayBuffer(encodedData.length + 1));
+  frame[0] = resize ? k8sResizeChannel : k8sStreamChannel;
+  frame.set(encodedData, 1);
+  return frame;
+};
 
 type WsMetadata = {
   tty: boolean;
@@ -42,7 +53,7 @@ export const useWebSocket = <T>(
   const sendMessage = React.useCallback((data: string, resize?: boolean) => {
     const ws = wsRef.current;
     if (ws?.readyState === WebSocket.OPEN) {
-      ws.send(msgToBytes(data, resize));
+      ws.send(encodeK8sChannelFrame(data, resize));
     }
   }, []);
 


### PR DESCRIPTION
In `useAppConsoleWebSocket`, reusing `msgToBytes` that's designed to work for k8s channels, was incorrectly sending the "0x04" prefix which is equivalent to "Control+D" and logged out the user.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated shared UI WebSocket handling in `libs/ui-components/`.
- Removed the Kubernetes-specific `msgToBytes` utility from `useAppConsoleWebSocket`.
- Added Kubernetes channel framing locally in `useWebSocket`.
- Prevented the incorrect `0x04` prefix that could trigger `Control+D` and log out the user.
- Resize messages from the app console are no longer transmitted.

## Impact

- Affects shared UI components used by platform applications.
- Improves WebSocket protocol correctness and user-session stability.
- Does not change `libs/types/`, `libs/i18n/`, `libs/cypress/`, `apps/standalone/`, `apps/ocp-plugin/`, `proxy/`, `packaging/`, or `.github/workflows/`.
- No security issue is introduced or reported.
- No container, E2E test, Go auth proxy, or CI configuration changes are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->