### PR TITLE
EDM-4888: Enable the restart action on success

### DIFF
--- a/libs/i18n/locales/en/translation.json
+++ b/libs/i18n/locales/en/translation.json
@@ -602,6 +602,7 @@
   "Stop": "Stop",
   "Restart": "Restart",
   "Open console": "Open console",
+  "The requested action failed": "The requested action failed",
   "Expand row": "Expand row",
   "Ready": "Ready",
   "Restarts": "Restarts",

--- a/libs/ui-components/src/components/DetailsPage/Tables/ApplicationLifecycleActions.tsx
+++ b/libs/ui-components/src/components/DetailsPage/Tables/ApplicationLifecycleActions.tsx
@@ -219,7 +219,7 @@ const ApplicationLifecycleActions = ({
           <Alert
             isInline
             variant="danger"
-            title={t('An error occurred')}
+            title={t('The requested action failed')}
             isPlain
             actionClose={<AlertActionCloseButton onClose={clearError} />}
           >

--- a/libs/ui-components/src/hooks/useApplicationLifecycle.ts
+++ b/libs/ui-components/src/hooks/useApplicationLifecycle.ts
@@ -2,7 +2,11 @@ import * as React from 'react';
 
 import type { ApplicationStatusType, Device } from '@flightctl/types';
 
-import { type ApplicationLifecycleAction, shouldClearPendingLifecycleAction } from '../utils/applicationLifecycle';
+import {
+  type ApplicationLifecycleAction,
+  RESTART_PENDING_TIMEOUT_MS,
+  shouldClearPendingLifecycleAction,
+} from '../utils/applicationLifecycle';
 import { getErrorMessage } from '../utils/error';
 import { useFetch } from './useFetch';
 
@@ -56,6 +60,21 @@ export const useApplicationLifecycle = ({
       restartsAtRequestRef.current = undefined;
     }
   }, [appRestarts, appStatus, pendingAction]);
+
+  React.useEffect(() => {
+    if (pendingAction !== 'restart') {
+      return;
+    }
+
+    // Restarting a running application does not produce an observable change in status.
+    // If the action was successfully submitted, it is considered finished after a short timeout.
+    const timer = window.setTimeout(() => {
+      setPendingAction(null);
+      restartsAtRequestRef.current = undefined;
+    }, RESTART_PENDING_TIMEOUT_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [pendingAction]);
 
   const executeAction = React.useCallback(
     async (action: ApplicationLifecycleAction) => {

--- a/libs/ui-components/src/utils/applicationLifecycle.ts
+++ b/libs/ui-components/src/utils/applicationLifecycle.ts
@@ -158,6 +158,12 @@ export const getDeviceAppLifecycleOverrides = (
   return mergeApplicationLifecycleLayers(fleetOverrides, deviceOverrides);
 };
 
+/**
+ * The "status.apps[].restarts" field is only modified on "real" app restarts/crashes, not by successful restarts.
+ * Successfully restarting an application is not observable through status, and the action is cleared after a timeout.
+ */
+export const RESTART_PENDING_TIMEOUT_MS = 500;
+
 export const shouldClearPendingLifecycleAction = (
   pendingAction: ApplicationLifecycleAction,
   currentStatus: ApplicationStatusType,
@@ -175,11 +181,13 @@ export const shouldClearPendingLifecycleAction = (
 
     case 'start':
       return (
-        currentStatus === ApplicationStatusType.ApplicationStatusStarting ||
+        currentStatus === ApplicationStatusType.ApplicationStatusCompleted ||
         currentStatus === ApplicationStatusType.ApplicationStatusRunning ||
         currentStatus === ApplicationStatusType.ApplicationStatusError
       );
     case 'restart':
+      // The following conditions to clearing pending "restart" actions may not always eventually be satisfied.
+      // See RESTART_PENDING_TIMEOUT_MS for more details.
       return (
         currentStatus === ApplicationStatusType.ApplicationStatusStarting ||
         currentStatus !== statusAtRequest ||


### PR DESCRIPTION
When the user attempts to "Restart" an already started application, the Backend just signals the intent with a new annotation called `restartGeneration`, and there is no observable field in status (or the annotation itself) that can be used to understand when the action is in progress or finished.

Given this, we clear the action after an arbitrary timeout to signal that the action has been received and was triggered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **Shared UI components:** Updated lifecycle handling in `libs/ui-components/`.
- Restart actions now clear after `RESTART_PENDING_TIMEOUT_MS` when the backend provides no completion status.
- Start actions now clear on `Completed`.
- The lifecycle error alert title now reads **“The requested action failed”**.
- The change affects shared UI behavior used by platform applications.
- No changes affect `libs/types/`, `libs/i18n/`, `libs/cypress/`, app-specific code, the Go auth proxy, container builds, E2E tests, or CI configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->