### PR TITLE
EDM-4999: Redefine which statuses allow start/stop actions

### DIFF
--- a/libs/ui-components/src/components/DetailsPage/Tables/ApplicationLifecycleActions.tsx
+++ b/libs/ui-components/src/components/DetailsPage/Tables/ApplicationLifecycleActions.tsx
@@ -21,6 +21,7 @@ import {
   type ApplicationLifecycleAction,
   hasAplicationStatusMismatch,
   startableStatuses,
+  stoppableStatuses,
   transitionalStatuses,
 } from '../../../utils/applicationLifecycle';
 import {
@@ -107,6 +108,7 @@ const ApplicationLifecycleActions = ({
   const isAppRunning = appStatus === ApplicationStatusType.ApplicationStatusRunning;
   const desiredStateIsStopped = desiredState === ApplicationDesiredState.ApplicationDesiredStateStopped;
   const canStart = startableStatuses.includes(appStatus);
+  const canStop = stoppableStatuses.includes(appStatus);
   const isTransitioning = transitionalStatuses.includes(appStatus);
   const hasStatusMismatch = hasAplicationStatusMismatch(appStatus, desiredState);
   const isUserInitiatedTransition = pendingAction != null;
@@ -162,7 +164,7 @@ const ApplicationLifecycleActions = ({
             {t('Start')}
           </DropdownItem>
         )}
-        {isAppRunning && (
+        {canStop && (
           <DropdownItem component="button" onClick={() => handleAction('stop')}>
             {t('Stop')}
           </DropdownItem>

--- a/libs/ui-components/src/utils/applicationLifecycle.ts
+++ b/libs/ui-components/src/utils/applicationLifecycle.ts
@@ -29,6 +29,13 @@ export const startableStatuses = [
   ApplicationStatusType.ApplicationStatusStopping,
   ApplicationStatusType.ApplicationStatusStopped,
   ApplicationStatusType.ApplicationStatusError,
+  ApplicationStatusType.ApplicationStatusUnknown,
+];
+
+export const stoppableStatuses = [
+  ApplicationStatusType.ApplicationStatusRunning,
+  ApplicationStatusType.ApplicationStatusError,
+  ApplicationStatusType.ApplicationStatusUnknown,
 ];
 
 export type ApplicationLifecycleAction = 'start' | 'stop' | 'restart';


### PR DESCRIPTION
The UI was not displaying the "Stop" action for applications in error status.

We'd now also allow Start/Stop for applications in an Unknown status.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Areas affected

- `libs/ui-components/`: Updates shared application lifecycle actions.
- Applications in `Error` status can use **Stop**.
- Applications in `Unknown` status can use **Start** and **Stop**.
- Shared UI behavior affects both standalone and OCP plugin consumers.

## Unaffected areas

- No changes to `libs/types/`, `libs/i18n/`, `libs/cypress/`, platform-specific app code, the Go auth proxy, container builds, E2E tests, or CI configuration.
- No security impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->