### PR TITLE
EDM-5625: Use correct links to RHEM 1.3

### DIFF
--- a/libs/ui-components/src/hooks/useAppLinks.ts
+++ b/libs/ui-components/src/hooks/useAppLinks.ts
@@ -3,7 +3,7 @@ import { useAppContext } from './useAppContext';
 // Links to other flightctl upstream resources
 export const DEMO_REPOSITORY_URL = 'https://github.com/flightctl/flightctl-demos';
 
-export const RHEM_VERSION = '1.2';
+export const RHEM_VERSION = '1.3';
 
 const baseUpstreamDocs = 'https://github.com/flightctl/flightctl/blob/main/docs';
 
@@ -21,7 +21,7 @@ const downstreamLinks = {
   createApp: `${baseDownstreamDocs}/managing_applications_on_an_edge_device/build-app-packages_managing-apps-edge-device`,
   useTemplateVars: `${baseDownstreamDocs}/managing_device_fleets/device-fleets_managing-device-fleets`,
   addNewDevice: `${baseDownstreamDocs}/operating_system_images_for_the_red_hat_edge_manager/edge-mgr-images_os-images-edge-manager#build-images-consider_os-images-edge-manager`,
-  createAcmRepo: `${baseDownstreamDocs}/managing_devices/devices-air-gapped#manage-git-repository_managing-devices`,
+  createAcmRepo: `${baseDownstreamDocs}/managing_devices/manage-devices-intro_managing-devices#manage-git-repository_managing-devices`,
   provisionDevice: `${baseDownstreamDocs}/provisioning_devices/provision-devices-intro_provisioning-devices`,
   catalog: `${baseDownstreamDocs}/managing_devices/manage-devices-intro_managing-devices#software-catalog_managing-devices`,
 };


### PR DESCRIPTION
Updates Downstream links to use 1.3

Note that the link to create a repository via the CLI was changed between 1.2 and 1.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the shared `libs/ui-components/` documentation links from RHEM 1.2 to RHEM 1.3.
- Updated the `createAcmRepo` link to the RHEM 1.3 device-management page.
- No changes affect `libs/types/`, `libs/i18n/`, `libs/cypress/`, `apps/standalone/`, `apps/ocp-plugin/`, `proxy/`, `packaging/`, or `.github/workflows/`.
- Applications that consume this shared hook receive the updated documentation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->